### PR TITLE
Use a SADL snapshot repository

### DIFF
--- a/tools/verdict-back-ends/README.md
+++ b/tools/verdict-back-ends/README.md
@@ -5,27 +5,29 @@
 The VERDICT tool consists of an OSATE plugin and a set of VERDICT
 back-end tools invoked by the plugin.  The OSATE plugin sources are in
 another directory [(../verdict)](../verdict) and the back-end tool
-sources are in this directory.
+sources are in this directory's [aadl2iml](aadl2iml) and
+[verdict-bundle-parent](verdict-bundle-parent) sub-directories.
 
 ## Set up your development environment
 
-You will need Java and Maven to build the back-end tools since most of
-the back-end tool sources are written in Java.  One exception is
-aadl2iml, which is written in OCaml; see its own [README](aadl2iml)
-for instructions how to build it (briefly, install OCaml, run make,
-rename the newly built ./main.native executable to aadl2iml, and put
-aadl2iml someplace where VERDICT can find it).
+The aadl2iml source is written in OCaml; see its own
+[README](aadl2iml) for instructions how to build it (briefly, install
+OCaml, run make, rename the newly built ./main.native executable to
+aadl2iml, and put aadl2iml someplace where VERDICT can find it).
 
-We have been building the tools with [Java
+The verdict-bundle-parent's sources are written in Java so you will
+need Java and Maven to build the tools in verdict-bundle-parent.  We
+have been building the tools with [Java
 8](https://www.oracle.com/technetwork/java/javase/overview/java8-2100321.html)
 to date.  We have not tried to build them with newer releases of Java.
 Newer Java versions probably will work, but you would have to change
 project.target.javaVersion from 1.8 to that newer version number in
-this directory's [pom.xml](pom.xml).  Your operating system most
-likely has a prebuilt [OpenJDK](http://openjdk.java.net/install/)
-package which you can install.
+verdict-bundle-parent's [pom.xml](verdict-bundle-parent/pom.xml).
+Your operating system most likely has a prebuilt
+[OpenJDK](http://openjdk.java.net/install/) package which you can
+install.
 
-We also have been building the tools with
+We have been building verdict-bundle-parent's sources with
 [Maven](https://maven.apache.org).  Your operating system may have a
 prebuilt Maven package which you can install, but most people probably
 will download a Maven archive from Apache's website, unpack the Maven
@@ -38,49 +40,43 @@ their settings.xml file (usually ${user.home}/.m2/settings.xml).
 Maven is unaffected by proxy environment variables, so it is still
 necessary to edit settings.xml.
 
-## Build some dependencies (SADL) first
+## Note the use of a SADL snapshot repository
 
-One of the back-end tools (verdict-stem-runner) uses some jars
-(reasoner-api, reasoner-impl, sadlserver-api, and sadlserver-impl)
-which Maven will not be able to find in any Maven repository.  You
-will have to check out the source code for these jars from an open
-source GitHub [repository](https://github.com/crapo/sadlos2) and build
-these jars locally before you can build verdict-stem-runner.  These
-jars are a part of the Semantic Application Design Language version 3
-([SADL](http://sadl.sourceforge.net/)), which has been open sourced by
-GE Global Research but used primarily only by some GE software
-(including verdict-stem-runner).
+One of the back-end tools (verdict-stem-runner) uses some SADL
+dependencies (reasoner-api, reasoner-impl, sadlserver-api, and
+sadlserver-impl) that are part of the Semantic Application Design
+Language version 3 ([SADL](http://sadl.sourceforge.net/)).  SADL has
+been open sourced by GE Global Research but still is used mostly by
+other GE Global Research software.  We need a snapshot version of
+these dependencies which Maven will not be able to find in the Maven
+central repositories since people normally distribute releases, not
+snapshots, of dependencies.  To make your build easier, we have put
+these SADL dependencies into a Maven repository inside another GitHub
+project
+([sadl-snapshot-repository](https://github.com/ge-high-assurance/sadl-snapshot-repository))
+to make these dependencies available when you build
+verdict-stem-runner.
 
-Build the necessary SADL jars with these commands which clone the SADL
-source tree from GitHub, check out the AugmentedTypes branch which
-currently is the primary active branch, and change directories to the
-right location in the source tree:
-
-```shell
-$ mdir ~/git
-$ pushd ~/git
-$ git clone https://github.com/crapo/sadlos2.git
-$ cd sadlos2
-$ git checkout AugmentedTypes
-$ cd sadl3/com.ge.research.parent
-$ mvn install
-```
-
-The Maven build usually takes at least ten minutes, but could take
-much longer since Maven probably will have to download many
-dependencies first.
+Therefore, you will not have to check out SADL's source code from its
+own GitHub [repository](https://github.com/crapo/sadlos2) and build
+SADL before you can build verdict-stem-runner.  The pom.xml for
+verdict-stem-runner has a repositories section that will tell Maven
+how to download these SADL dependencies from the above SADL snapshot
+repository.
 
 ## Build our back-end tools
 
-Once you've built the SADL jars, you should be able to return to this
-directory and build our back-end tools by running mvn install:
+Build our back-end tools by running make or mvn install inside these
+sub-directories:
 
 ```shell
-$ popd
+$ cd aad2iml
+$ make
+$ cd verdict-bundle-parent
 $ mvn install
 ```
 
-## Remaining steps
+## Do some remaining steps
 
 There are more
 [steps](../verdict/com.ge.research.osate.verdict/README.md) you will

--- a/tools/verdict-back-ends/verdict-bundle-parent/verdict-stem-runner/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle-parent/verdict-stem-runner/pom.xml
@@ -72,6 +72,20 @@
         </dependency>
     </dependencies>
 
+    <!-- This microrepository has our SADL dependencies -->
+    <repositories>
+        <repository>
+            <id>sadl-snapshot-repository</id>
+            <url>https://raw.github.com/ge-high-assurance/sadl-snapshot-repository/master/repository</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
To make building verdict-bundle-parent easier, we have put our SADL
dependencies into a Maven repository inside another GitHub project
(sadl-snapshot-repository).

Therefore, you will not have to check out SADL's source code from its
own GitHub repository and build SADL before you can build
verdict-bundle-parent.  The pom.xml for verdict-stem-runner has a
repositories section that will tell Maven how to download these SADL
dependencies from the above SADL snapshot repository.