### PR TITLE
Ensure Verdict.xtext gets copied

### DIFF
--- a/tools/verdict/README.md
+++ b/tools/verdict/README.md
@@ -19,22 +19,29 @@ OSATE plugin sources into an OSATE development environment, which is
 an Eclipse IDE based on the Eclipse Modeling Tools package, and
 manually export the VERDICT plugin feature into a deployable archive.
 
-If you try to build our plugin sources in a plain Eclipse IDE (even
+If you try to build our plugin sources in a regular Eclipse IDE (even
 one that can build Eclipse plugins), the Eclipse IDE will not have the
-OSATE software and you will not be able to install the missing OSATE
-software using Eclipse's Install New Software wizard since the OSATE
-software is not part of the regular Eclipse software.
+OSATE development tools.  OSATE does have an [update
+site](https://osate-build.sei.cmu.edu/download/osate/stable/latest/updates/)
+so you can install the OSATE AADL Tool Environment feature using
+Eclipse's Install New Software wizard.  However, you also may have to
+install some other target platform requirements such as the Xtext
+Complete SDK using Eclipse's Install New Software Wizard to ensure
+your Eclipse IDE can build the VERDICT plugin sources.
 
-Likewise, if you try to build our plugin sources in an OSATE release,
-the OSATE release will not have some of the Eclipse Modeling Tools
-software needed to build an OSATE plugin.  You would have to know how
-to install the missing Modeling Tools software using Eclipse's Install
-New Software wizard.
+If you try to build our plugin sources in an OSATE release, the OSATE
+release will not have some of the necessary software development
+tools.  As with a regular Eclipse IDE, you still will have to
+find and install all the software development tools using Eclipse's
+Install New Software wizard to ensure your OSATE release can build the
+VERDICT plugin sources.
 
-Therefore, you will have to follow the instructions in [Setting up an
-OSATE development
-environment](https://osate.org/setup-development.html) as your first
-step.
+Therefore, the first step we recommend is to follow the instructions
+in [Setting up an OSATE development
+environment](https://osate.org/setup-development.html).  Even though
+these instructions take longer than using the Install New Software
+Wizard, you will be certain to get an Eclipse development environment
+that can build the VERDICT plugin sources.
 
 You do not need to build an OSATE release; you simply have to launch
 your OSATE development environment and wait for it to get and build
@@ -98,12 +105,7 @@ files:
    button.
 
    ![proceed despite errors](../../docs/images/proceed-despite-errors.png)
-7. If the MWE2 workflow aborts with an exception saying Verdict.xtext
-   isn't in the classpath, manually copy that file from
-   com.ge.research.osate.verdict.dsl/src/.../Verdict.xtext to
-   com.ge.research.osate.verdict.dsl/bin/.../Verdict.xtext and run the
-   MWE2 Workflow again.  It should work then.
-8. Wait for Eclipse to rebuild the projects and the errors should go
+7. Wait for Eclipse to rebuild the projects and the errors should go
    away.
 
 ## Export our OSATE plugin feature

--- a/tools/verdict/com.ge.research.osate.verdict.dsl.ide/build.properties
+++ b/tools/verdict/com.ge.research.osate.verdict.dsl.ide/build.properties
@@ -1,3 +1,2 @@
 bin.includes = .,\
                META-INF/
-bin.excludes = **/*.xtend

--- a/tools/verdict/com.ge.research.osate.verdict.dsl.ui/build.properties
+++ b/tools/verdict/com.ge.research.osate.verdict.dsl.ui/build.properties
@@ -4,4 +4,3 @@ bin.includes = .,\
                META-INF/,\
                plugin.xml,\
                templates/
-bin.excludes = **/*.xtend

--- a/tools/verdict/com.ge.research.osate.verdict.dsl/build.properties
+++ b/tools/verdict/com.ge.research.osate.verdict.dsl/build.properties
@@ -5,8 +5,7 @@ bin.includes = model/,\
                .,\
                META-INF/,\
                plugin.xml
-bin.excludes = **/*.mwe2,\
-               **/*.xtend
+bin.excludes = **/*.mwe2
 additional.bundles = org.eclipse.xtext.common.types,\
                      org.eclipse.xtext.xtext.generator,\
                      org.eclipse.emf.codegen.ecore,\

--- a/tools/verdict/com.ge.research.osate.verdict.dsl/src/com/ge/research/osate/verdict/dsl/VerdictUtil.java
+++ b/tools/verdict/com.ge.research.osate.verdict.dsl/src/com/ge/research/osate/verdict/dsl/VerdictUtil.java
@@ -5,7 +5,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.antlr.v4.runtime.misc.NotNull;
 import org.eclipse.emf.ecore.EObject;
 import org.osate.aadl2.AnnexSubclause;
 import org.osate.aadl2.Classifier;
@@ -174,7 +173,6 @@ public class VerdictUtil {
 		 *
 		 * Note: in-out ports are not currently supported.
 		 */
-		@NotNull
 		public List<String> availablePorts;
 
 		/**


### PR DESCRIPTION
Fix build issue with Verdict.xtext not getting copied to the bin
folder.  Also fix build issue if VERDICT plugin is imported into
regular Eclipse plugin dev env with OSATE AADL Tool Environment
feature installed from OSATE update site.  Update the VERDICT plugin
build instructions accordingly.