### PR TITLE
Support for type aliases, assertions, prev, and int/real casts

### DIFF
--- a/tools/verdict-back-ends/aadl2iml/src/AADL2VDMIML.ml
+++ b/tools/verdict-back-ends/aadl2iml/src/AADL2VDMIML.ml
@@ -218,6 +218,8 @@ let agree_unary_op_to_iml_unary_op = function
   | AG.Not -> VI.Not
   | AG.UMinus -> VI.UMinus
   | AG.Pre -> VI.Pre
+  | AG.FloorCast -> VI.ToInt
+  | AG.RealCast -> VI.ToReal
 
 let rec agree_expr_to_iml_expr = function
   | AG.BinaryOp (_, op, e1, e2) ->

--- a/tools/verdict-back-ends/aadl2iml/src/AADL2VDMIML.ml
+++ b/tools/verdict-back-ends/aadl2iml/src/AADL2VDMIML.ml
@@ -236,6 +236,10 @@ let rec agree_expr_to_iml_expr = function
     let e2 = agree_expr_to_iml_expr e2 in
     let e3 = agree_expr_to_iml_expr e3 in
     VI.Ite (e1, e2, e3)
+  | AG.Prev (_, e1, e2) ->
+    let delay = agree_expr_to_iml_expr e1 in
+    let init = agree_expr_to_iml_expr e2 in
+    VI.BinaryOp (VI.Arrow, init, VI.UnaryOp (VI.Pre, delay))
   | AG.Proj (_, e, field) ->
     VI.Proj (agree_expr_to_iml_expr e, C.get_id field)
   | AG.Ident pn -> VI.Ident (C.pname_to_string pn)

--- a/tools/verdict-back-ends/aadl2iml/src/AADLAst.ml
+++ b/tools/verdict-back-ends/aadl2iml/src/AADLAst.ml
@@ -59,6 +59,7 @@ type system_type = {
 
 type data_type = {
   name: pid;
+  type_extension: qcref option;
   properties: property_association list;
 }
 

--- a/tools/verdict-back-ends/aadl2iml/src/AADLAst.mli
+++ b/tools/verdict-back-ends/aadl2iml/src/AADLAst.mli
@@ -59,6 +59,7 @@ type system_type = {
 
 type data_type = {
   name: pid;
+  type_extension: qcref option;
   properties: property_association list;
 }
 

--- a/tools/verdict-back-ends/aadl2iml/src/AADLInput.ml
+++ b/tools/verdict-back-ends/aadl2iml/src/AADLInput.ml
@@ -300,6 +300,10 @@ let merge_packages input =
       }
     in
 
+    let flatten_assertion { AG.expression } =
+      { AG.expression = flatten_agree_expr expression }
+    in
+
     let flatten_spec_statement = function
       | AG.NamedSpecStatement (pos, n) ->
         AG.NamedSpecStatement (pos, flatten_named_spec_statement n)
@@ -311,6 +315,8 @@ let merge_packages input =
         AG.NodeDefinition (pos, flatten_node_def n)
       | AG.AssignStatement (pos, a) ->
         AG.AssignStatement (pos, flatten_assign_statement a)
+      | AG.AssertStatement (pos, a) ->
+        AG.AssertStatement (pos, flatten_assertion a)
     in
 
     let flatten_agree_annex agree_annex =

--- a/tools/verdict-back-ends/aadl2iml/src/AADLInput.ml
+++ b/tools/verdict-back-ends/aadl2iml/src/AADLInput.ml
@@ -228,6 +228,8 @@ let merge_packages input =
         let e2 = flatten_agree_expr e2 in
         let e3 = flatten_agree_expr e3 in
         AG.Ite (pos, e1, e2, e3)
+      | AG.Prev (pos, e1, e2) ->
+        AG.Prev (pos, flatten_agree_expr e1, flatten_agree_expr e2)
       | AG.Proj (pos, e, pid) -> (
         match e with
         | AG.Ident name -> flatten_proj pos (name, pid)

--- a/tools/verdict-back-ends/aadl2iml/src/AADLLexer.mll
+++ b/tools/verdict-back-ends/aadl2iml/src/AADLLexer.mll
@@ -46,6 +46,7 @@
     "aadlinteger",    P.AADLINTEGER ;
     "aadlreal",       P.AADLREAL ;
     "enumeration",    P.ENUMERATION ;
+    "extends",        P.EXTENDS ;
     "property",       P.PROPERTY ;
     "package",        P.PACKAGE ;
     "system",         P.SYSTEM ;

--- a/tools/verdict-back-ends/aadl2iml/src/AADLParser.mly
+++ b/tools/verdict-back-ends/aadl2iml/src/AADLParser.mly
@@ -55,7 +55,7 @@ let mk_package_section header_items body_items =
 %}
 
 %token AADLBOOLEAN AADLSTRING AADLINTEGER AADLREAL ENUMERATION
-%token PROPERTY SET IS APPLIES TO INHERIT
+%token PROPERTY SET IS APPLIES TO INHERIT EXTENDS
 %token PACKAGE SYSTEM IMPLEMENTATION FEATURES PROPERTIES
 %token SUBCOMPONENTS CONNECTIONS
 %token PUBLIC PRIVATE
@@ -493,15 +493,19 @@ package_properties:
   (* INCOMPLE *)
 
 data_type:
-  DATA pid = ident
+  DATA pid = ident; ext_qcr = option(type_extension);
   prop_assocs = component_properties
   (* INCOMPLETE *)
   END ID ";"
   {
     { A.name = pid;
+      A.type_extension = ext_qcr;
       A.properties = prop_assocs;
     }
   }
+
+type_extension:
+  EXTENDS qcr = qcref { qcr }
 
 component_properties:
   | { [] }

--- a/tools/verdict-back-ends/aadl2iml/src/AGREEAst.ml
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREEAst.ml
@@ -38,6 +38,7 @@ type expr =
   | BinaryOp of Position.t * binary_op * expr * expr
   | UnaryOp of Position.t * unary_op * expr
   | Ite of Position.t * expr * expr * expr
+  | Prev of Position.t * expr * expr
   | Proj of Position.t * expr * pid
   | Ident of pname
   | EnumValue of Position.t * qcref * pid
@@ -200,6 +201,9 @@ let rec pp_print_expr ppf = function
   | Ite (_, e1, e2, e3) ->
     Format.fprintf ppf "(if %a then %a else %a)"
       pp_print_expr e1 pp_print_expr e2 pp_print_expr e3
+  | Prev (_, e1, e2) ->
+    Format.fprintf ppf "(prev(%a, %a))"
+      pp_print_expr e1 pp_print_expr e2
   | Proj (_, e, pid) ->
     Format.fprintf ppf "%a.%a"
       pp_print_expr e pp_print_id pid

--- a/tools/verdict-back-ends/aadl2iml/src/AGREEAst.ml
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREEAst.ml
@@ -32,7 +32,7 @@ type binary_op =
   | Arrow | Impl | Equiv | Or | And | Lt | Lte | Gt | Gte | Eq | Neq
   | Plus | Minus | Times | Div | IntDiv | Mod | Exp
 
-type unary_op = Not | UMinus | Pre
+type unary_op = Not | UMinus | Pre | FloorCast | RealCast
 
 type expr =
   | BinaryOp of Position.t * binary_op * expr * expr
@@ -190,6 +190,12 @@ let rec pp_print_expr ppf = function
       pp_print_expr e
   | UnaryOp (_, Pre, e) ->
     Format.fprintf ppf "(pre (%a))"
+      pp_print_expr e
+  | UnaryOp (_, FloorCast, e) ->
+    Format.fprintf ppf "(floor (%a))"
+      pp_print_expr e
+  | UnaryOp (_, RealCast, e) ->
+    Format.fprintf ppf "(real (%a))"
       pp_print_expr e
   | Ite (_, e1, e2, e3) ->
     Format.fprintf ppf "(if %a then %a else %a)"

--- a/tools/verdict-back-ends/aadl2iml/src/AGREEAst.ml
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREEAst.ml
@@ -90,12 +90,17 @@ type assign_statement = {
   definition: expr;
 }
 
+type assert_statement = {
+  expression: expr;
+}
+
 type spec_statement =
   | NamedSpecStatement of Position.t * named_spec_statement
   | ConstStatement of Position.t * const_statement
   | EqStatement of Position.t * eq_statement
   | AssignStatement of Position.t * assign_statement
   | NodeDefinition of Position.t * node_definition
+  | AssertStatement of Position.t * assert_statement
 
 type agree_annex = spec_statement list
 
@@ -280,6 +285,9 @@ let pp_print_spec_statement ind ppf = function
   )
   | NodeDefinition (_, node_def) -> (
     pp_print_node_def ind ppf node_def
+  )
+  | AssertStatement (_, {expression}) -> (
+    Format.fprintf ppf "assert %a;" pp_print_expr expression
   )
 
 let pp_print_agree_annex ind ppf annex =

--- a/tools/verdict-back-ends/aadl2iml/src/AGREEAst.mli
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREEAst.mli
@@ -32,7 +32,7 @@ type binary_op =
   | Arrow | Impl | Equiv | Or | And | Lt | Lte | Gt | Gte | Eq | Neq
   | Plus | Minus | Times | Div | IntDiv | Mod | Exp
 
-type unary_op = Not | UMinus | Pre
+type unary_op = Not | UMinus | Pre | FloorCast | RealCast
 
 type expr =
   | BinaryOp of Position.t * binary_op * expr * expr

--- a/tools/verdict-back-ends/aadl2iml/src/AGREEAst.mli
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREEAst.mli
@@ -38,6 +38,7 @@ type expr =
   | BinaryOp of Position.t * binary_op * expr * expr
   | UnaryOp of Position.t * unary_op * expr
   | Ite of Position.t * expr * expr * expr
+  | Prev of Position.t * expr * expr
   | Proj of Position.t * expr * pid
   | Ident of pname
   | EnumValue of Position.t * qcref * pid

--- a/tools/verdict-back-ends/aadl2iml/src/AGREEAst.mli
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREEAst.mli
@@ -90,12 +90,17 @@ type assign_statement = {
   definition: expr;
 }
 
+type assert_statement = {
+  expression: expr;
+}
+
 type spec_statement =
   | NamedSpecStatement of Position.t * named_spec_statement
   | ConstStatement of Position.t * const_statement
   | EqStatement of Position.t * eq_statement
   | AssignStatement of Position.t * assign_statement
   | NodeDefinition of Position.t * node_definition
+  | AssertStatement of Position.t * assert_statement
 
 type agree_annex = spec_statement list
 

--- a/tools/verdict-back-ends/aadl2iml/src/AGREELexer.mll
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREELexer.mll
@@ -63,6 +63,7 @@ rule token = parse
   | "returns"        { P.RETURNS }
   | "node"           { P.NODE }
   | "enum"           { P.ENUM }
+  | "floor"          { P.FLOOR }
   | "real"           { P.REAL }
   | "bool"           { P.BOOL }
   | "int"            { P.INT }

--- a/tools/verdict-back-ends/aadl2iml/src/AGREELexer.mll
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREELexer.mll
@@ -54,6 +54,7 @@ let real_lit = digit+ ('_' digit+)* '.' digit+ ('_' digit+)* exponent?
 let id = ['a'-'z' 'A'-'Z'] ['a'-'z' 'A'-'Z' '_' '0'-'9']*
 
 rule token = parse
+  | "assert"         { P.ASSERT }
   | "assign"         { P.ASSIGN }
   | "assume"         { P.ASSUME }
   | "guarantee"      { P.GUARANTEE }

--- a/tools/verdict-back-ends/aadl2iml/src/AGREELexer.mll
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREELexer.mll
@@ -82,6 +82,7 @@ rule token = parse
   | "else"           { P.ELSE }
   | "true"           { P.TRUE }
   | "false"          { P.FALSE }
+  | "prev"           { P.PREV }
 
   | "**}"            { P.ANNEX_BLOCK_END }
   | "<=>"            { P.EQUIV }

--- a/tools/verdict-back-ends/aadl2iml/src/AGREEParser.mly
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREEParser.mly
@@ -63,6 +63,7 @@ let add_range rg = function
 %token PLUS "+"
 %token MINUS "-"
 %token POWER "^"
+%token PREV
 %token <string>ID
 %token <string>INTEGER_LIT
 %token <string>REAL_LIT
@@ -332,6 +333,8 @@ expr:
     { A.IntegerLit (mk_pos $startpos, l) }
   | n = expr "(" args = separated_list(",", expr) ")"
     { A.Call (mk_pos $startpos, n, args) }
+  | PREV "(" e1 = expr "," e2 = expr ")"
+    { A.Prev (mk_pos $startpos, e1, e2) }
   | r = expr "{" fs = separated_nonempty_list(";", record_field_def) "}"
     { A.RecordExpr (mk_pos $startpos, r, fs) }
   | l = REAL_LIT

--- a/tools/verdict-back-ends/aadl2iml/src/AGREEParser.mly
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREEParser.mly
@@ -30,7 +30,7 @@ let add_range rg = function
 
 %}
 
-%token ASSUME GUARANTEE LEMMA ASSIGN
+%token ASSUME GUARANTEE LEMMA ASSIGN ASSERT
 %token NODE RETURNS LET TEL VAR
 %token CONST ENUM
 %token REAL BOOL INT
@@ -113,6 +113,10 @@ spec_statement:
   {
     A.NodeDefinition (mk_pos $startpos, nd)
   }
+  | ass = assert_statement
+  {
+    A.AssertStatement (mk_pos $startpos, ass)
+  }
   (* INCOMPLETE *)
 
 ident: id = ID { (mk_pos $startpos, id) }
@@ -174,6 +178,12 @@ named_spec_statement:
   | LEMMA id = option(ident) desc = STRING ":" e = expr_or_pattern_statement ";"
   {
     A.Lemma { A.id = id; A.desc = desc; A.spec = e }
+  }
+
+assert_statement:
+  ASSERT  e = expr_or_pattern_statement ";"
+  {
+    { A.expression = e }
   }
 
 expr_or_pattern_statement:

--- a/tools/verdict-back-ends/aadl2iml/src/AGREEParser.mly
+++ b/tools/verdict-back-ends/aadl2iml/src/AGREEParser.mly
@@ -33,7 +33,7 @@ let add_range rg = function
 %token ASSUME GUARANTEE LEMMA ASSIGN ASSERT
 %token NODE RETURNS LET TEL VAR
 %token CONST ENUM
-%token REAL BOOL INT
+%token REAL BOOL INT FLOOR
 %token NOT AND OR EQ
 %token IF THEN ELSE PRE
 %token ANNEX_BLOCK_END "**}"
@@ -316,6 +316,10 @@ expr:
     { A.UnaryOp (mk_pos $startpos, A.UMinus, e) }
   | PRE "(" e = expr ")"
     { A.UnaryOp (mk_pos $startpos, A.Pre, e) }
+  | FLOOR "(" e = expr ")"
+    { A.UnaryOp (mk_pos $startpos, A.FloorCast, e) }
+  | REAL "(" e = expr ")"
+    { A.UnaryOp (mk_pos $startpos, A.RealCast, e) }
   | IF e1 = expr THEN e2 = expr ELSE e3 = expr
     { A.Ite (mk_pos $startpos, e1, e2, e3) }
   | e = expr "." pid = ident

--- a/tools/verdict-back-ends/aadl2iml/src/VDMIML.ml
+++ b/tools/verdict-back-ends/aadl2iml/src/VDMIML.ml
@@ -49,7 +49,7 @@ type binary_op =
   | Arrow | Impl | Equiv | Or | And | Lt | Lte | Gt | Gte | Eq | Neq
   | Plus | Minus | Times | Div | IntDiv | Mod
 
-type unary_op = Not | UMinus | Pre
+type unary_op = Not | UMinus | Pre | ToInt | ToReal
 
 type expr =
   | BinaryOp of binary_op * expr * expr
@@ -564,6 +564,8 @@ let get_unary_op_kind_and_field = function
   | Not -> "Not", "not"
   | UMinus -> "Negative", "negative"
   | Pre -> "Pre", "pre"
+  | ToInt -> "ToInt", "to_int"
+  | ToReal -> "ToReal", "to_real"
 
 let rec pp_print_expr ind ppf expr =
   Format.fprintf ppf "e.kind = ExpressionKind.";

--- a/tools/verdict-back-ends/aadl2iml/src/VDMIML.mli
+++ b/tools/verdict-back-ends/aadl2iml/src/VDMIML.mli
@@ -49,7 +49,7 @@ type binary_op =
   | Arrow | Impl | Equiv | Or | And | Lt | Lte | Gt | Gte | Eq | Neq
   | Plus | Minus | Times | Div | IntDiv | Mod
 
-type unary_op = Not | UMinus | Pre
+type unary_op = Not | UMinus | Pre | ToInt | ToReal
 
 type expr =
   | BinaryOp of binary_op * expr * expr

--- a/tools/verdict-back-ends/verdict-bundle-parent/iml-verdict-translator/src/main/java/edu/uiowa/clc/verdict/vdm/translator/Type.java
+++ b/tools/verdict-back-ends/verdict-bundle-parent/iml-verdict-translator/src/main/java/edu/uiowa/clc/verdict/vdm/translator/Type.java
@@ -326,6 +326,9 @@ public enum Type {
     REAL_Lit("RealLiteral"),
     BOOL_Lit("BoolLiteral"),
 
+    TO_REAL("ToReal"),
+    TO_INT("ToInt"),
+    
     NOT("Not"),
     PRE("Pre"),
     EQ("Equal"),

--- a/tools/verdict-back-ends/verdict-bundle-parent/iml-verdict-translator/src/main/java/edu/uiowa/clc/verdict/vdm/translator/VDMParser.java
+++ b/tools/verdict-back-ends/verdict-bundle-parent/iml-verdict-translator/src/main/java/edu/uiowa/clc/verdict/vdm/translator/VDMParser.java
@@ -551,7 +551,18 @@ public class VDMParser extends Parser {
                 expression.setPre(pre_expr);
                 return expression;
             }
+            if (type == Type.TO_REAL) {
+                Expression real_expr = expression();
+                expression.setToReal(real_expr);
+                return expression;
+            }
+            if (type == Type.TO_INT) {
+                Expression int_expr = expression();
+                expression.setToInt(int_expr);
+                return expression;
+            }
 
+            
             if (token.type == Type.BINARY_OP) {
                 // OP
                 // EQ


### PR DESCRIPTION
Add support for AADL type aliases provided via type extensions
Add support for int and real casts, assertions, and the `prev` operator in AGREE annexes