### PR TITLE
Display failure paths with more information

### DIFF
--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/CapecDefenseTable.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/CapecDefenseTable.java
@@ -37,13 +37,14 @@ public class CapecDefenseTable {
 			newRow.addToRow("Path # " + (i + 1));
 			newRow.addToRow(path.getLikelihood());
 			newRow.addToRow(path.attacks());
-			newRow.addToRow(path.applicableDefenses());
+			newRow.addToRow(path.suggestedDefenses());
+			newRow.addToRow(path.suggestedDefensesProfile());
 			newRow.addToRow(path.implDefenses());
 			
 			// Find descriptions for all CAPECs and NISTS
 			// We don't have the unformatted attacks/defenses, so we need to do a regex split
 			// We ignore "(", ")", and whitespace, plus the words "and" and "or"
-			for (ComponentData data : path.getComponentCapecs()) {
+			for (ComponentData data : path.getComponentAttacks()) {
 				String[] keys = data.getData().split("[\\s()]");
 				for (String key : keys) {
 					if (key.length() == 0 || "and".equals(key) || "or".equals(key)) {
@@ -55,7 +56,7 @@ public class CapecDefenseTable {
 					}
 				}
 			}
-			for (ComponentData data : path.getComponentDefenses()) {
+			for (ComponentData data : path.getComponentSuggestedDefensesProfile()) {
 				String[] keys = data.getData().split("[\\s()]");
 				for (String key : keys) {
 					if (key.length() == 0 || "and".equals(key) || "or".equals(key)) {

--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/CapecDefenseView.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/CapecDefenseView.java
@@ -64,9 +64,11 @@ public class CapecDefenseView extends ViewPart {
 		TableColumn col3 = new TableColumn(table, SWT.CENTER | SWT.WRAP);
 		col3.setText("Attack Type");
 		TableColumn col4 = new TableColumn(table, SWT.CENTER | SWT.WRAP);
-		col4.setText("Suggested Defense");
+		col4.setText("Suggested Defenses");
 		TableColumn col5 = new TableColumn(table, SWT.CENTER | SWT.WRAP);
-		col5.setText("Implemented Defenses");
+		col5.setText("Suggested Defenses Profile");
+		TableColumn col6 = new TableColumn(table, SWT.CENTER | SWT.WRAP);
+		col6.setText("Implemented Defenses");
 
 		int itemCount = tableContents.size();
 		for (int i = 0; i < itemCount; i++) {
@@ -93,8 +95,8 @@ public class CapecDefenseView extends ViewPart {
 			if (item.getTextBounds(2).contains(event.x, event.y)) {
 				// Attack type (CAPEC)
 				text = String.join("\n", data.getAttackHoverText());
-			} else if (item.getTextBounds(3).contains(event.x, event.y)) {
-				// Suggested defense (NIST)
+			} else if (item.getTextBounds(4).contains(event.x, event.y)) {
+				// Suggested defenses profile (NIST)
 				text = String.join("\n", data.getDefenseHoverText());
 			}
 			if (text.length() > 0) {

--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/MBASReadXMLFile.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/MBASReadXMLFile.java
@@ -89,11 +89,12 @@ public class MBASReadXMLFile {
 				newPath.setLikelihood(eElement.getAttribute("likelihood"));
 				NodeList attacks = eElement.getElementsByTagName("Attack");
 				if (attacks.getLength() > 0) {
-					newPath.setComponentCapecs(extractComponents(attacks.item(0), "capec"));
+					newPath.setComponentAttacks(extractComponents(attacks.item(0), "attack"));
 				}
 				NodeList defenses = eElement.getElementsByTagName("Defense");
 				if (defenses.getLength() > 0) {
-					newPath.setComponentDefenses(extractComponents(defenses.item(0), "profile"));
+					newPath.setComponentSuggestedDefenses(extractComponents(defenses.item(0), "suggested"));
+					newPath.setComponentSuggestedDefensesProfile(extractComponents(defenses.item(0), "profile"));
 				}
 				list.add(newPath);
 			}
@@ -112,7 +113,7 @@ public class MBASReadXMLFile {
 			Node nNode = nList.item(temp);
 			if (nNode.getNodeType() == Node.ELEMENT_NODE) {
 				Element elem = (Element) nNode;
-				data.add(new PathAttributes.ComponentData(elem.getAttribute("name"),
+				data.add(new PathAttributes.ComponentData(elem.getAttribute("comp"),
 						elem.getAttribute(dataLabel)));
 			}
 		}

--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/MBASReportGenerator.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/MBASReportGenerator.java
@@ -29,8 +29,8 @@ import org.w3c.dom.NodeList;
 //to be called from MBAS handler (just before the handler returns for static implementation
 //dynamic update can be implemented by creating two threads: one for MBAS tool and the other for this class)
 public class MBASReportGenerator implements Runnable {
-	private String fileName1;
-	private String fileName2;
+	private String applicableDefense;
+	private String implProperty;
 	public static IWorkbenchWindow window;
 	private List<MissionAttributes> missions = new ArrayList<MissionAttributes>();
 	private Map<String, List<MBASSafetyResult>> safetyResults;
@@ -38,8 +38,8 @@ public class MBASReportGenerator implements Runnable {
 
 	public MBASReportGenerator(String applicableDefense, String implProperty, String safetyApplicableDefense,
 			String safetyImplProperty, IWorkbenchWindow window, String capecFile, String nistFile) {
-		this.fileName1 = applicableDefense;
-		this.fileName2 = implProperty;
+		this.applicableDefense = applicableDefense;
+		this.implProperty = implProperty;
 		MBASReportGenerator.window = window;
 		IWorkbenchPage wp = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
 		IViewPart myView1 = wp.findView(MBASResultsView.ID);
@@ -68,7 +68,7 @@ public class MBASReportGenerator implements Runnable {
 
 	@Override
 	public void run() {
-		new MBASResultSummary(fileName1, fileName2);
+		new MBASResultSummary(applicableDefense, implProperty);
 	}
 
 	// invokes the MBAS Result viewer-tab in OSATE
@@ -91,16 +91,16 @@ public class MBASReportGenerator implements Runnable {
 		});
 	}
 
-	private Map<String, List<MBASSafetyResult>> loadSafetyResults(String applicableDefenseFile,
-			String implPropertyFile) {
+	private Map<String, List<MBASSafetyResult>> loadSafetyResults(String safetyApplicableDefense,
+			String safetyImplProperty) {
 		Map<String, List<MBASSafetyResult>> results = new LinkedHashMap<>();
 
-		// We don't use both files right now because AFAIK they are totally identical
+		// We don't use both files right now because AFAIK they are 99.9% identical
 
 		try {
 			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-			Document doc = dBuilder.parse(new File(applicableDefenseFile));
+			Document doc = dBuilder.parse(new File(safetyApplicableDefense));
 			doc.getDocumentElement().normalize();
 
 			NodeList missionNodes = doc.getElementsByTagName("Mission");

--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/MBASResultSummary.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/MBASResultSummary.java
@@ -22,10 +22,10 @@ public class MBASResultSummary {
 
 	private List<MissionAttributes> missions;
 
-	public MBASResultSummary(String fileName1, String fileName2) {
-		MBASReadXMLFile xmlReader1 = new MBASReadXMLFile(fileName1);
-		MBASReadXMLFile xmlReader2 = new MBASReadXMLFile(fileName2);
-		missions = loadTableContents(xmlReader1.getContent(), xmlReader2.getContent());
+	public MBASResultSummary(String applicableDefense, String implProperty) {
+		MBASReadXMLFile applicableDefenseReader = new MBASReadXMLFile(applicableDefense);
+		MBASReadXMLFile implPropertyReader = new MBASReadXMLFile(implProperty);
+		missions = loadTableContents(applicableDefenseReader.getContent(), implPropertyReader.getContent());
 	}
 
 	public List<MissionAttributes> loadTableContents(List<MissionAttributes> missions1,
@@ -92,7 +92,7 @@ public class MBASResultSummary {
 					PathAttributes path = paths1.get(k);
 					Optional<PathAttributes> other = paths2.stream().filter(o -> path.compareCutset(o)).findFirst();
 					if (other.isPresent()) {
-						path.setComponentImplDefense(other.get().getComponentDefenses());
+						path.setComponentImplDefense(other.get().getComponentSuggestedDefenses());
 					} else {
 						System.err.println("Missing impl defenses");
 						path.setComponentImplDefense(Collections.emptyList());

--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/PathAttributes.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/PathAttributes.java
@@ -39,8 +39,9 @@ public class PathAttributes implements Serializable, Cloneable {
 
 	private static final long serialVersionUID = 1L;
 	private String likelihood;
-	private List<ComponentData> componentCapecs = new ArrayList<>();
-	private List<ComponentData> componentApplicableDefenses = new ArrayList<>();
+	private List<ComponentData> componentAttacks = new ArrayList<>();
+	private List<ComponentData> componentSuggestedDefenses = new ArrayList<>();
+	private List<ComponentData> componentSuggestedDefensesProfile = new ArrayList<>();
 	private List<ComponentData> componentImplDefenses = new ArrayList<>();
 
 	public void setLikelihood(String str) {
@@ -51,20 +52,28 @@ public class PathAttributes implements Serializable, Cloneable {
 		return likelihood;
 	}
 	
-	public void setComponentCapecs(List<ComponentData> componentCapecs) {
-		this.componentCapecs = componentCapecs;
+	public void setComponentAttacks(List<ComponentData> componentAttacks) {
+		this.componentAttacks = componentAttacks;
 	}
 	
-	public List<ComponentData> getComponentCapecs() {
-		return componentCapecs;
+	public List<ComponentData> getComponentAttacks() {
+		return componentAttacks;
 	}
 	
-	public void setComponentDefenses(List<ComponentData> componentDefenses) {
-		this.componentApplicableDefenses = componentDefenses;
+	public void setComponentSuggestedDefenses(List<ComponentData> componentDefenses) {
+		this.componentSuggestedDefenses = componentDefenses;
 	}
 	
-	public List<ComponentData> getComponentDefenses() {
-		return componentApplicableDefenses;
+	public List<ComponentData> getComponentSuggestedDefenses() {
+		return componentSuggestedDefenses;
+	}
+	
+	public void setComponentSuggestedDefensesProfile(List<ComponentData> componentDefensesProfile) {
+		this.componentSuggestedDefensesProfile = componentDefensesProfile;
+	}
+	
+	public List<ComponentData> getComponentSuggestedDefensesProfile() {
+		return componentSuggestedDefensesProfile;
 	}
 	
 	public void setComponentImplDefense(List<ComponentData> componentImplDefenses) {
@@ -83,11 +92,15 @@ public class PathAttributes implements Serializable, Cloneable {
 	}
 	
 	public String attacks() {
-		return joinComponentDataList(componentCapecs);
+		return joinComponentDataList(componentAttacks);
 	}
 	
-	public String applicableDefenses() {
-		return joinComponentDataList(componentApplicableDefenses);
+	public String suggestedDefenses() {
+		return joinComponentDataList(componentSuggestedDefenses);
+	}
+	
+	public String suggestedDefensesProfile() {
+		return joinComponentDataList(componentSuggestedDefensesProfile);
 	}
 	
 	public String implDefenses() {
@@ -98,12 +111,12 @@ public class PathAttributes implements Serializable, Cloneable {
 		// We use this so that we can search for matching cutsets
 		// between ApplicableDefenseProperties and ImplProperties.
 		
-		if (other.componentCapecs.size() != componentCapecs.size()) {
+		if (other.componentAttacks.size() != componentAttacks.size()) {
 			return false;
 		}
-		for (int i = 0; i < componentCapecs.size(); i++) {
-			if (!other.componentCapecs.get(i).getComponent().equals(componentCapecs.get(i).getComponent())
-					|| !other.componentCapecs.get(i).getData().equals(componentCapecs.get(i).getData())) {
+		for (int i = 0; i < componentAttacks.size(); i++) {
+			if (!other.componentAttacks.get(i).getComponent().equals(componentAttacks.get(i).getComponent())
+					|| !other.componentAttacks.get(i).getData().equals(componentAttacks.get(i).getData())) {
 				return false;
 			}
 		}


### PR DESCRIPTION
Change what the VERDICT plugin displays in the Security Failure Paths
tab.  Rename the Suggested Defense column to Suggested Defenses and
make that column contain the names of specific defenses instead of
NIST profiles.  Add a Suggested Defenses Profile column and make it
contain the NIST profiles.  Move the NIST profile tooltip to the new
column.

Update the code that reads the XML output files from Soteria++ to
handle the changes to the attributes.  Rename some methods/fields to
follow these changes or to be clearer what they represent.