### PR TITLE
Update VERDICT_Properties in some models

### DIFF
--- a/models/CruiseController/CruiseController.aadl
+++ b/models/CruiseController/CruiseController.aadl
@@ -290,9 +290,7 @@ public
 				VERDICT_Properties::insideTrustedBoundary => true;
 				VERDICT_Properties::componentType => Hybrid;
 				VERDICT_Properties::pedigree => InternallyDeveloped;
-				VERDICT_Properties::dataReceivedFromUntrusted => true;
-				VERDICT_Properties::controlReceivedFromUntrusted => true;
-				VERDICT_Properties::adversariallyTested => true;
+				VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 7;
 			};
 			setSpeed: system SetSpeed
 			{
@@ -300,9 +298,7 @@ public
 				VERDICT_Properties::insideTrustedBoundary => false;
 				VERDICT_Properties::componentType => Hybrid;
 				VERDICT_Properties::pedigree => InternallyDeveloped;
-				VERDICT_Properties::dataReceivedFromUntrusted => true;
-				VERDICT_Properties::controlReceivedFromUntrusted => true;
-				VERDICT_Properties::adversariallyTested => false;
+				VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 0;
 			};
 			controlSpeed: system ControlSpeed
 			{
@@ -310,9 +306,7 @@ public
 				VERDICT_Properties::insideTrustedBoundary => true;
 				VERDICT_Properties::componentType => Hybrid;
 				VERDICT_Properties::pedigree => InternallyDeveloped;
-				VERDICT_Properties::dataReceivedFromUntrusted => true;
-				VERDICT_Properties::controlReceivedFromUntrusted => true;
-				VERDICT_Properties::adversariallyTested => true;
+				VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 7;
 			};
 			filter: system Filter
 			{
@@ -320,84 +314,80 @@ public
 				VERDICT_Properties::insideTrustedBoundary => true;
 				VERDICT_Properties::componentType => Hybrid;
 				VERDICT_Properties::pedigree => InternallyDeveloped;
-				VERDICT_Properties::dataReceivedFromUntrusted => true;
-				VERDICT_Properties::controlReceivedFromUntrusted => true;
-				VERDICT_Properties::adversariallyTested => true;
+				VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 7;
 			};
 		
 		connections
 			c01: port on_off -> setSpeed.on_off
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c02: port resume_speed -> setSpeed.resume_speed
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c03: port set_speed -> setSpeed.set_speed
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c04: port inc -> setSpeed.inc
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c05: port dec -> setSpeed.dec
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c06: port brake_cancel -> setSpeed.brake_cancel
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c07: port measureSpeed.speed -> setSpeed.speed
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c08: port measureSpeed.speed -> controlSpeed.speed
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c09: port setSpeed.enabled -> enabled
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c10: port setSpeed.desired_speed -> filter.desired_speed
 			{
-				VERDICT_Properties::flowType => Xdata;
-		     	VERDICT_Properties::connectionType => Remote;
-			 	VERDICT_Properties::authenticated => false;
-			 	VERDICT_Properties::encryptedTransmission => false;
-			 	VERDICT_Properties::trustedConnection => false;
+				VERDICT_Properties::connectionType => Untrusted;
+				VERDICT_Properties::deviceAuthentication => 0;
+				VERDICT_Properties::encryptedTransmission => 0;
 			};
 			c11: port controlSpeed.force -> force
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c12: port rotate -> measureSpeed.rotate
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c13: port second -> measureSpeed.second
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c14: port filter.filtered_desired_speed -> controlSpeed.desired_speed
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			c15: port filter_is_enabled -> filter.is_enabled
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			-- Virtual connection for the sake of analysis
 			v01: port filter.filtered_desired_speed -> desired_speed
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 			v02: port measureSpeed.speed -> speed
 			{
-				VERDICT_Properties::flowType => Xdata;
+				VERDICT_Properties::connectionType => Trusted;
 			};
 	end CruiseControllerSystem.Impl;
 	

--- a/models/CruiseController/VERDICT_Properties.aadl
+++ b/models/CruiseController/VERDICT_Properties.aadl
@@ -1,31 +1,375 @@
+-------------------------------------------------------------------------
+--- The following VERDICT_Properties enable the use of the VERDICT tool suite for both the high-level Model-Based
+--- Architectural Analysis (MBAA) and behavioral analysis using the Cyber Resiliency Verifier (CRV). Each property
+--- below is tagged for which tools uses the property followed by a short description.
+---
+--- This file contains four different types of properties:
+--- 	Mandatory User Defined Component Properties must be assigned for VERDICT tools to execute
+--- 	Port Properties are used to designate analysis-only ports for use in behavioral analysis
+--- 	Connection Properties contain necessary inputs as well as annotations for applied mitigations on connections
+--- 	Connection Cyber Defense Properties allow the designer to annotate applied mitigations for connections
+--- 	Component Cyber Defense Properties allow the designer to annotate applied mitigations for system components
+-------------------------------------------------------------------------
 property set VERDICT_Properties is
--- Port properties
- probe: aadlboolean applies to (port);
 
--- Connection properties, including defenses and DAL values
- flowType: enumeration (Xdata, Xcontrol, Xrequest) applies to (connection);
- connectionType: enumeration (Local, Remote) applies to (connection);
- authenticated: aadlboolean applies to (connection);
- trustedConnection: aadlboolean applies to (connection);
- encryptedTransmission: aadlboolean applies to (connection);
- encryptedTransmissionDAL: aadlinteger 0 .. 9 applies to (connection);
 
--- Component properties 
- pedigree: enumeration (InternallyDeveloped, COTS, Sourced) applies to (system);
- category: aadlstring applies to (system);
- componentType: enumeration (Software, Hardware, Human, Hybrid) applies to (system);
- situated: enumeration (OnBoard, Remote) applies to (system);
- adversariallyTested: aadlboolean applies to (system);
- hasSensitiveInfo: aadlboolean applies to (system);
- insideTrustedBoundary: aadlboolean applies to (system);
+
+-------------------------------------------------------------------------
+--- Mandatory User Defined Component Properties
+---          NOTE: The mandatory user defined component properties must be assigned for each applicable component as a minimum for VERDICT to execute.
+-------------------------------------------------------------------------
+
+ --- MBAA:
+ --- 	canReceiveConfigUpdate is a property used to determine whether the system is susceptible to attacks attempting to tamper with the configuration
+ --- 	of a system. Apply this property if the configuration of software or hardware within the system can be updated outside of the original
+ --- 	manufacturer's facility.
+
  canReceiveConfigUpdate: aadlboolean applies to (system);
- canReceiveSWUpdate: aadlboolean applies to (system);
- controlReceivedFromUntrusted: aadlboolean applies to (system);
- controlSentToUntrusted: aadlboolean applies to (system);
- dataReceivedFromUntrusted: aadlboolean applies to (system);
- dataSentToUntrusted: aadlboolean applies to (system);
 
- -- Cyber Attack Properties from TA1 
+ --- MBAA:
+ --- 	canRecieveSWUpdate is a property used to determine whether the system is susceptible to attacks attempting to install malicious software
+ --- 	updates. Apply this property if the software within the system can be updated outside of the original manufacturer's facility.
+
+ canReceiveSWUpdate: aadlboolean applies to (system);
+
+ --- MBAA:
+ --- 	componentType is a property used to determine whether the system is subject to attacks targeting software, hardware, humans, or hybrid
+ --- 	(software and hardware). For example, systems that represent software only will not be subject to CAPEC-440 Hardware Integrity Attack.
+ --- CRV:
+ --- 	A componentType designates whether a component is a software, a hardware, a Human, or a Hybrid (mix of Software and Hardware).
+ --- 	This helps CRV to decide what sort of attack can the component be susceptible to. For instance, a Hybrid component can be susceptible
+ --- 	to both hardware (e.g., trojans) and software (e.g., logic bomb) attacks whereas a Human component can only be susceptible to insider/outsider threat.
+
+ componentType: enumeration (Software, Hardware, Human, SwHwHybrid, SwHumanHybrid, HwHumanHybrid, Hybrid) applies to (system);
+
+ --- MBAA:
+ --- 	If a system contains the property hasSensitiveInfo it will be considered for attacks resulting in loss of confidentiality.
+
+ hasSensitiveInfo: aadlboolean applies to (system);
+
+ --- MBAA:
+ --- 	insideTrustedBoundary designates a system that will be analyzed for their potential to be attacked. Also, systems where insideTrustedBoundary=TRUE
+ --- 	will not be considered the initial source of attacks.
+ --- CRV:
+ --- 	If a component's insideTrustedBoundary property is true, it signifies to CRV that the component is inside the system's trust boundary. For instance,
+ --- 	if a human component is inside the trusted boundary of the system, then an insider attack can occur.
+
+ insideTrustedBoundary: aadlboolean applies to (system);
+
+
+ --- MBAA:
+ --- 	pedigree is a property used to infer the level of trust in a system. A "COTS" component will be untrusted and considered a
+ --- 	potential source of attacks, whereas "Sourced" and "InternallyDeveloped" components will be trusted. Both of these can be explicitly
+ --- 	overridden by the insideTrustedBoundary property.
+ ---
+ --- CRV:
+ --- 	The pedigree component property allows CRV to decide whether a component can be susceptible to a hardware
+ --- 	trojan (hardware/hybrid component) or a logic bomb (software/hybrid component) attack. If a component is designated
+ --- 	as "InternallyDeveloped", it is neither susceptible to a hardware trojan nor a logic bomb attack. For other values,
+ --- 	however, they can be susceptible to the attacks.
+
+ pedigree: enumeration (InternallyDeveloped, COTS, Sourced) applies to (system);
+
+
+
+-------------------------------------------------------------------------
+--- Port properties
+-------------------------------------------------------------------------
+
+ --- CRV:
+ --- 	If a port's probe property is true, it signifies to CRV that it is not part of the original architecture but is
+ --- 	included just for the convenience of CRV's reasoning. When a system is modeled hierarchically, a probe port allows CRV
+ --- 	to peek inside a component's behavior without needing to expose the behavior completely at a top level.
+
+ probe: aadlboolean => FALSE applies to (port);
+
+
+
+-------------------------------------------------------------------------
+--- Connection properties
+-------------------------------------------------------------------------
+
+
+ --- MBAA:
+ ---          connectionType is used by MBAA to make decisions around the level of trust for connections that are incompletely modeled.
+ ---          An example Untrusted connectionType would be GPS, where the satelite and ground systems may be excluded from the model, but
+ ---          this could also be used for logical models where the physical connection passes outside of the trust boundary.
+ ---          An example Trusted connectionType would be a connection passing between two local systems, where the physical communications
+ ---          medium is entirely contained within the trust boundary indicating that the connection itself can be trusted.
+ --- CRV:
+ ---          connectionType enables CRV to decide whether a certain connection can be susceptible to network injection attack
+ ---          or the component to which this connection is incident upon is susceptible to Remote code injection or other software
+ ---          attacks(e.g., virus, trojan, worm). Trusted connections are assumed to be free of attacks whereas Untrusted connections can be
+ ---          susceptible to attacks depending on the values of the following additional properties (encryptedTransmission/deviceAuthentication).
+
+ connectionType: enumeration (Trusted, Untrusted) => Untrusted applies to (connection);
+
+
+
+------------------------------------------------------------------------
+-- Optional Component Properties
+------------------------------------------------------------------------
+
+ --- CRV:
+ --- 	The category property lets CRV know whether a certain component is one of the pre-defined ones (e.g., GPS, IMU, LIDAR).
+ --- 	If it is one of the pre-defined components, then CRV decides it to be susceptible to a pre-defined set of attacks (e.g., Location spoofing).
+
+ category: aadlstring applies to (system);
+
+ --- CRV:
+ --- 	If adversariallyTestedForTrojanOrLogicBomb property of a component is assigned an integer greater than '0', it suggests CRV that even if the
+ --- 	component's pedigree is sourced/COTS, it is not susceptible to hardware trojan or logic bomb type of attacks.
+
+ adversariallyTestedForTrojanOrLogicBomb: aadlinteger 0 .. 9 => 0 applies to (system);
+
+
+
+------------------------------------------------------------------------
+-- Connection Cyber Defense Properties
+---          NOTE: Each cyber defense represents one or more NIST 800-53r4 controls that has been applied to the system and the relative level of rigor
+---          that is used to develop the implementation of that control. If the system does not have the property or the value is '0', it is assumed that this
+---          defense has not been applied. More information on NIST 800-53 controls can be found at: https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/final.
+------------------------------------------------------------------------
+
+ --- MBAA:
+ --- encryptedTransmission
+ ---          SC-8 Transmission Confidentiality and Integrity
+ ---                         SC-8 generally covers protection of the confidentiality of communications between two components, which
+ ---                         can include encryption of the data payload, protection of the header or protocol fields, and confidentiality
+ ---                         of data just prior to sending and just after receipt.
+ --- CRV:
+ ---          Not used by CRV
+
+ encryptedTransmission: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+ --- MBAA:
+ --- deviceAuthentication
+ ---          IA-3 Device Identification and Authentication
+ ---          IA-3 (1) Cryptographic Bidirectional Authentication
+ ---                         IA-3 specifies general verification of the identity of other connected systems, while enhancement IA-3 (1) establishes
+ ---                         requirements for mutual verification of identity through cryptographic algorithms.
+
+ deviceAuthentication: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+ --- MBAA:
+ --- sessionAuthenticity
+ ---          SC-23 Session Authenticity
+ ---                         SC-23 specifies technical means to maintain the authenticity of communications after establishing initial
+ ---                         identity. Mitigations focus on unique randomly generated session identifiers.
+ --- CRV:
+ ---          Need to add description for CRV use
+
+ sessionAuthenticity: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+
+
+-------------------------------------------------------------------------
+--- Component Cyber Defense Properties
+---          NOTE: Each cyber defense represents one or more NIST 800-53r4 controls that has been applied to the system and the relative level of rigor
+---          that is used to develop the implementation of that control. If the system does not have the property or the value is '0', it is assumed that this
+---          defense has not been applied. More information on NIST 800-53 controls can be found at: https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/final.
+-------------------------------------------------------------------------
+
+ --- MBAA:
+ --- antiJamming
+ ---          SC-40 Wireless Link Protection
+ ---          SC-40 (1) Electromagnetic Interference
+ ---                         SC-40 specifies general protections for wireless links by directing protection on signal parameters,
+ ---                         while SC-40 (1) specifies more specific techniques, such as cryptographic frequency hopping to prevent
+ ---                         the adversary from jamming communications.
+
+ antiJamming: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- auditMessageResponses
+ ---          SI-11 Error Handling
+ ---                         SI-11 ensures that error messages are designed to provide only the minimal information necessary for
+ ---                         informed authorized users to take the appropriate corrective actions and exclude any additional information that
+ ---                         would reveal more about the systems to potential attackers.
+
+ auditMessageResponses: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- dosProtection
+ ---          SC-5 Denial of Service Protection
+ ---          SC-5 (2) Excess Capacity/Bandwidth/Redundancy
+ ---                         SC-5 specifies general denial of service protections, including packet filtering and increased capacities
+ ---                         to withstand attacks. Enhancement SC-5 (2) describes more specific solutions to manage capacities, which
+ ---                         include usage priorities, quotas, and partitioning.
+
+ dosProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- encryptedStorage
+ ---          SC-28 Protection of Information at Rest
+ ---                         SC-28 specifies means to protect sensitive information stored within the system, which can include
+ ---                         encryption of stored data or stored configuration files.
+
+ encryptedStorage: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- failSafe
+ ---          SI-17 Fail-Safe Procedures
+ ---                         SI-17 specifies the implementation of logic within the system to follow a known procedure during attacks
+ ---                         that result in sustained communication interruptions. Fail-Safe procedures can include shutdown process, alerts,
+ ---                         or predefined operational paths to follow.
+
+ failSafe: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- heterogeneity
+ ---          SC-29 Heterogeneity
+ ---                         SC-29 promotes the use of a diverse set of technologies to defend against common mode failures, which prevent
+ ---                         the same attack from successfully defeating two systems intended to be independent.
+
+ heterogeneity: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- inputValidation
+ ---          SI-10 Information Input Validation
+ ---          SI-10 (5) Restrict Inputs to Trusted Sources and Approved Formats
+ ---                         SI-10 specifies checking of the validity of incoming communications. Validity checks can be performed based
+ ---                         on a whitelisted character set, packet length, numerical ranges, or a list of acceptable values, as well as many
+ ---                         other factors. Enhancement SI-10 (5) focuses on enforcing only known trusted sources and valid message formats.
+
+ inputValidation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- logging
+ ---          AU-12 Audit Generation
+ ---          AU-12 (1) System-Wide/Time-Correlated Audit Trails
+ ---          AU-12 (3) Changes by Authorized Individuals
+ ---          AU-9 Protection of Audit Information
+ ---          AU-9 (3) Cryptographic Protection
+ ---                         AU-12 with enhancements (1) and (3) focuses on the implementation of auditable records that are time-synced across
+ ---                         the broader system to aid in forensic activities and available only to authorized users. AU-9 with enhancement (3)
+ ---                         ensures audit records are protected from tampering or deletion via signed hash functions or asymmetric encryption.
+
+ logging: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- memoryProtection
+ ---          SI-16 Memory Protection
+ ---                         SI-16 describes protections from unauthorized code execution, including non-executable regions of memory and
+ ---                         address space layout randomization.
+
+ memoryProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- physicalAccessControl
+ ---          PE-3 Physical Access Control
+ ---                         PE-3 is an operational control that describes elements of a program to physically secure a facility or site that
+ ---                         containing a sensitive system. This includes verifying an individual's identity and authorization, logging physical
+ ---                         accesses, escorting visitors, taking inventory of devices, and installing/maintaining physical access devices
+ ---                         (e.g. locks, key readers, etc.).
+
+ physicalAccessControl: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- remoteAttestation
+ ---          IA-3 (4) Device Attestation
+ ---                         Enhancement IS-3 (4) describes means for one system to assure to another system the authenticity of its configuration
+ ---                         and operating state. This is often paired with secure boot, secure update, and other run-time mechanisms to
+ ---                         maintain trusted authenticity and identity between interdependent systems.
+
+ remoteAttestation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- removeIdentifyingInformation
+ ---          SI-15 Information Output Filtering
+ ---                         SI-15 requires validation of the output of the system to ensure that appropriate outputs are being sent given the context
+ ---                         of the request. Mitigations satisfying this control could be to block unnecessary data or alert on anomalous behavior.
+
+ removeIdentifyingInformation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- resourceAvailability
+ ---          SC-6 Resource Availability
+ ---                         SC-6 describes protections preventing an attacker from consuming the resources of a system, including
+ ---                         prioritization or quotas.
+
+ resourceAvailability: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- resourceIsolation
+ ---          SC-4 Information in Shared Resources
+ ---                         SC-4 provides general protection mechanisms to prevent sensitive information from being leaked through
+ ---                         shared registers, memory, or hard disk space.
+
+ resourceIsolation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- secureBoot
+ ---          SI-7 (1) Integrity Checks
+ ---          SI-7 (5) Automated Response to Integrity Violations
+ ---          SI-7 (6) Cryptographic Protection
+ ---          SI-7 (9) Verify Boot Process
+ ---          SI-7 (15) Code Authentication
+ ---                         SI-7 Enhancement (1) specifies integrity checks of software, firmware, and information on a system. Enhancement SI-7 (5) defines
+ ---                         the response to detected violations of these checks. Enhancement SI-7 (6) specifies cryptographic algorithms should
+ ---                         be used to perform these checks. Enhancement SI-7 (9) specifies the checks be performed on the boot process to ensures
+ ---                         the system is operating correctly prior to execution. Enhancement SI-7 (15) specifies the checks be performed on all
+ ---                         new software prior to installation and execution to ensure no malicious code is injected.
+
+ secureBoot: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- staticCodeAnalysis
+ ---          SA-11 (1) Static Code Analysis
+ ---                         Enhancement SA-11 (1) is an organizational control specifying the use of software tools to look for common
+ ---                         source code patterns that can be exploited by known attacks.
+
+ staticCodeAnalysis: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- strongCryptoAlgorithms
+ ---          SC-13 Cryptographic Protection
+ ---                         SC-13 is an enhancement to controls specifying the use of cryptographic algorithms. Application of this control
+ ---                         ensures only approved algorithms are used and their implementation is sufficient to protect against known attacks.
+
+ strongCryptoAlgorithms: aadlinteger 0 .. 9 applies to (system);
+
+ --- MBAA:
+ --- supplyChainSecurity
+ ---          SA-12 Supply Chain Protection
+ ---                         SA-12 is an organizational control listing best practices for acquiring services, systems, components securely. These
+ ---                         best practices include supplier reviews, operational security, component validation, and component identification
+ ---                         and traceability.
+
+ supplyChainSecurity: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- systemAccessControl
+ ---          PE-3 (1) Information System Access
+ ---                         Enhancement PE-3 (1) improves the protection applied in the "physicalAccessControl" defense by additionally restricting
+ ---                         physical access to each critical system beyond those applied to a site or facility, such that only authentic and
+ ---                         authorized individuals for that system can gain physical access.
+
+ systemAccessControl: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- tamperProtection
+ ---          SA-18 (1) [Tamper Resistance and Detection] Multiple Phases of SDLC
+ ---                         Enhancement SA-18 (1) describes multiple technical countermeasures to prevent reverse engineering or tampering with a
+ ---                         component. These countermeasures can include obfuscation, self-checking, and customization.
+
+ tamperProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- userAuthentication
+ ---          userAuthentication is NOT USED. It is a placeholder for future tool improvements.
+
+ userAuthentication: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- zeroize
+ ---          MP-6 (8) Remote Purging / Wiping of Information
+ ---                         Enhancement MP-6 (8) specifies the purging or wiping of sensitive information either from a remote command or following
+ ---                         some logic within the device to prevent unauthorized individuals from extracting that information.
+
+ zeroize: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ -- Cyber Attack Properties from TA1
  Configuration_Attack: aadlboolean applies to (system);
  Physical_Theft_Attack: aadlboolean applies to (system);
  Interception_Attack: aadlboolean applies to (system);
@@ -39,50 +383,4 @@ property set VERDICT_Properties is
  Buffer_Attack: aadlboolean applies to (system);
  Flooding_Attack: aadlboolean applies to (system);
 
- -- Cyber Defense Properties
- antiJamming: aadlboolean applies to (system); 
- auditMessageResponses: aadlboolean applies to (system);
- deviceAuthentication: aadlboolean applies to (system);
- dosProtection: aadlboolean applies to (system);
- encryptedStorage: aadlboolean applies to (system);
- heterogeneity: aadlboolean applies to (system);
- inputValidation: aadlboolean applies to (system);
- logging: aadlboolean applies to (system);
- memoryProtection: aadlboolean applies to (system);
- physicalAccessControl: aadlboolean applies to (system);
- removeIdentifyingInformation: aadlboolean applies to (system);
- resourceAvailability: aadlboolean applies to (system);
- resourceIsolation: aadlboolean applies to (system);
- secureBoot: aadlboolean applies to (system);
- sessionAuthenticity: aadlboolean applies to (system);
- staticCodeAnalysis: aadlboolean applies to (system);
- strongCryptoAlgorithms: aadlboolean applies to (system);
- supplyChainSecurity: aadlboolean applies to (system);
- systemAccessControl: aadlboolean applies to (system);
- tamperProtection: aadlboolean applies to (system);
- userAuthentication: aadlboolean applies to (system);
-
- -- DAL for Cyber Defense Properties
- antiJammingDAL: aadlinteger 0 .. 9 applies to (system);
- auditMessageResponsesDAL: aadlinteger 0 .. 9 applies to (system);
- deviceAuthenticationDAL: aadlinteger 0 .. 9 applies to (system);
- dosProtectionDAL: aadlinteger 0 .. 9 applies to (system);
- encryptedStorageDAL: aadlinteger 0 .. 9 applies to (system);
- heterogeneityDAL: aadlinteger 0 .. 9 applies to (system);
- inputValidationDAL: aadlinteger 0 .. 9 applies to (system);
- loggingDAL: aadlinteger 0 .. 9 applies to (system);
- memoryProtectionDAL: aadlinteger 0 .. 9 applies to (system);
- physicalAccessControlDAL: aadlinteger 0 .. 9 applies to (system);
- removeIdentifyingInformationDAL: aadlinteger 0 .. 9 applies to (system);
- resourceAvailabilityDAL: aadlinteger 0 .. 9 applies to (system);
- resourceIsolationDAL: aadlinteger 0 .. 9 applies to (system);
- secureBootDAL: aadlinteger 0 .. 9 applies to (system);
- sessionAuthenticityDAL: aadlinteger 0 .. 9 applies to (system);
- staticCodeAnalysisDAL: aadlinteger 0 .. 9 applies to (system);
- strongCryptoAlgorithmsDAL: aadlinteger 0 .. 9 applies to (system);
- supplyChainSecurityDAL: aadlinteger 0 .. 9 applies to (system);
- systemAccessControlDAL: aadlinteger 0 .. 9 applies to (system);
- tamperProtectionDAL: aadlinteger 0 .. 9 applies to (system);
- userAuthenticationDAL: aadlinteger 0 .. 9 applies to (system);
- 
 end VERDICT_Properties;

--- a/models/DeliveryDrone/DeliveryDrone.aadl
+++ b/models/DeliveryDrone/DeliveryDrone.aadl
@@ -2,10 +2,10 @@ package DeliveryDrone
 
 public
 	with Base_Types;
-    with Data_Types;
-    with Agree_Constants;
-    with Agree_Nodes;
-    with Agree_Constants;
+	with Data_Types;
+	with Agree_Constants;
+	with Agree_Nodes;
+	with Agree_Constants;
 	with VERDICT_Properties;
 	with GNC;
 
@@ -642,36 +642,19 @@ public
 				VERDICT_Properties::insideTrustedBoundary => true;
 				VERDICT_Properties::componentType => Hybrid;
 				VERDICT_Properties::pedigree => InternallyDeveloped;
-				VERDICT_Properties::dataReceivedFromUntrusted => true;
-				VERDICT_Properties::controlReceivedFromUntrusted => true;
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 7;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 7;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 7;
-				VERDICT_Properties::secureBoot => true;
-				VERDICT_Properties::secureBootDAL => 7;
-				VERDICT_Properties::memoryProtection => true;
-				VERDICT_Properties::memoryProtectionDAL => 7;
-				VERDICT_Properties::staticCodeAnalysis => true;
-				VERDICT_Properties::staticCodeAnalysisDAL => 7;
-				VERDICT_Properties::resourceAvailability => true;
-				VERDICT_Properties::resourceAvailabilityDAL => 7;
-				VERDICT_Properties::antiJamming => true;
-				VERDICT_Properties::antiJammingDAL => 7;
-				VERDICT_Properties::dosProtection => true;
-				VERDICT_Properties::dosProtectionDAL => 7;
-				VERDICT_Properties::deviceAuthentication => true;
-				VERDICT_Properties::deviceAuthenticationDAL => 7;
-				VERDICT_Properties::inputValidation => true;
-				VERDICT_Properties::inputValidationDAL => 7;
-				VERDICT_Properties::sessionAuthenticity => true;
-				VERDICT_Properties::sessionAuthenticityDAL => 7;
-				VERDICT_Properties::strongCryptoAlgorithms => true;
-				VERDICT_Properties::strongCryptoAlgorithmsDAL => 7;
+				VERDICT_Properties::supplyChainSecurity => 7;
+				VERDICT_Properties::physicalAccessControl => 7;
+				VERDICT_Properties::systemAccessControl => 7;
+				VERDICT_Properties::secureBoot => 7;
+				VERDICT_Properties::memoryProtection => 7;
+				VERDICT_Properties::staticCodeAnalysis => 7;
+				VERDICT_Properties::resourceAvailability => 7;
+				VERDICT_Properties::antiJamming => 7;
+				VERDICT_Properties::dosProtection => 7;
+				VERDICT_Properties::inputValidation => 7;
+				VERDICT_Properties::strongCryptoAlgorithms => 7;
 				
 							
 			};
@@ -684,21 +667,15 @@ public
 				VERDICT_Properties::hasSensitiveInfo => true;
 				VERDICT_Properties::canReceiveSWUpdate => true;
 		
-			 	VERDICT_Properties::adversariallyTested => false;
-			 	--VERDICT_Properties::adversariallyTested => true; -- Fix for Logic Bomb
+				VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 0;
+				--VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 7; -- Fix for Logic Bomb
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 7;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 7;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 7;
-				
-				VERDICT_Properties::secureBoot => true;
-				VERDICT_Properties::secureBootDAL => 7;
-				VERDICT_Properties::memoryProtection => true;
-				VERDICT_Properties::memoryProtectionDAL => 7;
+				VERDICT_Properties::supplyChainSecurity => 7;
+				VERDICT_Properties::physicalAccessControl => 7;
+				VERDICT_Properties::systemAccessControl => 7;
+				VERDICT_Properties::secureBoot => 7;
+				VERDICT_Properties::memoryProtection => 7;
 			};
 			navigation: system Navigation
 			{
@@ -710,17 +687,11 @@ public
 				VERDICT_Properties::canReceiveSWUpdate => true;
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 7;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 7;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 7;
-				
-				VERDICT_Properties::secureBoot => true;
-				VERDICT_Properties::secureBootDAL => 7;
-				VERDICT_Properties::memoryProtection => true;
-				VERDICT_Properties::memoryProtectionDAL => 7;	
+				VERDICT_Properties::supplyChainSecurity => 7;
+				VERDICT_Properties::physicalAccessControl => 7;
+				VERDICT_Properties::systemAccessControl => 7;
+				VERDICT_Properties::secureBoot => 7;
+				VERDICT_Properties::memoryProtection => 7;
 			};
 			fc: system FlightControl
 			{
@@ -732,17 +703,11 @@ public
 				VERDICT_Properties::canReceiveSWUpdate => true;
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 7;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 7;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 7;
-				
-				VERDICT_Properties::secureBoot => true;
-				VERDICT_Properties::secureBootDAL => 7;
-				VERDICT_Properties::memoryProtection => true;
-				VERDICT_Properties::memoryProtectionDAL => 7;
+				VERDICT_Properties::supplyChainSecurity => 7;
+				VERDICT_Properties::physicalAccessControl => 7;
+				VERDICT_Properties::systemAccessControl => 7;
+				VERDICT_Properties::secureBoot => 7;
+				VERDICT_Properties::memoryProtection => 7;
 			};
 			actuation: system Actuation
 			{
@@ -753,12 +718,9 @@ public
 				VERDICT_Properties::hasSensitiveInfo => true;
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 7;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 7;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 7;
+				VERDICT_Properties::supplyChainSecurity => 7;
+				VERDICT_Properties::physicalAccessControl => 7;
+				VERDICT_Properties::systemAccessControl => 7;
 			};
 			deliveryPlanner: system DeliveryPlanner
 			{	
@@ -769,37 +731,19 @@ public
 				--VERDICT_Properties::pedigree => InternallyDeveloped; -- Fix for Logic Bomb
 				VERDICT_Properties::hasSensitiveInfo => true;
 				VERDICT_Properties::canReceiveSWUpdate => true;
-				VERDICT_Properties::controlReceivedFromUntrusted => true;
-				VERDICT_Properties::dataReceivedFromUntrusted => true;
 			
 				-- VERDICT Cyber Defense and DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 7;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 7;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 7;
-				
-				VERDICT_Properties::secureBoot => true;
-				VERDICT_Properties::secureBootDAL => 7;
-				VERDICT_Properties::memoryProtection => true;
-				VERDICT_Properties::memoryProtectionDAL => 7;	
-				VERDICT_Properties::staticCodeAnalysis => true;
-				VERDICT_Properties::staticCodeAnalysisDAL => 7;
-				VERDICT_Properties::resourceAvailability => true;
-				VERDICT_Properties::resourceAvailabilityDAL => 7;
-				VERDICT_Properties::antiJamming => true;
-				VERDICT_Properties::antiJammingDAL => 7;
-				VERDICT_Properties::dosProtection => true;
-				VERDICT_Properties::dosProtectionDAL => 7;
-				VERDICT_Properties::deviceAuthentication => true;
-				VERDICT_Properties::deviceAuthenticationDAL => 7;
-				VERDICT_Properties::inputValidation => true;
-				VERDICT_Properties::inputValidationDAL => 7;
-				VERDICT_Properties::sessionAuthenticity => true;
-				VERDICT_Properties::sessionAuthenticityDAL => 7;
-				VERDICT_Properties::strongCryptoAlgorithms => true;
-				VERDICT_Properties::strongCryptoAlgorithmsDAL => 7;
+				VERDICT_Properties::supplyChainSecurity => 7;
+				VERDICT_Properties::physicalAccessControl => 7;
+				VERDICT_Properties::systemAccessControl => 7;
+				VERDICT_Properties::secureBoot => 7;
+				VERDICT_Properties::memoryProtection => 7;
+				VERDICT_Properties::staticCodeAnalysis => 7;
+				VERDICT_Properties::resourceAvailability => 7;
+				VERDICT_Properties::antiJamming => 7;
+				VERDICT_Properties::dosProtection => 7;
+				VERDICT_Properties::inputValidation => 7;
+				VERDICT_Properties::strongCryptoAlgorithms => 7;
 			};
 			deliveryItemMechanism: system DeliveryItemMechanism
 			{
@@ -810,12 +754,9 @@ public
 				VERDICT_Properties::hasSensitiveInfo => true;
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 7;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 7;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 7;
+				VERDICT_Properties::supplyChainSecurity => 7;
+				VERDICT_Properties::physicalAccessControl => 7;
+				VERDICT_Properties::systemAccessControl => 7;
 				
 			};
 			camera: system Camera
@@ -827,12 +768,9 @@ public
 				VERDICT_Properties::hasSensitiveInfo => true;
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 7;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 7;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 7;
+				VERDICT_Properties::supplyChainSecurity => 7;
+				VERDICT_Properties::physicalAccessControl => 7;
+				VERDICT_Properties::systemAccessControl => 7;
 			};
 			
 			connector: system Connector
@@ -843,154 +781,149 @@ public
 			 	
 			 	VERDICT_Properties::pedigree => COTS;
 			 	--VERDICT_Properties::pedigree => InternallyDeveloped; -- Fix for Logic Bomb / Hardware Trojan
-			 	VERDICT_Properties::adversariallyTested => false;
+				VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 0;
 			};
-			
+
 		connections
 			c1: port positionEstimator.est_pos -> navigation.est_pos
-			{VERDICT_Properties::flowType => Xcontrol;
-			 VERDICT_Properties::trustedConnection => true;	
-			 VERDICT_Properties::encryptedTransmission => true;
-			 VERDICT_Properties::encryptedTransmissionDAL => 6;
+			{VERDICT_Properties::connectionType => Trusted;
+			 VERDICT_Properties::encryptedTransmission => 6;
 			};
 			
 			c1b: port deliveryPlanner.launch_pos -> gnc.launch_pos
-			{VERDICT_Properties::flowType => Xrequest;
-			 VERDICT_Properties::trustedConnection => false;
-			};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c2: port navigation.move -> fc.move
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 
 			c3: port fc.fc_state -> navigation.flight_control_state
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c4: port deliveryPlanner.dest_location -> navigation.dest_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c5: port navigation.cur_pos -> deliveryPlanner.cur_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			
 			c7: port deliveryItemMechanism.delivery_status_out -> deliveryPlanner.delivery_status			
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c9: port camera.camera_out -> deliveryPlanner.camera_result			
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c10: port deliveryPlanner.radio_cmd -> radio.radio_in
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c11: port radio.radio_out -> deliveryPlanner.radio_response
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c12: port gnc.gps_pos -> positionEstimator.gps_pos
 			{
-			VERDICT_Properties::flowType => Xdata;
-			-- VERDICT_Properties::trustedConnection => false;
+			VERDICT_Properties::connectionType => Trusted;
+			-- VERDICT_Properties::connectionType => Untrusted;
 			};
 			
 			c14a: port bus1 -> connector.bus_in
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Untrusted;};
 			
 			c14b: port connector.bus_out -> DeliveryPlanner.bus_in
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c15: port deliveryPlanner.bus_out -> bus2
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c16: port comm1 -> radio.comm_in
-			{VERDICT_Properties::flowType => Xdata;
-		     VERDICT_Properties::connectionType => Remote;
-			 VERDICT_Properties::authenticated => false;
-			 VERDICT_Properties::encryptedTransmission => false;
-			 --VERDICT_Properties::authenticated => true; -- Fix for Network Injection
-			 --VERDICT_Properties::encryptedTransmission => true; -- Fix for Network Injection
+			{VERDICT_Properties::connectionType => Untrusted;
+			 VERDICT_Properties::deviceAuthentication => 0;
+			 VERDICT_Properties::encryptedTransmission => 0;
+			 --VERDICT_Properties::deviceAuthentication => 7; -- Fix for Network Injection
+			 --VERDICT_Properties::encryptedTransmission => 5; -- Fix for Network Injection
 			};
 			
 			c17: port radio.comm_out -> comm2
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 
 			c18a: port gnc.imu_pos -> positionEstimator.imu_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c19: port fc.motor_cmd -> actuation.motor_cmd
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c20: port actuation.response -> fc.actuation_response
-			{VERDICT_Properties::flowType => Xdata;};	
+			{VERDICT_Properties::connectionType => Trusted;};
 
 			c22: port satellite0_sig_pos -> gnc.satellite0_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c23: port satellite1_sig_pos -> gnc.satellite1_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c24: port navigation.pos_act_out -> positionEstimator.pos_act_in
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c25: port deliveryPlanner.delivery_cmd -> deliveryItemMechanism.delivery_cmd_in
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 
 			c26: port deliveryPlanner.nav_cmd -> navigation.cmd
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c27: port deliveryPlanner.camera -> camera.camera_in			
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c28: port deliveryPlanner.radio_cmd -> radio_cmd
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c29: port radio.radio_out -> radio_response
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c30: port deliveryItemMechanism.delivery_status_out -> delivery_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c31: port deliveryPlanner.delivery_cmd -> probe_delivery_cmd
-			{VERDICT_Properties::flowType => Xdata;}; 							
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c32: port actuation.response -> actuation_out
-			{VERDICT_Properties::flowType => Xdata;};	
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c33: port deliveryPlanner.constellation -> gnc.constellation
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c34: port gnc.gps_health_status -> deliveryPlanner.gps_health_status
 			{
-			VERDICT_Properties::flowType => Xdata;
-			--VERDICT_Properties::trustedConnection => false;
+			VERDICT_Properties::connectionType => Trusted;
+			--VERDICT_Properties::connectionType => Untrusted;
 			};
 			
 			c35: port gnc.imu_health_status -> deliveryPlanner.imu_health_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c36: port radio.health_status -> deliveryPlanner.rdo_health_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c37: port camera.health_status -> deliveryPlanner.cam_health_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c38: port gnc.probe_constellation -> probe_constellation
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c39: port deliveryPlanner.probe_init_mode -> probe_init_mode
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c40: port gnc.probe_launch_pos -> probe_launch_location
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c41: port navigation.probe_dest_pos -> probe_delivery_location
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c42: port deliveryItemMechanism.package_is_secure -> deliveryPlanner.package_is_secure
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c43: port deliveryPlanner.nav_cmd -> probe_fly_cmd
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c44: port deliveryPlanner.probe_abort_mode -> probe_abort_mode
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 												
 	end DeliveryDroneSystem.impl;
 	

--- a/models/DeliveryDrone/GNC.aadl
+++ b/models/DeliveryDrone/GNC.aadl
@@ -2,9 +2,9 @@ package GNC
 
 public
 	with Base_Types;
-    with Data_Types;
-    with Agree_Nodes;
-    with VERDICT_Properties;
+	with Data_Types;
+	with Agree_Nodes;
+	with VERDICT_Properties;
 
 	system GPS
 		features
@@ -115,41 +115,24 @@ public
 			gps: system GPS
 			{
 				-- VERDICT Component Properties
-				VERDICT_Properties::insideTrustedBoundary => true; -- Another scenario - set this to false along with trustedConnection for c12 and c34 to false
+				VERDICT_Properties::insideTrustedBoundary => true; -- Another scenario - set this to false along with connectionType for c12 and c34 to Untrusted
 				VERDICT_Properties::componentType => Hybrid;
 				VERDICT_Properties::pedigree => COTS;
 				--VERDICT_Properties::pedigree => InternallyDeveloped; -- Fix for Logic Bomb / Hardware Trojan
-				VERDICT_Properties::dataReceivedFromUntrusted => true;
-					
-				VERDICT_Properties::adversariallyTested => false;
+				VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 0;
 
-                -- VERDICT Cyber Defenses & DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 7;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 7;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 7;
-				VERDICT_Properties::secureBoot => true;
-				VERDICT_Properties::secureBootDAL => 7;
-				VERDICT_Properties::memoryProtection => true;
-				VERDICT_Properties::memoryProtectionDAL => 7;
-				VERDICT_Properties::staticCodeAnalysis => true;
-				VERDICT_Properties::staticCodeAnalysisDAL => 7;
-				VERDICT_Properties::resourceAvailability => true;
-				VERDICT_Properties::resourceAvailabilityDAL => 7;
-				VERDICT_Properties::antiJamming => true;
-				VERDICT_Properties::antiJammingDAL => 7;
-				VERDICT_Properties::dosProtection => true;
-				VERDICT_Properties::dosProtectionDAL => 7;
-				VERDICT_Properties::deviceAuthentication => true;
-				VERDICT_Properties::deviceAuthenticationDAL => 7;
-				VERDICT_Properties::inputValidation => true;
-				VERDICT_Properties::inputValidationDAL => 7;
-				VERDICT_Properties::sessionAuthenticity => true;
-				VERDICT_Properties::sessionAuthenticityDAL => 7;
-				VERDICT_Properties::strongCryptoAlgorithms => true;
-				VERDICT_Properties::strongCryptoAlgorithmsDAL => 7;																
+				-- VERDICT Cyber Defenses & DAL Mitigations
+				VERDICT_Properties::supplyChainSecurity => 7;
+				VERDICT_Properties::physicalAccessControl => 7;
+				VERDICT_Properties::systemAccessControl => 7;
+				VERDICT_Properties::secureBoot => 7;
+				VERDICT_Properties::memoryProtection => 7;
+				VERDICT_Properties::staticCodeAnalysis => 7;
+				VERDICT_Properties::resourceAvailability => 7;
+				VERDICT_Properties::antiJamming => 7;
+				VERDICT_Properties::dosProtection => 7;
+				VERDICT_Properties::inputValidation => 7;
+				VERDICT_Properties::strongCryptoAlgorithms => 7;
 			};
 			imu: system IMU
 			{ 
@@ -160,38 +143,32 @@ public
 				--VERDICT_Properties::pedigree => InternallyDeveloped; -- Fix for Logic Bomb / Hardware Trojan
 				
 				-- VERDICT Cyber Defenses & DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 7;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 7;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 7;
-				
-				VERDICT_Properties::secureBoot => true;
-				VERDICT_Properties::secureBootDAL => 7;
-				VERDICT_Properties::memoryProtection => true;
-				VERDICT_Properties::memoryProtectionDAL => 7;
+				VERDICT_Properties::supplyChainSecurity => 7;
+				VERDICT_Properties::physicalAccessControl => 7;
+				VERDICT_Properties::systemAccessControl => 7;
+				VERDICT_Properties::secureBoot => 7;
+				VERDICT_Properties::memoryProtection => 7;
 			};
 		connections
 			i1: port constellation -> gps.constellation
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i2: port satellite0_pos -> gps.satellite0_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Untrusted;};
 			i3: port satellite1_pos -> gps.satellite1_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Untrusted;};
 			i4: port launch_pos -> imu.launch_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i5: port gps.gps_pos -> gps_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i6: port gps.health_status -> gps_health_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i7: port gps.probe_constellation -> probe_constellation
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i8: port imu.imu_pos -> imu_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i9: port imu.health_status -> imu_health_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i10: port imu.probe_launch_pos -> probe_launch_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 	end GNC.Impl;
 end GNC;

--- a/models/DeliveryDrone/VERDICT_Properties.aadl
+++ b/models/DeliveryDrone/VERDICT_Properties.aadl
@@ -1,31 +1,375 @@
+-------------------------------------------------------------------------
+--- The following VERDICT_Properties enable the use of the VERDICT tool suite for both the high-level Model-Based
+--- Architectural Analysis (MBAA) and behavioral analysis using the Cyber Resiliency Verifier (CRV). Each property
+--- below is tagged for which tools uses the property followed by a short description.
+---
+--- This file contains four different types of properties:
+--- 	Mandatory User Defined Component Properties must be assigned for VERDICT tools to execute
+--- 	Port Properties are used to designate analysis-only ports for use in behavioral analysis
+--- 	Connection Properties contain necessary inputs as well as annotations for applied mitigations on connections
+--- 	Connection Cyber Defense Properties allow the designer to annotate applied mitigations for connections
+--- 	Component Cyber Defense Properties allow the designer to annotate applied mitigations for system components
+-------------------------------------------------------------------------
 property set VERDICT_Properties is
--- Port properties
- probe: aadlboolean applies to (port);
 
--- Connection properties, including defenses and DAL values
- flowType: enumeration (Xdata, Xcontrol, Xrequest) applies to (connection);
- connectionType: enumeration (Local, Remote) applies to (connection);
- authenticated: aadlboolean applies to (connection);
- trustedConnection: aadlboolean applies to (connection);
- encryptedTransmission: aadlboolean applies to (connection);
- encryptedTransmissionDAL: aadlinteger 0 .. 9 applies to (connection);
 
--- Component properties 
- pedigree: enumeration (InternallyDeveloped, COTS, Sourced) applies to (system);
- category: aadlstring applies to (system);
- componentType: enumeration (Software, Hardware, Human, Hybrid) applies to (system);
- situated: enumeration (OnBoard, Remote) applies to (system);
- adversariallyTested: aadlboolean applies to (system);
- hasSensitiveInfo: aadlboolean applies to (system);
- insideTrustedBoundary: aadlboolean applies to (system);
+
+-------------------------------------------------------------------------
+--- Mandatory User Defined Component Properties
+---          NOTE: The mandatory user defined component properties must be assigned for each applicable component as a minimum for VERDICT to execute.
+-------------------------------------------------------------------------
+
+ --- MBAA:
+ --- 	canReceiveConfigUpdate is a property used to determine whether the system is susceptible to attacks attempting to tamper with the configuration
+ --- 	of a system. Apply this property if the configuration of software or hardware within the system can be updated outside of the original
+ --- 	manufacturer's facility.
+
  canReceiveConfigUpdate: aadlboolean applies to (system);
- canReceiveSWUpdate: aadlboolean applies to (system);
- controlReceivedFromUntrusted: aadlboolean applies to (system);
- controlSentToUntrusted: aadlboolean applies to (system);
- dataReceivedFromUntrusted: aadlboolean applies to (system);
- dataSentToUntrusted: aadlboolean applies to (system);
 
- -- Cyber Attack Properties from TA1 
+ --- MBAA:
+ --- 	canRecieveSWUpdate is a property used to determine whether the system is susceptible to attacks attempting to install malicious software
+ --- 	updates. Apply this property if the software within the system can be updated outside of the original manufacturer's facility.
+
+ canReceiveSWUpdate: aadlboolean applies to (system);
+
+ --- MBAA:
+ --- 	componentType is a property used to determine whether the system is subject to attacks targeting software, hardware, humans, or hybrid
+ --- 	(software and hardware). For example, systems that represent software only will not be subject to CAPEC-440 Hardware Integrity Attack.
+ --- CRV:
+ --- 	A componentType designates whether a component is a software, a hardware, a Human, or a Hybrid (mix of Software and Hardware).
+ --- 	This helps CRV to decide what sort of attack can the component be susceptible to. For instance, a Hybrid component can be susceptible
+ --- 	to both hardware (e.g., trojans) and software (e.g., logic bomb) attacks whereas a Human component can only be susceptible to insider/outsider threat.
+
+ componentType: enumeration (Software, Hardware, Human, SwHwHybrid, SwHumanHybrid, HwHumanHybrid, Hybrid) applies to (system);
+
+ --- MBAA:
+ --- 	If a system contains the property hasSensitiveInfo it will be considered for attacks resulting in loss of confidentiality.
+
+ hasSensitiveInfo: aadlboolean applies to (system);
+
+ --- MBAA:
+ --- 	insideTrustedBoundary designates a system that will be analyzed for their potential to be attacked. Also, systems where insideTrustedBoundary=TRUE
+ --- 	will not be considered the initial source of attacks.
+ --- CRV:
+ --- 	If a component's insideTrustedBoundary property is true, it signifies to CRV that the component is inside the system's trust boundary. For instance,
+ --- 	if a human component is inside the trusted boundary of the system, then an insider attack can occur.
+
+ insideTrustedBoundary: aadlboolean applies to (system);
+
+
+ --- MBAA:
+ --- 	pedigree is a property used to infer the level of trust in a system. A "COTS" component will be untrusted and considered a
+ --- 	potential source of attacks, whereas "Sourced" and "InternallyDeveloped" components will be trusted. Both of these can be explicitly
+ --- 	overridden by the insideTrustedBoundary property.
+ ---
+ --- CRV:
+ --- 	The pedigree component property allows CRV to decide whether a component can be susceptible to a hardware
+ --- 	trojan (hardware/hybrid component) or a logic bomb (software/hybrid component) attack. If a component is designated
+ --- 	as "InternallyDeveloped", it is neither susceptible to a hardware trojan nor a logic bomb attack. For other values,
+ --- 	however, they can be susceptible to the attacks.
+
+ pedigree: enumeration (InternallyDeveloped, COTS, Sourced) applies to (system);
+
+
+
+-------------------------------------------------------------------------
+--- Port properties
+-------------------------------------------------------------------------
+
+ --- CRV:
+ --- 	If a port's probe property is true, it signifies to CRV that it is not part of the original architecture but is
+ --- 	included just for the convenience of CRV's reasoning. When a system is modeled hierarchically, a probe port allows CRV
+ --- 	to peek inside a component's behavior without needing to expose the behavior completely at a top level.
+
+ probe: aadlboolean => FALSE applies to (port);
+
+
+
+-------------------------------------------------------------------------
+--- Connection properties
+-------------------------------------------------------------------------
+
+
+ --- MBAA:
+ ---          connectionType is used by MBAA to make decisions around the level of trust for connections that are incompletely modeled.
+ ---          An example Untrusted connectionType would be GPS, where the satelite and ground systems may be excluded from the model, but
+ ---          this could also be used for logical models where the physical connection passes outside of the trust boundary.
+ ---          An example Trusted connectionType would be a connection passing between two local systems, where the physical communications
+ ---          medium is entirely contained within the trust boundary indicating that the connection itself can be trusted.
+ --- CRV:
+ ---          connectionType enables CRV to decide whether a certain connection can be susceptible to network injection attack
+ ---          or the component to which this connection is incident upon is susceptible to Remote code injection or other software
+ ---          attacks(e.g., virus, trojan, worm). Trusted connections are assumed to be free of attacks whereas Untrusted connections can be
+ ---          susceptible to attacks depending on the values of the following additional properties (encryptedTransmission/deviceAuthentication).
+
+ connectionType: enumeration (Trusted, Untrusted) => Untrusted applies to (connection);
+
+
+
+------------------------------------------------------------------------
+-- Optional Component Properties
+------------------------------------------------------------------------
+
+ --- CRV:
+ --- 	The category property lets CRV know whether a certain component is one of the pre-defined ones (e.g., GPS, IMU, LIDAR).
+ --- 	If it is one of the pre-defined components, then CRV decides it to be susceptible to a pre-defined set of attacks (e.g., Location spoofing).
+
+ category: aadlstring applies to (system);
+
+ --- CRV:
+ --- 	If adversariallyTestedForTrojanOrLogicBomb property of a component is assigned an integer greater than '0', it suggests CRV that even if the
+ --- 	component's pedigree is sourced/COTS, it is not susceptible to hardware trojan or logic bomb type of attacks.
+
+ adversariallyTestedForTrojanOrLogicBomb: aadlinteger 0 .. 9 => 0 applies to (system);
+
+
+
+------------------------------------------------------------------------
+-- Connection Cyber Defense Properties
+---          NOTE: Each cyber defense represents one or more NIST 800-53r4 controls that has been applied to the system and the relative level of rigor
+---          that is used to develop the implementation of that control. If the system does not have the property or the value is '0', it is assumed that this
+---          defense has not been applied. More information on NIST 800-53 controls can be found at: https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/final.
+------------------------------------------------------------------------
+
+ --- MBAA:
+ --- encryptedTransmission
+ ---          SC-8 Transmission Confidentiality and Integrity
+ ---                         SC-8 generally covers protection of the confidentiality of communications between two components, which
+ ---                         can include encryption of the data payload, protection of the header or protocol fields, and confidentiality
+ ---                         of data just prior to sending and just after receipt.
+ --- CRV:
+ ---          Not used by CRV
+
+ encryptedTransmission: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+ --- MBAA:
+ --- deviceAuthentication
+ ---          IA-3 Device Identification and Authentication
+ ---          IA-3 (1) Cryptographic Bidirectional Authentication
+ ---                         IA-3 specifies general verification of the identity of other connected systems, while enhancement IA-3 (1) establishes
+ ---                         requirements for mutual verification of identity through cryptographic algorithms.
+
+ deviceAuthentication: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+ --- MBAA:
+ --- sessionAuthenticity
+ ---          SC-23 Session Authenticity
+ ---                         SC-23 specifies technical means to maintain the authenticity of communications after establishing initial
+ ---                         identity. Mitigations focus on unique randomly generated session identifiers.
+ --- CRV:
+ ---          Need to add description for CRV use
+
+ sessionAuthenticity: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+
+
+-------------------------------------------------------------------------
+--- Component Cyber Defense Properties
+---          NOTE: Each cyber defense represents one or more NIST 800-53r4 controls that has been applied to the system and the relative level of rigor
+---          that is used to develop the implementation of that control. If the system does not have the property or the value is '0', it is assumed that this
+---          defense has not been applied. More information on NIST 800-53 controls can be found at: https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/final.
+-------------------------------------------------------------------------
+
+ --- MBAA:
+ --- antiJamming
+ ---          SC-40 Wireless Link Protection
+ ---          SC-40 (1) Electromagnetic Interference
+ ---                         SC-40 specifies general protections for wireless links by directing protection on signal parameters,
+ ---                         while SC-40 (1) specifies more specific techniques, such as cryptographic frequency hopping to prevent
+ ---                         the adversary from jamming communications.
+
+ antiJamming: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- auditMessageResponses
+ ---          SI-11 Error Handling
+ ---                         SI-11 ensures that error messages are designed to provide only the minimal information necessary for
+ ---                         informed authorized users to take the appropriate corrective actions and exclude any additional information that
+ ---                         would reveal more about the systems to potential attackers.
+
+ auditMessageResponses: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- dosProtection
+ ---          SC-5 Denial of Service Protection
+ ---          SC-5 (2) Excess Capacity/Bandwidth/Redundancy
+ ---                         SC-5 specifies general denial of service protections, including packet filtering and increased capacities
+ ---                         to withstand attacks. Enhancement SC-5 (2) describes more specific solutions to manage capacities, which
+ ---                         include usage priorities, quotas, and partitioning.
+
+ dosProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- encryptedStorage
+ ---          SC-28 Protection of Information at Rest
+ ---                         SC-28 specifies means to protect sensitive information stored within the system, which can include
+ ---                         encryption of stored data or stored configuration files.
+
+ encryptedStorage: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- failSafe
+ ---          SI-17 Fail-Safe Procedures
+ ---                         SI-17 specifies the implementation of logic within the system to follow a known procedure during attacks
+ ---                         that result in sustained communication interruptions. Fail-Safe procedures can include shutdown process, alerts,
+ ---                         or predefined operational paths to follow.
+
+ failSafe: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- heterogeneity
+ ---          SC-29 Heterogeneity
+ ---                         SC-29 promotes the use of a diverse set of technologies to defend against common mode failures, which prevent
+ ---                         the same attack from successfully defeating two systems intended to be independent.
+
+ heterogeneity: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- inputValidation
+ ---          SI-10 Information Input Validation
+ ---          SI-10 (5) Restrict Inputs to Trusted Sources and Approved Formats
+ ---                         SI-10 specifies checking of the validity of incoming communications. Validity checks can be performed based
+ ---                         on a whitelisted character set, packet length, numerical ranges, or a list of acceptable values, as well as many
+ ---                         other factors. Enhancement SI-10 (5) focuses on enforcing only known trusted sources and valid message formats.
+
+ inputValidation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- logging
+ ---          AU-12 Audit Generation
+ ---          AU-12 (1) System-Wide/Time-Correlated Audit Trails
+ ---          AU-12 (3) Changes by Authorized Individuals
+ ---          AU-9 Protection of Audit Information
+ ---          AU-9 (3) Cryptographic Protection
+ ---                         AU-12 with enhancements (1) and (3) focuses on the implementation of auditable records that are time-synced across
+ ---                         the broader system to aid in forensic activities and available only to authorized users. AU-9 with enhancement (3)
+ ---                         ensures audit records are protected from tampering or deletion via signed hash functions or asymmetric encryption.
+
+ logging: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- memoryProtection
+ ---          SI-16 Memory Protection
+ ---                         SI-16 describes protections from unauthorized code execution, including non-executable regions of memory and
+ ---                         address space layout randomization.
+
+ memoryProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- physicalAccessControl
+ ---          PE-3 Physical Access Control
+ ---                         PE-3 is an operational control that describes elements of a program to physically secure a facility or site that
+ ---                         containing a sensitive system. This includes verifying an individual's identity and authorization, logging physical
+ ---                         accesses, escorting visitors, taking inventory of devices, and installing/maintaining physical access devices
+ ---                         (e.g. locks, key readers, etc.).
+
+ physicalAccessControl: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- remoteAttestation
+ ---          IA-3 (4) Device Attestation
+ ---                         Enhancement IS-3 (4) describes means for one system to assure to another system the authenticity of its configuration
+ ---                         and operating state. This is often paired with secure boot, secure update, and other run-time mechanisms to
+ ---                         maintain trusted authenticity and identity between interdependent systems.
+
+ remoteAttestation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- removeIdentifyingInformation
+ ---          SI-15 Information Output Filtering
+ ---                         SI-15 requires validation of the output of the system to ensure that appropriate outputs are being sent given the context
+ ---                         of the request. Mitigations satisfying this control could be to block unnecessary data or alert on anomalous behavior.
+
+ removeIdentifyingInformation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- resourceAvailability
+ ---          SC-6 Resource Availability
+ ---                         SC-6 describes protections preventing an attacker from consuming the resources of a system, including
+ ---                         prioritization or quotas.
+
+ resourceAvailability: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- resourceIsolation
+ ---          SC-4 Information in Shared Resources
+ ---                         SC-4 provides general protection mechanisms to prevent sensitive information from being leaked through
+ ---                         shared registers, memory, or hard disk space.
+
+ resourceIsolation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- secureBoot
+ ---          SI-7 (1) Integrity Checks
+ ---          SI-7 (5) Automated Response to Integrity Violations
+ ---          SI-7 (6) Cryptographic Protection
+ ---          SI-7 (9) Verify Boot Process
+ ---          SI-7 (15) Code Authentication
+ ---                         SI-7 Enhancement (1) specifies integrity checks of software, firmware, and information on a system. Enhancement SI-7 (5) defines
+ ---                         the response to detected violations of these checks. Enhancement SI-7 (6) specifies cryptographic algorithms should
+ ---                         be used to perform these checks. Enhancement SI-7 (9) specifies the checks be performed on the boot process to ensures
+ ---                         the system is operating correctly prior to execution. Enhancement SI-7 (15) specifies the checks be performed on all
+ ---                         new software prior to installation and execution to ensure no malicious code is injected.
+
+ secureBoot: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- staticCodeAnalysis
+ ---          SA-11 (1) Static Code Analysis
+ ---                         Enhancement SA-11 (1) is an organizational control specifying the use of software tools to look for common
+ ---                         source code patterns that can be exploited by known attacks.
+
+ staticCodeAnalysis: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- strongCryptoAlgorithms
+ ---          SC-13 Cryptographic Protection
+ ---                         SC-13 is an enhancement to controls specifying the use of cryptographic algorithms. Application of this control
+ ---                         ensures only approved algorithms are used and their implementation is sufficient to protect against known attacks.
+
+ strongCryptoAlgorithms: aadlinteger 0 .. 9 applies to (system);
+
+ --- MBAA:
+ --- supplyChainSecurity
+ ---          SA-12 Supply Chain Protection
+ ---                         SA-12 is an organizational control listing best practices for acquiring services, systems, components securely. These
+ ---                         best practices include supplier reviews, operational security, component validation, and component identification
+ ---                         and traceability.
+
+ supplyChainSecurity: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- systemAccessControl
+ ---          PE-3 (1) Information System Access
+ ---                         Enhancement PE-3 (1) improves the protection applied in the "physicalAccessControl" defense by additionally restricting
+ ---                         physical access to each critical system beyond those applied to a site or facility, such that only authentic and
+ ---                         authorized individuals for that system can gain physical access.
+
+ systemAccessControl: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- tamperProtection
+ ---          SA-18 (1) [Tamper Resistance and Detection] Multiple Phases of SDLC
+ ---                         Enhancement SA-18 (1) describes multiple technical countermeasures to prevent reverse engineering or tampering with a
+ ---                         component. These countermeasures can include obfuscation, self-checking, and customization.
+
+ tamperProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- userAuthentication
+ ---          userAuthentication is NOT USED. It is a placeholder for future tool improvements.
+
+ userAuthentication: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- zeroize
+ ---          MP-6 (8) Remote Purging / Wiping of Information
+ ---                         Enhancement MP-6 (8) specifies the purging or wiping of sensitive information either from a remote command or following
+ ---                         some logic within the device to prevent unauthorized individuals from extracting that information.
+
+ zeroize: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ -- Cyber Attack Properties from TA1
  Configuration_Attack: aadlboolean applies to (system);
  Physical_Theft_Attack: aadlboolean applies to (system);
  Interception_Attack: aadlboolean applies to (system);
@@ -39,50 +383,4 @@ property set VERDICT_Properties is
  Buffer_Attack: aadlboolean applies to (system);
  Flooding_Attack: aadlboolean applies to (system);
 
- -- Cyber Defense Properties
- antiJamming: aadlboolean applies to (system); 
- auditMessageResponses: aadlboolean applies to (system);
- deviceAuthentication: aadlboolean applies to (system);
- dosProtection: aadlboolean applies to (system);
- encryptedStorage: aadlboolean applies to (system);
- heterogeneity: aadlboolean applies to (system);
- inputValidation: aadlboolean applies to (system);
- logging: aadlboolean applies to (system);
- memoryProtection: aadlboolean applies to (system);
- physicalAccessControl: aadlboolean applies to (system);
- removeIdentifyingInformation: aadlboolean applies to (system);
- resourceAvailability: aadlboolean applies to (system);
- resourceIsolation: aadlboolean applies to (system);
- secureBoot: aadlboolean applies to (system);
- sessionAuthenticity: aadlboolean applies to (system);
- staticCodeAnalysis: aadlboolean applies to (system);
- strongCryptoAlgorithms: aadlboolean applies to (system);
- supplyChainSecurity: aadlboolean applies to (system);
- systemAccessControl: aadlboolean applies to (system);
- tamperProtection: aadlboolean applies to (system);
- userAuthentication: aadlboolean applies to (system);
-
- -- DAL for Cyber Defense Properties
- antiJammingDAL: aadlinteger 0 .. 9 applies to (system);
- auditMessageResponsesDAL: aadlinteger 0 .. 9 applies to (system);
- deviceAuthenticationDAL: aadlinteger 0 .. 9 applies to (system);
- dosProtectionDAL: aadlinteger 0 .. 9 applies to (system);
- encryptedStorageDAL: aadlinteger 0 .. 9 applies to (system);
- heterogeneityDAL: aadlinteger 0 .. 9 applies to (system);
- inputValidationDAL: aadlinteger 0 .. 9 applies to (system);
- loggingDAL: aadlinteger 0 .. 9 applies to (system);
- memoryProtectionDAL: aadlinteger 0 .. 9 applies to (system);
- physicalAccessControlDAL: aadlinteger 0 .. 9 applies to (system);
- removeIdentifyingInformationDAL: aadlinteger 0 .. 9 applies to (system);
- resourceAvailabilityDAL: aadlinteger 0 .. 9 applies to (system);
- resourceIsolationDAL: aadlinteger 0 .. 9 applies to (system);
- secureBootDAL: aadlinteger 0 .. 9 applies to (system);
- sessionAuthenticityDAL: aadlinteger 0 .. 9 applies to (system);
- staticCodeAnalysisDAL: aadlinteger 0 .. 9 applies to (system);
- strongCryptoAlgorithmsDAL: aadlinteger 0 .. 9 applies to (system);
- supplyChainSecurityDAL: aadlinteger 0 .. 9 applies to (system);
- systemAccessControlDAL: aadlinteger 0 .. 9 applies to (system);
- tamperProtectionDAL: aadlinteger 0 .. 9 applies to (system);
- userAuthenticationDAL: aadlinteger 0 .. 9 applies to (system);
- 
 end VERDICT_Properties;

--- a/models/DeliveryDrone_BusBindings/DeliveryDrone.aadl
+++ b/models/DeliveryDrone_BusBindings/DeliveryDrone.aadl
@@ -2,10 +2,10 @@ package DeliveryDrone
 
 public
 	with Base_Types;
-    with Data_Types;
-    with Agree_Constants;
-    with Agree_Nodes;
-    with Agree_Constants;
+	with Data_Types;
+	with Agree_Constants;
+	with Agree_Nodes;
+	with Agree_Constants;
 	with VERDICT_Properties;
 	with GNC;
 
@@ -572,22 +572,22 @@ public
       		
       		eq release_cmd: bool = (probe_delivery_cmd = Agree_Constants::RELEASE_PACKAGE_CMD);
       		
-      		guarantee "P1: constellation for GPS is initialized properly": 
+      		guarantee "P1: Constellation for GPS is initialized properly":
       			isOn => (most_recent_constellation = probe_constellation);
       		
-      		guarantee "P2: launch location for IMU is initialized properly": 
+      		guarantee "P2: Launch location for IMU is initialized properly":
       			isOn => most_recent_launch_location = probe_launch_location;
       		
-      		guarantee "P3: delivery location for navigation is initialized properly": 
+      		guarantee "P3: Delivery location for navigation is initialized properly":
       			isOn => most_recent_delivery_location = probe_delivery_location;
 
-      		guarantee "P4: a command to release a valuable package is issued only if drone has received confirmation from base":
+      		guarantee "P4: A command to release a valuable package is issued only if drone has received confirmation from base":
     			release_cmd and valuable_package => target_confirmed;
 
   			guarantee "P5: The drone will always request a confirmation to base before starting delivery of a valuable package":
     			delivery_started and valuable_package => confirmation_requested;
 
-    		guarantee "P6: The drone is flying only if since last initialization, it has not got aborted": 
+    		guarantee "P6: The drone is flying only if since last initialization the mission was not aborted":
       			probe_fly_cmd => Agree_Nodes::Since(probe_init_mode, not (probe_abort_mode));
 		**};
 			
@@ -648,8 +648,6 @@ public
 				VERDICT_Properties::insideTrustedBoundary => false;
 				VERDICT_Properties::componentType => Hybrid;
 				VERDICT_Properties::pedigree => InternallyDeveloped;
-				VERDICT_Properties::dataReceivedFromUntrusted => true;
-				VERDICT_Properties::controlReceivedFromUntrusted => true;
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
 				VERDICT_Properties::supplyChainSecurity => 7;
@@ -661,9 +659,7 @@ public
 				VERDICT_Properties::resourceAvailability => 7;
 				VERDICT_Properties::antiJamming => 7;
 				VERDICT_Properties::dosProtection => 7;
-				VERDICT_Properties::deviceAuthentication => 7;
 				VERDICT_Properties::inputValidation => 7;
-				VERDICT_Properties::sessionAuthenticity => 7;
 				VERDICT_Properties::strongCryptoAlgorithms => 7;
 				
 							
@@ -677,16 +673,14 @@ public
 				VERDICT_Properties::hasSensitiveInfo => true;
 				VERDICT_Properties::canReceiveSWUpdate => true;
 		
-			 	VERDICT_Properties::adversariallyTested => false;
-			 	--VERDICT_Properties::adversariallyTested => true; -- Fix for Logic Bomb
+				VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 0;
+				--VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 7; -- Fix for Logic Bomb
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
 				VERDICT_Properties::supplyChainSecurity => 7;
 				VERDICT_Properties::physicalAccessControl => 7;
 				VERDICT_Properties::systemAccessControl => 7;
-				
 				VERDICT_Properties::secureBoot => 7;
-
 				VERDICT_Properties::memoryProtection => 7;
 			};
 			navigation: system Navigation
@@ -702,9 +696,8 @@ public
 				VERDICT_Properties::supplyChainSecurity => 7;
 				VERDICT_Properties::physicalAccessControl => 7;
 				VERDICT_Properties::systemAccessControl => 7;
-				
 				VERDICT_Properties::secureBoot => 7;
-				VERDICT_Properties::memoryProtection => 7;	
+				VERDICT_Properties::memoryProtection => 7;
 			};
 			fc: system FlightControl
 			{
@@ -719,7 +712,6 @@ public
 				VERDICT_Properties::supplyChainSecurity => 7;
 				VERDICT_Properties::physicalAccessControl => 7;
 				VERDICT_Properties::systemAccessControl => 7;
-				
 				VERDICT_Properties::secureBoot => 7;
 				VERDICT_Properties::memoryProtection => 7;
 			};
@@ -745,31 +737,18 @@ public
 				--VERDICT_Properties::pedigree => InternallyDeveloped; -- Fix for Logic Bomb
 				VERDICT_Properties::hasSensitiveInfo => true;
 				VERDICT_Properties::canReceiveSWUpdate => true;
-				VERDICT_Properties::controlReceivedFromUntrusted => true;
-				VERDICT_Properties::dataReceivedFromUntrusted => true;
 			
 				-- VERDICT Cyber Defense and DAL Mitigations
 				VERDICT_Properties::supplyChainSecurity => 7;
 				VERDICT_Properties::physicalAccessControl => 7;
 				VERDICT_Properties::systemAccessControl => 7;
-				
 				VERDICT_Properties::secureBoot => 7;
-				VERDICT_Properties::memoryProtection => 7;	
-				
+				VERDICT_Properties::memoryProtection => 7;
 				VERDICT_Properties::staticCodeAnalysis => 7;
-				
 				VERDICT_Properties::resourceAvailability => 7;
-				
 				VERDICT_Properties::antiJamming => 7;
-				
 				VERDICT_Properties::dosProtection => 7;
-				
-				VERDICT_Properties::deviceAuthentication => 7;
-				
 				VERDICT_Properties::inputValidation => 7;
-				
-				VERDICT_Properties::sessionAuthenticity => 7;
-				
 				VERDICT_Properties::strongCryptoAlgorithms => 7;
 			};
 			deliveryItemMechanism: system DeliveryItemMechanism
@@ -781,11 +760,8 @@ public
 				VERDICT_Properties::hasSensitiveInfo => true;
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
-				
 				VERDICT_Properties::supplyChainSecurity => 7;
-				
 				VERDICT_Properties::physicalAccessControl => 7;
-				
 				VERDICT_Properties::systemAccessControl => 7;
 				
 			};
@@ -798,11 +774,8 @@ public
 				VERDICT_Properties::hasSensitiveInfo => true;
 				
 				-- VERDICT Cyber Defense and DAL Mitigations
-				
 				VERDICT_Properties::supplyChainSecurity => 7;
-				
 				VERDICT_Properties::physicalAccessControl => 7;
-				
 				VERDICT_Properties::systemAccessControl => 7;
 			};
 			
@@ -814,153 +787,149 @@ public
 			 	
 			 	VERDICT_Properties::pedigree => COTS;
 			 	--VERDICT_Properties::pedigree => InternallyDeveloped; -- Fix for Logic Bomb / Hardware Trojan
-			 	VERDICT_Properties::adversariallyTested => false;
+				VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 0;
 			};
 
 		connections
 			c1: port positionEstimator.est_pos -> navigation.est_pos
-			{VERDICT_Properties::flowType => Xcontrol;
---			 VERDICT_Properties::trustedConnection => false;	
+			{VERDICT_Properties::connectionType => Untrusted;
 			 VERDICT_Properties::encryptedTransmission => 6;
 			};
 			
 			c1b: port deliveryPlanner.launch_pos -> gnc.launch_pos
-			{VERDICT_Properties::flowType => Xrequest;
-			 VERDICT_Properties::trustedConnection => false;
-			};
+			{VERDICT_Properties::connectionType => Untrusted;};
 			
 			c2: port navigation.move -> fc.move
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 
 			c3: port fc.fc_state -> navigation.flight_control_state
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c4: port deliveryPlanner.dest_location -> navigation.dest_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c5: port navigation.cur_pos -> deliveryPlanner.cur_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			
 			c7: port deliveryItemMechanism.delivery_status_out -> deliveryPlanner.delivery_status			
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c9: port camera.camera_out -> deliveryPlanner.camera_result			
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c10: port deliveryPlanner.radio_cmd -> radio.radio_in
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c11: port radio.radio_out -> deliveryPlanner.radio_response
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c12: port gnc.gps_pos -> positionEstimator.gps_pos
 			{
-			VERDICT_Properties::flowType => Xdata;
-			-- VERDICT_Properties::trustedConnection => false;
+			VERDICT_Properties::connectionType => Trusted;
+			-- VERDICT_Properties::connectionType => Untrusted;
 			};
 			
 			c14a: port bus1 -> connector.bus_in
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c14b: port connector.bus_out -> DeliveryPlanner.bus_in
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c15: port deliveryPlanner.bus_out -> bus2
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c16: port comm1 -> radio.comm_in
-			{VERDICT_Properties::flowType => Xdata;
-		     VERDICT_Properties::connectionType => Remote;
-			 VERDICT_Properties::authenticated => false;
+			{VERDICT_Properties::connectionType => Untrusted;
+			 VERDICT_Properties::deviceAuthentication => 0;
 			 VERDICT_Properties::encryptedTransmission => 0;
-			 --VERDICT_Properties::authenticated => true; -- Fix for Network Injection
-			 --VERDICT_Properties::encryptedTransmission => true; -- Fix for Network Injection
+			 --VERDICT_Properties::deviceAuthentication => 7; -- Fix for Network Injection
+			 --VERDICT_Properties::encryptedTransmission => 5; -- Fix for Network Injection
 			};
 			
 			c17: port radio.comm_out -> comm2
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 
 			c18a: port gnc.imu_pos -> positionEstimator.imu_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c19: port fc.motor_cmd -> actuation.motor_cmd
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c20: port actuation.response -> fc.actuation_response
-			{VERDICT_Properties::flowType => Xdata;};	
+			{VERDICT_Properties::connectionType => Trusted;};
 
 			c22: port satellite0_sig_pos -> gnc.satellite0_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c23: port satellite1_sig_pos -> gnc.satellite1_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c24: port navigation.pos_act_out -> positionEstimator.pos_act_in
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c25: port deliveryPlanner.delivery_cmd -> deliveryItemMechanism.delivery_cmd_in
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 
 			c26: port deliveryPlanner.nav_cmd -> navigation.cmd
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c27: port deliveryPlanner.camera -> camera.camera_in			
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c28: port deliveryPlanner.radio_cmd -> radio_cmd
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c29: port radio.radio_out -> radio_response
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c30: port deliveryItemMechanism.delivery_status_out -> delivery_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c31: port deliveryPlanner.delivery_cmd -> probe_delivery_cmd
-			{VERDICT_Properties::flowType => Xdata;}; 							
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c32: port actuation.response -> actuation_out
-			{VERDICT_Properties::flowType => Xdata;};	
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c33: port deliveryPlanner.constellation -> gnc.constellation
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c34: port gnc.gps_health_status -> deliveryPlanner.gps_health_status
 			{
-			VERDICT_Properties::flowType => Xdata;
-			--VERDICT_Properties::trustedConnection => false;
+			VERDICT_Properties::connectionType => Trusted;
+			--VERDICT_Properties::connectionType => Untrusted;
 			};
 			
 			c35: port gnc.imu_health_status -> deliveryPlanner.imu_health_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c36: port radio.health_status -> deliveryPlanner.rdo_health_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c37: port camera.health_status -> deliveryPlanner.cam_health_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c38: port gnc.probe_constellation -> probe_constellation
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c39: port deliveryPlanner.probe_init_mode -> probe_init_mode
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c40: port gnc.probe_launch_pos -> probe_launch_location
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c41: port navigation.probe_dest_pos -> probe_delivery_location
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c42: port deliveryItemMechanism.package_is_secure -> deliveryPlanner.package_is_secure
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c43: port deliveryPlanner.nav_cmd -> probe_fly_cmd
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			
 			c44: port deliveryPlanner.probe_abort_mode -> probe_abort_mode
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 		properties
 			Actual_Connection_Binding => (reference (ethernet)) applies to c1, c16;			
 															

--- a/models/DeliveryDrone_BusBindings/GNC.aadl
+++ b/models/DeliveryDrone_BusBindings/GNC.aadl
@@ -2,9 +2,9 @@ package GNC
 
 public
 	with Base_Types;
-    with Data_Types;
-    with Agree_Nodes;
-    with VERDICT_Properties;
+	with Data_Types;
+	with Agree_Nodes;
+	with VERDICT_Properties;
 
 	system GPS
 		features
@@ -110,39 +110,29 @@ public
 		
 	end GNC;
 		
-	
 	system implementation GNC.Impl
 		subcomponents
 			gps: system GPS
 			{
 				-- VERDICT Component Properties
-				VERDICT_Properties::insideTrustedBoundary => true; -- Another scenario - set this to false along with trustedConnection for c12 and c34 to false
+				VERDICT_Properties::insideTrustedBoundary => true; -- Another scenario - set this to false along with connectionType for c12 and c34 to Untrusted
 				VERDICT_Properties::componentType => Hybrid;
 				VERDICT_Properties::pedigree => COTS;
 				--VERDICT_Properties::pedigree => InternallyDeveloped; -- Fix for Logic Bomb / Hardware Trojan
-				VERDICT_Properties::dataReceivedFromUntrusted => true;
-					
-				VERDICT_Properties::adversariallyTested => false;
+				VERDICT_Properties::adversariallyTestedForTrojanOrLogicBomb => 0;
 
-                -- VERDICT Cyber Defenses & DAL Mitigations
---				VERDICT_Properties::supplyChainSecurity => true;
+				-- VERDICT Cyber Defenses & DAL Mitigations
 				VERDICT_Properties::supplyChainSecurity => 7;
---				VERDICT_Properties::physicalAccessControl => true;
 				VERDICT_Properties::physicalAccessControl => 7;
---				VERDICT_Properties::systemAccessControl => true;
 				VERDICT_Properties::systemAccessControl => 7;
---				VERDICT_Properties::secureBoot => true;
 				VERDICT_Properties::secureBoot => 7;
---				VERDICT_Properties::memoryProtection => true;
 				VERDICT_Properties::memoryProtection => 7;
 				VERDICT_Properties::staticCodeAnalysis => 7;
 				VERDICT_Properties::resourceAvailability => 7;
 				VERDICT_Properties::antiJamming => 7;
 				VERDICT_Properties::dosProtection => 7;
-				VERDICT_Properties::deviceAuthentication => 7;
 				VERDICT_Properties::inputValidation => 7;
-				VERDICT_Properties::sessionAuthenticity => 7;
-				VERDICT_Properties::strongCryptoAlgorithms => 7;																
+				VERDICT_Properties::strongCryptoAlgorithms => 7;
 			};
 			imu: system IMU
 			{ 
@@ -161,24 +151,24 @@ public
 			};
 		connections
 			i1: port constellation -> gps.constellation
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i2: port satellite0_pos -> gps.satellite0_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i3: port satellite1_pos -> gps.satellite1_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i4: port launch_pos -> imu.launch_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i5: port gps.gps_pos -> gps_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i6: port gps.health_status -> gps_health_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i7: port gps.probe_constellation -> probe_constellation
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i8: port imu.imu_pos -> imu_pos
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i9: port imu.health_status -> imu_health_status
-			{VERDICT_Properties::flowType => Xdata;};
+			{VERDICT_Properties::connectionType => Trusted;};
 			i10: port imu.probe_launch_pos -> probe_launch_pos
-			{VERDICT_Properties::flowType => Xdata;};			
+			{VERDICT_Properties::connectionType => Trusted;};
 	end GNC.Impl;
 end GNC;

--- a/models/DeliveryDrone_BusBindings/VERDICT_Properties.aadl
+++ b/models/DeliveryDrone_BusBindings/VERDICT_Properties.aadl
@@ -1,33 +1,375 @@
+-------------------------------------------------------------------------
+--- The following VERDICT_Properties enable the use of the VERDICT tool suite for both the high-level Model-Based
+--- Architectural Analysis (MBAA) and behavioral analysis using the Cyber Resiliency Verifier (CRV). Each property
+--- below is tagged for which tools uses the property followed by a short description.
+---
+--- This file contains four different types of properties:
+--- 	Mandatory User Defined Component Properties must be assigned for VERDICT tools to execute
+--- 	Port Properties are used to designate analysis-only ports for use in behavioral analysis
+--- 	Connection Properties contain necessary inputs as well as annotations for applied mitigations on connections
+--- 	Connection Cyber Defense Properties allow the designer to annotate applied mitigations for connections
+--- 	Component Cyber Defense Properties allow the designer to annotate applied mitigations for system components
+-------------------------------------------------------------------------
 property set VERDICT_Properties is
--- Port properties
- probe: aadlboolean applies to (port);
 
--- Connection properties, including defenses and DAL values
- flowType: enumeration (Xdata, Xcontrol, Xrequest) applies to (connection);
- connectionType: enumeration (Local, Remote) applies to (connection);
- authenticated: aadlboolean applies to (connection);
- trustedConnection: aadlboolean applies to (connection);
- encryptedTransmission: aadlinteger 0 .. 9 applies to (connection);
 
--- Component properties 
- pedigree: enumeration (InternallyDeveloped, COTS, Sourced) applies to (system);
- category: aadlstring applies to (system);
- componentType: enumeration (Software, Hardware, Human, Hybrid) applies to (system);
- situated: enumeration (OnBoard, Remote) applies to (system);
- adversariallyTested: aadlboolean applies to (system);
- hasSensitiveInfo: aadlboolean applies to (system);
- insideTrustedBoundary: aadlboolean applies to (system);
+
+-------------------------------------------------------------------------
+--- Mandatory User Defined Component Properties
+---          NOTE: The mandatory user defined component properties must be assigned for each applicable component as a minimum for VERDICT to execute.
+-------------------------------------------------------------------------
+
+ --- MBAA:
+ --- 	canReceiveConfigUpdate is a property used to determine whether the system is susceptible to attacks attempting to tamper with the configuration
+ --- 	of a system. Apply this property if the configuration of software or hardware within the system can be updated outside of the original
+ --- 	manufacturer's facility.
+
  canReceiveConfigUpdate: aadlboolean applies to (system);
- canReceiveSWUpdate: aadlboolean applies to (system);
- controlReceivedFromUntrusted: aadlboolean applies to (system);
- controlSentToUntrusted: aadlboolean applies to (system);
- dataReceivedFromUntrusted: aadlboolean applies to (system);
- dataSentToUntrusted: aadlboolean applies to (system);
- failSafe:aadlinteger 0 .. 9 applies to (system);
- remoteAttestation: aadlinteger 0 .. 9 applies to (system);
- zeroize:  aadlinteger 0 .. 9 applies to (system);
 
- -- Cyber Attack Properties from TA1 
+ --- MBAA:
+ --- 	canRecieveSWUpdate is a property used to determine whether the system is susceptible to attacks attempting to install malicious software
+ --- 	updates. Apply this property if the software within the system can be updated outside of the original manufacturer's facility.
+
+ canReceiveSWUpdate: aadlboolean applies to (system);
+
+ --- MBAA:
+ --- 	componentType is a property used to determine whether the system is subject to attacks targeting software, hardware, humans, or hybrid
+ --- 	(software and hardware). For example, systems that represent software only will not be subject to CAPEC-440 Hardware Integrity Attack.
+ --- CRV:
+ --- 	A componentType designates whether a component is a software, a hardware, a Human, or a Hybrid (mix of Software and Hardware).
+ --- 	This helps CRV to decide what sort of attack can the component be susceptible to. For instance, a Hybrid component can be susceptible
+ --- 	to both hardware (e.g., trojans) and software (e.g., logic bomb) attacks whereas a Human component can only be susceptible to insider/outsider threat.
+
+ componentType: enumeration (Software, Hardware, Human, SwHwHybrid, SwHumanHybrid, HwHumanHybrid, Hybrid) applies to (system);
+
+ --- MBAA:
+ --- 	If a system contains the property hasSensitiveInfo it will be considered for attacks resulting in loss of confidentiality.
+
+ hasSensitiveInfo: aadlboolean applies to (system);
+
+ --- MBAA:
+ --- 	insideTrustedBoundary designates a system that will be analyzed for their potential to be attacked. Also, systems where insideTrustedBoundary=TRUE
+ --- 	will not be considered the initial source of attacks.
+ --- CRV:
+ --- 	If a component's insideTrustedBoundary property is true, it signifies to CRV that the component is inside the system's trust boundary. For instance,
+ --- 	if a human component is inside the trusted boundary of the system, then an insider attack can occur.
+
+ insideTrustedBoundary: aadlboolean applies to (system);
+
+
+ --- MBAA:
+ --- 	pedigree is a property used to infer the level of trust in a system. A "COTS" component will be untrusted and considered a
+ --- 	potential source of attacks, whereas "Sourced" and "InternallyDeveloped" components will be trusted. Both of these can be explicitly
+ --- 	overridden by the insideTrustedBoundary property.
+ ---
+ --- CRV:
+ --- 	The pedigree component property allows CRV to decide whether a component can be susceptible to a hardware
+ --- 	trojan (hardware/hybrid component) or a logic bomb (software/hybrid component) attack. If a component is designated
+ --- 	as "InternallyDeveloped", it is neither susceptible to a hardware trojan nor a logic bomb attack. For other values,
+ --- 	however, they can be susceptible to the attacks.
+
+ pedigree: enumeration (InternallyDeveloped, COTS, Sourced) applies to (system);
+
+
+
+-------------------------------------------------------------------------
+--- Port properties
+-------------------------------------------------------------------------
+
+ --- CRV:
+ --- 	If a port's probe property is true, it signifies to CRV that it is not part of the original architecture but is
+ --- 	included just for the convenience of CRV's reasoning. When a system is modeled hierarchically, a probe port allows CRV
+ --- 	to peek inside a component's behavior without needing to expose the behavior completely at a top level.
+
+ probe: aadlboolean => FALSE applies to (port);
+
+
+
+-------------------------------------------------------------------------
+--- Connection properties
+-------------------------------------------------------------------------
+
+
+ --- MBAA:
+ ---          connectionType is used by MBAA to make decisions around the level of trust for connections that are incompletely modeled.
+ ---          An example Untrusted connectionType would be GPS, where the satelite and ground systems may be excluded from the model, but
+ ---          this could also be used for logical models where the physical connection passes outside of the trust boundary.
+ ---          An example Trusted connectionType would be a connection passing between two local systems, where the physical communications
+ ---          medium is entirely contained within the trust boundary indicating that the connection itself can be trusted.
+ --- CRV:
+ ---          connectionType enables CRV to decide whether a certain connection can be susceptible to network injection attack
+ ---          or the component to which this connection is incident upon is susceptible to Remote code injection or other software
+ ---          attacks(e.g., virus, trojan, worm). Trusted connections are assumed to be free of attacks whereas Untrusted connections can be
+ ---          susceptible to attacks depending on the values of the following additional properties (encryptedTransmission/deviceAuthentication).
+
+ connectionType: enumeration (Trusted, Untrusted) => Untrusted applies to (connection);
+
+
+
+------------------------------------------------------------------------
+-- Optional Component Properties
+------------------------------------------------------------------------
+
+ --- CRV:
+ --- 	The category property lets CRV know whether a certain component is one of the pre-defined ones (e.g., GPS, IMU, LIDAR).
+ --- 	If it is one of the pre-defined components, then CRV decides it to be susceptible to a pre-defined set of attacks (e.g., Location spoofing).
+
+ category: aadlstring applies to (system);
+
+ --- CRV:
+ --- 	If adversariallyTestedForTrojanOrLogicBomb property of a component is assigned an integer greater than '0', it suggests CRV that even if the
+ --- 	component's pedigree is sourced/COTS, it is not susceptible to hardware trojan or logic bomb type of attacks.
+
+ adversariallyTestedForTrojanOrLogicBomb: aadlinteger 0 .. 9 => 0 applies to (system);
+
+
+
+------------------------------------------------------------------------
+-- Connection Cyber Defense Properties
+---          NOTE: Each cyber defense represents one or more NIST 800-53r4 controls that has been applied to the system and the relative level of rigor
+---          that is used to develop the implementation of that control. If the system does not have the property or the value is '0', it is assumed that this
+---          defense has not been applied. More information on NIST 800-53 controls can be found at: https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/final.
+------------------------------------------------------------------------
+
+ --- MBAA:
+ --- encryptedTransmission
+ ---          SC-8 Transmission Confidentiality and Integrity
+ ---                         SC-8 generally covers protection of the confidentiality of communications between two components, which
+ ---                         can include encryption of the data payload, protection of the header or protocol fields, and confidentiality
+ ---                         of data just prior to sending and just after receipt.
+ --- CRV:
+ ---          Not used by CRV
+
+ encryptedTransmission: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+ --- MBAA:
+ --- deviceAuthentication
+ ---          IA-3 Device Identification and Authentication
+ ---          IA-3 (1) Cryptographic Bidirectional Authentication
+ ---                         IA-3 specifies general verification of the identity of other connected systems, while enhancement IA-3 (1) establishes
+ ---                         requirements for mutual verification of identity through cryptographic algorithms.
+
+ deviceAuthentication: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+ --- MBAA:
+ --- sessionAuthenticity
+ ---          SC-23 Session Authenticity
+ ---                         SC-23 specifies technical means to maintain the authenticity of communications after establishing initial
+ ---                         identity. Mitigations focus on unique randomly generated session identifiers.
+ --- CRV:
+ ---          Need to add description for CRV use
+
+ sessionAuthenticity: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+
+
+-------------------------------------------------------------------------
+--- Component Cyber Defense Properties
+---          NOTE: Each cyber defense represents one or more NIST 800-53r4 controls that has been applied to the system and the relative level of rigor
+---          that is used to develop the implementation of that control. If the system does not have the property or the value is '0', it is assumed that this
+---          defense has not been applied. More information on NIST 800-53 controls can be found at: https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/final.
+-------------------------------------------------------------------------
+
+ --- MBAA:
+ --- antiJamming
+ ---          SC-40 Wireless Link Protection
+ ---          SC-40 (1) Electromagnetic Interference
+ ---                         SC-40 specifies general protections for wireless links by directing protection on signal parameters,
+ ---                         while SC-40 (1) specifies more specific techniques, such as cryptographic frequency hopping to prevent
+ ---                         the adversary from jamming communications.
+
+ antiJamming: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- auditMessageResponses
+ ---          SI-11 Error Handling
+ ---                         SI-11 ensures that error messages are designed to provide only the minimal information necessary for
+ ---                         informed authorized users to take the appropriate corrective actions and exclude any additional information that
+ ---                         would reveal more about the systems to potential attackers.
+
+ auditMessageResponses: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- dosProtection
+ ---          SC-5 Denial of Service Protection
+ ---          SC-5 (2) Excess Capacity/Bandwidth/Redundancy
+ ---                         SC-5 specifies general denial of service protections, including packet filtering and increased capacities
+ ---                         to withstand attacks. Enhancement SC-5 (2) describes more specific solutions to manage capacities, which
+ ---                         include usage priorities, quotas, and partitioning.
+
+ dosProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- encryptedStorage
+ ---          SC-28 Protection of Information at Rest
+ ---                         SC-28 specifies means to protect sensitive information stored within the system, which can include
+ ---                         encryption of stored data or stored configuration files.
+
+ encryptedStorage: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- failSafe
+ ---          SI-17 Fail-Safe Procedures
+ ---                         SI-17 specifies the implementation of logic within the system to follow a known procedure during attacks
+ ---                         that result in sustained communication interruptions. Fail-Safe procedures can include shutdown process, alerts,
+ ---                         or predefined operational paths to follow.
+
+ failSafe: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- heterogeneity
+ ---          SC-29 Heterogeneity
+ ---                         SC-29 promotes the use of a diverse set of technologies to defend against common mode failures, which prevent
+ ---                         the same attack from successfully defeating two systems intended to be independent.
+
+ heterogeneity: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- inputValidation
+ ---          SI-10 Information Input Validation
+ ---          SI-10 (5) Restrict Inputs to Trusted Sources and Approved Formats
+ ---                         SI-10 specifies checking of the validity of incoming communications. Validity checks can be performed based
+ ---                         on a whitelisted character set, packet length, numerical ranges, or a list of acceptable values, as well as many
+ ---                         other factors. Enhancement SI-10 (5) focuses on enforcing only known trusted sources and valid message formats.
+
+ inputValidation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- logging
+ ---          AU-12 Audit Generation
+ ---          AU-12 (1) System-Wide/Time-Correlated Audit Trails
+ ---          AU-12 (3) Changes by Authorized Individuals
+ ---          AU-9 Protection of Audit Information
+ ---          AU-9 (3) Cryptographic Protection
+ ---                         AU-12 with enhancements (1) and (3) focuses on the implementation of auditable records that are time-synced across
+ ---                         the broader system to aid in forensic activities and available only to authorized users. AU-9 with enhancement (3)
+ ---                         ensures audit records are protected from tampering or deletion via signed hash functions or asymmetric encryption.
+
+ logging: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- memoryProtection
+ ---          SI-16 Memory Protection
+ ---                         SI-16 describes protections from unauthorized code execution, including non-executable regions of memory and
+ ---                         address space layout randomization.
+
+ memoryProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- physicalAccessControl
+ ---          PE-3 Physical Access Control
+ ---                         PE-3 is an operational control that describes elements of a program to physically secure a facility or site that
+ ---                         containing a sensitive system. This includes verifying an individual's identity and authorization, logging physical
+ ---                         accesses, escorting visitors, taking inventory of devices, and installing/maintaining physical access devices
+ ---                         (e.g. locks, key readers, etc.).
+
+ physicalAccessControl: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- remoteAttestation
+ ---          IA-3 (4) Device Attestation
+ ---                         Enhancement IS-3 (4) describes means for one system to assure to another system the authenticity of its configuration
+ ---                         and operating state. This is often paired with secure boot, secure update, and other run-time mechanisms to
+ ---                         maintain trusted authenticity and identity between interdependent systems.
+
+ remoteAttestation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- removeIdentifyingInformation
+ ---          SI-15 Information Output Filtering
+ ---                         SI-15 requires validation of the output of the system to ensure that appropriate outputs are being sent given the context
+ ---                         of the request. Mitigations satisfying this control could be to block unnecessary data or alert on anomalous behavior.
+
+ removeIdentifyingInformation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- resourceAvailability
+ ---          SC-6 Resource Availability
+ ---                         SC-6 describes protections preventing an attacker from consuming the resources of a system, including
+ ---                         prioritization or quotas.
+
+ resourceAvailability: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- resourceIsolation
+ ---          SC-4 Information in Shared Resources
+ ---                         SC-4 provides general protection mechanisms to prevent sensitive information from being leaked through
+ ---                         shared registers, memory, or hard disk space.
+
+ resourceIsolation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- secureBoot
+ ---          SI-7 (1) Integrity Checks
+ ---          SI-7 (5) Automated Response to Integrity Violations
+ ---          SI-7 (6) Cryptographic Protection
+ ---          SI-7 (9) Verify Boot Process
+ ---          SI-7 (15) Code Authentication
+ ---                         SI-7 Enhancement (1) specifies integrity checks of software, firmware, and information on a system. Enhancement SI-7 (5) defines
+ ---                         the response to detected violations of these checks. Enhancement SI-7 (6) specifies cryptographic algorithms should
+ ---                         be used to perform these checks. Enhancement SI-7 (9) specifies the checks be performed on the boot process to ensures
+ ---                         the system is operating correctly prior to execution. Enhancement SI-7 (15) specifies the checks be performed on all
+ ---                         new software prior to installation and execution to ensure no malicious code is injected.
+
+ secureBoot: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- staticCodeAnalysis
+ ---          SA-11 (1) Static Code Analysis
+ ---                         Enhancement SA-11 (1) is an organizational control specifying the use of software tools to look for common
+ ---                         source code patterns that can be exploited by known attacks.
+
+ staticCodeAnalysis: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- strongCryptoAlgorithms
+ ---          SC-13 Cryptographic Protection
+ ---                         SC-13 is an enhancement to controls specifying the use of cryptographic algorithms. Application of this control
+ ---                         ensures only approved algorithms are used and their implementation is sufficient to protect against known attacks.
+
+ strongCryptoAlgorithms: aadlinteger 0 .. 9 applies to (system);
+
+ --- MBAA:
+ --- supplyChainSecurity
+ ---          SA-12 Supply Chain Protection
+ ---                         SA-12 is an organizational control listing best practices for acquiring services, systems, components securely. These
+ ---                         best practices include supplier reviews, operational security, component validation, and component identification
+ ---                         and traceability.
+
+ supplyChainSecurity: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- systemAccessControl
+ ---          PE-3 (1) Information System Access
+ ---                         Enhancement PE-3 (1) improves the protection applied in the "physicalAccessControl" defense by additionally restricting
+ ---                         physical access to each critical system beyond those applied to a site or facility, such that only authentic and
+ ---                         authorized individuals for that system can gain physical access.
+
+ systemAccessControl: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- tamperProtection
+ ---          SA-18 (1) [Tamper Resistance and Detection] Multiple Phases of SDLC
+ ---                         Enhancement SA-18 (1) describes multiple technical countermeasures to prevent reverse engineering or tampering with a
+ ---                         component. These countermeasures can include obfuscation, self-checking, and customization.
+
+ tamperProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- userAuthentication
+ ---          userAuthentication is NOT USED. It is a placeholder for future tool improvements.
+
+ userAuthentication: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- zeroize
+ ---          MP-6 (8) Remote Purging / Wiping of Information
+ ---                         Enhancement MP-6 (8) specifies the purging or wiping of sensitive information either from a remote command or following
+ ---                         some logic within the device to prevent unauthorized individuals from extracting that information.
+
+ zeroize: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ -- Cyber Attack Properties from TA1
  Configuration_Attack: aadlboolean applies to (system);
  Physical_Theft_Attack: aadlboolean applies to (system);
  Interception_Attack: aadlboolean applies to (system);
@@ -41,50 +383,4 @@ property set VERDICT_Properties is
  Buffer_Attack: aadlboolean applies to (system);
  Flooding_Attack: aadlboolean applies to (system);
 
- -- Cyber Defense Properties
--- antiJamming: aadlboolean applies to (system); 
--- auditMessageResponses: aadlboolean applies to (system);
--- deviceAuthentication: aadlboolean applies to (system);
--- dosProtection: aadlboolean applies to (system);
--- encryptedStorage: aadlboolean applies to (system);
--- heterogeneity: aadlboolean applies to (system);
--- inputValidation: aadlboolean applies to (system);
--- logging: aadlboolean applies to (system);
--- memoryProtection: aadlboolean applies to (system);
--- physicalAccessControl: aadlboolean applies to (system);
--- removeIdentifyingInformation: aadlboolean applies to (system);
--- resourceAvailability: aadlboolean applies to (system);
--- resourceIsolation: aadlboolean applies to (system);
--- secureBoot: aadlboolean applies to (system);
--- sessionAuthenticity: aadlboolean applies to (system);
--- staticCodeAnalysis: aadlboolean applies to (system);
--- strongCryptoAlgorithms: aadlboolean applies to (system);
--- supplyChainSecurity: aadlboolean applies to (system);
--- systemAccessControl: aadlboolean applies to (system);
--- tamperProtection: aadlboolean applies to (system);
--- userAuthentication: aadlboolean applies to (system);
-
- -- DAL for Cyber Defense Properties
- antiJamming: aadlinteger 0 .. 9 applies to (system);
- auditMessageResponses: aadlinteger 0 .. 9 applies to (system);
- deviceAuthentication: aadlinteger 0 .. 9 applies to (system);
- dosProtection: aadlinteger 0 .. 9 applies to (system);
- encryptedStorage: aadlinteger 0 .. 9 applies to (system);
- heterogeneity: aadlinteger 0 .. 9 applies to (system);
- inputValidation: aadlinteger 0 .. 9 applies to (system);
- logging: aadlinteger 0 .. 9 applies to (system);
- memoryProtection: aadlinteger 0 .. 9 applies to (system);
- physicalAccessControl: aadlinteger 0 .. 9 applies to (system);
- removeIdentifyingInformation: aadlinteger 0 .. 9 applies to (system);
- resourceAvailability: aadlinteger 0 .. 9 applies to (system);
- resourceIsolation: aadlinteger 0 .. 9 applies to (system);
- secureBoot: aadlinteger 0 .. 9 applies to (system);
- sessionAuthenticity: aadlinteger 0 .. 9 applies to (system);
- staticCodeAnalysis: aadlinteger 0 .. 9 applies to (system);
- strongCryptoAlgorithms: aadlinteger 0 .. 9 applies to (system);
- supplyChainSecurity: aadlinteger 0 .. 9 applies to (system);
- systemAccessControl: aadlinteger 0 .. 9 applies to (system);
- tamperProtection: aadlinteger 0 .. 9 applies to (system);
- userAuthentication: aadlinteger 0 .. 9 applies to (system);
- 
 end VERDICT_Properties;

--- a/models/Thermostat_with_verdict_props/Thermostat.aadl
+++ b/models/Thermostat_with_verdict_props/Thermostat.aadl
@@ -213,16 +213,11 @@ public
 				VERDICT_Properties::pedigree => COTS;
 				
 				-- VRERDICT Cyber Defense Properties and DAL Mitigations
-				VERDICT_Properties::supplyChainSecurity => true;
-				VERDICT_Properties::supplyChainSecurityDAL => 3;
-				VERDICT_Properties::physicalAccessControl => true;
-				VERDICT_Properties::physicalAccessControlDAL => 3;
-				VERDICT_Properties::systemAccessControl => true;
-				VERDICT_Properties::systemAccessControlDAL => 3;
-				VERDICT_Properties::secureBoot => true;
-				VERDICT_Properties::secureBootDAL => 3;
-				VERDICT_Properties::memoryProtection => true;
-				VERDICT_Properties::memoryProtectionDAL => 3;
+				VERDICT_Properties::supplyChainSecurity => 3;
+				VERDICT_Properties::physicalAccessControl => 3;
+				VERDICT_Properties::systemAccessControl => 3;
+				VERDICT_Properties::secureBoot => 3;
+				VERDICT_Properties::memoryProtection => 3;
 				
 			};
 			

--- a/models/Thermostat_with_verdict_props/VERDICT_Properties.aadl
+++ b/models/Thermostat_with_verdict_props/VERDICT_Properties.aadl
@@ -1,31 +1,375 @@
+-------------------------------------------------------------------------
+--- The following VERDICT_Properties enable the use of the VERDICT tool suite for both the high-level Model-Based
+--- Architectural Analysis (MBAA) and behavioral analysis using the Cyber Resiliency Verifier (CRV). Each property
+--- below is tagged for which tools uses the property followed by a short description.
+---
+--- This file contains four different types of properties:
+--- 	Mandatory User Defined Component Properties must be assigned for VERDICT tools to execute
+--- 	Port Properties are used to designate analysis-only ports for use in behavioral analysis
+--- 	Connection Properties contain necessary inputs as well as annotations for applied mitigations on connections
+--- 	Connection Cyber Defense Properties allow the designer to annotate applied mitigations for connections
+--- 	Component Cyber Defense Properties allow the designer to annotate applied mitigations for system components
+-------------------------------------------------------------------------
 property set VERDICT_Properties is
--- Port properties
- probe: aadlboolean applies to (port);
 
--- Connection properties, including defenses and DAL values
- flowType: enumeration (Xdata, Xcontrol, Xrequest) applies to (connection);
- connectionType: enumeration (Local, Remote) applies to (connection);
- authenticated: aadlboolean applies to (connection);
- trustedConnection: aadlboolean applies to (connection);
- encryptedTransmission: aadlboolean applies to (connection);
- encryptedTransmissionDAL: aadlinteger 0 .. 9 applies to (connection);
 
--- Component properties 
- pedigree: enumeration (InternallyDeveloped, COTS, Sourced) applies to (system);
- category: aadlstring applies to (system);
- componentType: enumeration (Software, Hardware, Human, Hybrid) applies to (system);
- situated: enumeration (OnBoard, Remote) applies to (system);
- adversariallyTested: aadlboolean applies to (system);
- hasSensitiveInfo: aadlboolean applies to (system);
- insideTrustedBoundary: aadlboolean applies to (system);
+
+-------------------------------------------------------------------------
+--- Mandatory User Defined Component Properties
+---          NOTE: The mandatory user defined component properties must be assigned for each applicable component as a minimum for VERDICT to execute.
+-------------------------------------------------------------------------
+
+ --- MBAA:
+ --- 	canReceiveConfigUpdate is a property used to determine whether the system is susceptible to attacks attempting to tamper with the configuration
+ --- 	of a system. Apply this property if the configuration of software or hardware within the system can be updated outside of the original
+ --- 	manufacturer's facility.
+
  canReceiveConfigUpdate: aadlboolean applies to (system);
- canReceiveSWUpdate: aadlboolean applies to (system);
- controlReceivedFromUntrusted: aadlboolean applies to (system);
- controlSentToUntrusted: aadlboolean applies to (system);
- dataReceivedFromUntrusted: aadlboolean applies to (system);
- dataSentToUntrusted: aadlboolean applies to (system);
 
- -- Cyber Attack Properties from TA1 
+ --- MBAA:
+ --- 	canRecieveSWUpdate is a property used to determine whether the system is susceptible to attacks attempting to install malicious software
+ --- 	updates. Apply this property if the software within the system can be updated outside of the original manufacturer's facility.
+
+ canReceiveSWUpdate: aadlboolean applies to (system);
+
+ --- MBAA:
+ --- 	componentType is a property used to determine whether the system is subject to attacks targeting software, hardware, humans, or hybrid
+ --- 	(software and hardware). For example, systems that represent software only will not be subject to CAPEC-440 Hardware Integrity Attack.
+ --- CRV:
+ --- 	A componentType designates whether a component is a software, a hardware, a Human, or a Hybrid (mix of Software and Hardware).
+ --- 	This helps CRV to decide what sort of attack can the component be susceptible to. For instance, a Hybrid component can be susceptible
+ --- 	to both hardware (e.g., trojans) and software (e.g., logic bomb) attacks whereas a Human component can only be susceptible to insider/outsider threat.
+
+ componentType: enumeration (Software, Hardware, Human, SwHwHybrid, SwHumanHybrid, HwHumanHybrid, Hybrid) applies to (system);
+
+ --- MBAA:
+ --- 	If a system contains the property hasSensitiveInfo it will be considered for attacks resulting in loss of confidentiality.
+
+ hasSensitiveInfo: aadlboolean applies to (system);
+
+ --- MBAA:
+ --- 	insideTrustedBoundary designates a system that will be analyzed for their potential to be attacked. Also, systems where insideTrustedBoundary=TRUE
+ --- 	will not be considered the initial source of attacks.
+ --- CRV:
+ --- 	If a component's insideTrustedBoundary property is true, it signifies to CRV that the component is inside the system's trust boundary. For instance,
+ --- 	if a human component is inside the trusted boundary of the system, then an insider attack can occur.
+
+ insideTrustedBoundary: aadlboolean applies to (system);
+
+
+ --- MBAA:
+ --- 	pedigree is a property used to infer the level of trust in a system. A "COTS" component will be untrusted and considered a
+ --- 	potential source of attacks, whereas "Sourced" and "InternallyDeveloped" components will be trusted. Both of these can be explicitly
+ --- 	overridden by the insideTrustedBoundary property.
+ ---
+ --- CRV:
+ --- 	The pedigree component property allows CRV to decide whether a component can be susceptible to a hardware
+ --- 	trojan (hardware/hybrid component) or a logic bomb (software/hybrid component) attack. If a component is designated
+ --- 	as "InternallyDeveloped", it is neither susceptible to a hardware trojan nor a logic bomb attack. For other values,
+ --- 	however, they can be susceptible to the attacks.
+
+ pedigree: enumeration (InternallyDeveloped, COTS, Sourced) applies to (system);
+
+
+
+-------------------------------------------------------------------------
+--- Port properties
+-------------------------------------------------------------------------
+
+ --- CRV:
+ --- 	If a port's probe property is true, it signifies to CRV that it is not part of the original architecture but is
+ --- 	included just for the convenience of CRV's reasoning. When a system is modeled hierarchically, a probe port allows CRV
+ --- 	to peek inside a component's behavior without needing to expose the behavior completely at a top level.
+
+ probe: aadlboolean => FALSE applies to (port);
+
+
+
+-------------------------------------------------------------------------
+--- Connection properties
+-------------------------------------------------------------------------
+
+
+ --- MBAA:
+ ---          connectionType is used by MBAA to make decisions around the level of trust for connections that are incompletely modeled.
+ ---          An example Untrusted connectionType would be GPS, where the satelite and ground systems may be excluded from the model, but
+ ---          this could also be used for logical models where the physical connection passes outside of the trust boundary.
+ ---          An example Trusted connectionType would be a connection passing between two local systems, where the physical communications
+ ---          medium is entirely contained within the trust boundary indicating that the connection itself can be trusted.
+ --- CRV:
+ ---          connectionType enables CRV to decide whether a certain connection can be susceptible to network injection attack
+ ---          or the component to which this connection is incident upon is susceptible to Remote code injection or other software
+ ---          attacks(e.g., virus, trojan, worm). Trusted connections are assumed to be free of attacks whereas Untrusted connections can be
+ ---          susceptible to attacks depending on the values of the following additional properties (encryptedTransmission/deviceAuthentication).
+
+ connectionType: enumeration (Trusted, Untrusted) => Untrusted applies to (connection);
+
+
+
+------------------------------------------------------------------------
+-- Optional Component Properties
+------------------------------------------------------------------------
+
+ --- CRV:
+ --- 	The category property lets CRV know whether a certain component is one of the pre-defined ones (e.g., GPS, IMU, LIDAR).
+ --- 	If it is one of the pre-defined components, then CRV decides it to be susceptible to a pre-defined set of attacks (e.g., Location spoofing).
+
+ category: aadlstring applies to (system);
+
+ --- CRV:
+ --- 	If adversariallyTestedForTrojanOrLogicBomb property of a component is assigned an integer greater than '0', it suggests CRV that even if the
+ --- 	component's pedigree is sourced/COTS, it is not susceptible to hardware trojan or logic bomb type of attacks.
+
+ adversariallyTestedForTrojanOrLogicBomb: aadlinteger 0 .. 9 => 0 applies to (system);
+
+
+
+------------------------------------------------------------------------
+-- Connection Cyber Defense Properties
+---          NOTE: Each cyber defense represents one or more NIST 800-53r4 controls that has been applied to the system and the relative level of rigor
+---          that is used to develop the implementation of that control. If the system does not have the property or the value is '0', it is assumed that this
+---          defense has not been applied. More information on NIST 800-53 controls can be found at: https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/final.
+------------------------------------------------------------------------
+
+ --- MBAA:
+ --- encryptedTransmission
+ ---          SC-8 Transmission Confidentiality and Integrity
+ ---                         SC-8 generally covers protection of the confidentiality of communications between two components, which
+ ---                         can include encryption of the data payload, protection of the header or protocol fields, and confidentiality
+ ---                         of data just prior to sending and just after receipt.
+ --- CRV:
+ ---          Not used by CRV
+
+ encryptedTransmission: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+ --- MBAA:
+ --- deviceAuthentication
+ ---          IA-3 Device Identification and Authentication
+ ---          IA-3 (1) Cryptographic Bidirectional Authentication
+ ---                         IA-3 specifies general verification of the identity of other connected systems, while enhancement IA-3 (1) establishes
+ ---                         requirements for mutual verification of identity through cryptographic algorithms.
+
+ deviceAuthentication: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+ --- MBAA:
+ --- sessionAuthenticity
+ ---          SC-23 Session Authenticity
+ ---                         SC-23 specifies technical means to maintain the authenticity of communications after establishing initial
+ ---                         identity. Mitigations focus on unique randomly generated session identifiers.
+ --- CRV:
+ ---          Need to add description for CRV use
+
+ sessionAuthenticity: aadlinteger 0 .. 9 => 0 applies to (connection);
+
+
+
+-------------------------------------------------------------------------
+--- Component Cyber Defense Properties
+---          NOTE: Each cyber defense represents one or more NIST 800-53r4 controls that has been applied to the system and the relative level of rigor
+---          that is used to develop the implementation of that control. If the system does not have the property or the value is '0', it is assumed that this
+---          defense has not been applied. More information on NIST 800-53 controls can be found at: https://csrc.nist.gov/publications/detail/sp/800-53/rev-4/final.
+-------------------------------------------------------------------------
+
+ --- MBAA:
+ --- antiJamming
+ ---          SC-40 Wireless Link Protection
+ ---          SC-40 (1) Electromagnetic Interference
+ ---                         SC-40 specifies general protections for wireless links by directing protection on signal parameters,
+ ---                         while SC-40 (1) specifies more specific techniques, such as cryptographic frequency hopping to prevent
+ ---                         the adversary from jamming communications.
+
+ antiJamming: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- auditMessageResponses
+ ---          SI-11 Error Handling
+ ---                         SI-11 ensures that error messages are designed to provide only the minimal information necessary for
+ ---                         informed authorized users to take the appropriate corrective actions and exclude any additional information that
+ ---                         would reveal more about the systems to potential attackers.
+
+ auditMessageResponses: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- dosProtection
+ ---          SC-5 Denial of Service Protection
+ ---          SC-5 (2) Excess Capacity/Bandwidth/Redundancy
+ ---                         SC-5 specifies general denial of service protections, including packet filtering and increased capacities
+ ---                         to withstand attacks. Enhancement SC-5 (2) describes more specific solutions to manage capacities, which
+ ---                         include usage priorities, quotas, and partitioning.
+
+ dosProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- encryptedStorage
+ ---          SC-28 Protection of Information at Rest
+ ---                         SC-28 specifies means to protect sensitive information stored within the system, which can include
+ ---                         encryption of stored data or stored configuration files.
+
+ encryptedStorage: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- failSafe
+ ---          SI-17 Fail-Safe Procedures
+ ---                         SI-17 specifies the implementation of logic within the system to follow a known procedure during attacks
+ ---                         that result in sustained communication interruptions. Fail-Safe procedures can include shutdown process, alerts,
+ ---                         or predefined operational paths to follow.
+
+ failSafe: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- heterogeneity
+ ---          SC-29 Heterogeneity
+ ---                         SC-29 promotes the use of a diverse set of technologies to defend against common mode failures, which prevent
+ ---                         the same attack from successfully defeating two systems intended to be independent.
+
+ heterogeneity: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- inputValidation
+ ---          SI-10 Information Input Validation
+ ---          SI-10 (5) Restrict Inputs to Trusted Sources and Approved Formats
+ ---                         SI-10 specifies checking of the validity of incoming communications. Validity checks can be performed based
+ ---                         on a whitelisted character set, packet length, numerical ranges, or a list of acceptable values, as well as many
+ ---                         other factors. Enhancement SI-10 (5) focuses on enforcing only known trusted sources and valid message formats.
+
+ inputValidation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- logging
+ ---          AU-12 Audit Generation
+ ---          AU-12 (1) System-Wide/Time-Correlated Audit Trails
+ ---          AU-12 (3) Changes by Authorized Individuals
+ ---          AU-9 Protection of Audit Information
+ ---          AU-9 (3) Cryptographic Protection
+ ---                         AU-12 with enhancements (1) and (3) focuses on the implementation of auditable records that are time-synced across
+ ---                         the broader system to aid in forensic activities and available only to authorized users. AU-9 with enhancement (3)
+ ---                         ensures audit records are protected from tampering or deletion via signed hash functions or asymmetric encryption.
+
+ logging: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- memoryProtection
+ ---          SI-16 Memory Protection
+ ---                         SI-16 describes protections from unauthorized code execution, including non-executable regions of memory and
+ ---                         address space layout randomization.
+
+ memoryProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- physicalAccessControl
+ ---          PE-3 Physical Access Control
+ ---                         PE-3 is an operational control that describes elements of a program to physically secure a facility or site that
+ ---                         containing a sensitive system. This includes verifying an individual's identity and authorization, logging physical
+ ---                         accesses, escorting visitors, taking inventory of devices, and installing/maintaining physical access devices
+ ---                         (e.g. locks, key readers, etc.).
+
+ physicalAccessControl: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- remoteAttestation
+ ---          IA-3 (4) Device Attestation
+ ---                         Enhancement IS-3 (4) describes means for one system to assure to another system the authenticity of its configuration
+ ---                         and operating state. This is often paired with secure boot, secure update, and other run-time mechanisms to
+ ---                         maintain trusted authenticity and identity between interdependent systems.
+
+ remoteAttestation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- removeIdentifyingInformation
+ ---          SI-15 Information Output Filtering
+ ---                         SI-15 requires validation of the output of the system to ensure that appropriate outputs are being sent given the context
+ ---                         of the request. Mitigations satisfying this control could be to block unnecessary data or alert on anomalous behavior.
+
+ removeIdentifyingInformation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- resourceAvailability
+ ---          SC-6 Resource Availability
+ ---                         SC-6 describes protections preventing an attacker from consuming the resources of a system, including
+ ---                         prioritization or quotas.
+
+ resourceAvailability: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- resourceIsolation
+ ---          SC-4 Information in Shared Resources
+ ---                         SC-4 provides general protection mechanisms to prevent sensitive information from being leaked through
+ ---                         shared registers, memory, or hard disk space.
+
+ resourceIsolation: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- secureBoot
+ ---          SI-7 (1) Integrity Checks
+ ---          SI-7 (5) Automated Response to Integrity Violations
+ ---          SI-7 (6) Cryptographic Protection
+ ---          SI-7 (9) Verify Boot Process
+ ---          SI-7 (15) Code Authentication
+ ---                         SI-7 Enhancement (1) specifies integrity checks of software, firmware, and information on a system. Enhancement SI-7 (5) defines
+ ---                         the response to detected violations of these checks. Enhancement SI-7 (6) specifies cryptographic algorithms should
+ ---                         be used to perform these checks. Enhancement SI-7 (9) specifies the checks be performed on the boot process to ensures
+ ---                         the system is operating correctly prior to execution. Enhancement SI-7 (15) specifies the checks be performed on all
+ ---                         new software prior to installation and execution to ensure no malicious code is injected.
+
+ secureBoot: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- staticCodeAnalysis
+ ---          SA-11 (1) Static Code Analysis
+ ---                         Enhancement SA-11 (1) is an organizational control specifying the use of software tools to look for common
+ ---                         source code patterns that can be exploited by known attacks.
+
+ staticCodeAnalysis: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- strongCryptoAlgorithms
+ ---          SC-13 Cryptographic Protection
+ ---                         SC-13 is an enhancement to controls specifying the use of cryptographic algorithms. Application of this control
+ ---                         ensures only approved algorithms are used and their implementation is sufficient to protect against known attacks.
+
+ strongCryptoAlgorithms: aadlinteger 0 .. 9 applies to (system);
+
+ --- MBAA:
+ --- supplyChainSecurity
+ ---          SA-12 Supply Chain Protection
+ ---                         SA-12 is an organizational control listing best practices for acquiring services, systems, components securely. These
+ ---                         best practices include supplier reviews, operational security, component validation, and component identification
+ ---                         and traceability.
+
+ supplyChainSecurity: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- systemAccessControl
+ ---          PE-3 (1) Information System Access
+ ---                         Enhancement PE-3 (1) improves the protection applied in the "physicalAccessControl" defense by additionally restricting
+ ---                         physical access to each critical system beyond those applied to a site or facility, such that only authentic and
+ ---                         authorized individuals for that system can gain physical access.
+
+ systemAccessControl: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- tamperProtection
+ ---          SA-18 (1) [Tamper Resistance and Detection] Multiple Phases of SDLC
+ ---                         Enhancement SA-18 (1) describes multiple technical countermeasures to prevent reverse engineering or tampering with a
+ ---                         component. These countermeasures can include obfuscation, self-checking, and customization.
+
+ tamperProtection: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- userAuthentication
+ ---          userAuthentication is NOT USED. It is a placeholder for future tool improvements.
+
+ userAuthentication: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ --- MBAA:
+ --- zeroize
+ ---          MP-6 (8) Remote Purging / Wiping of Information
+ ---                         Enhancement MP-6 (8) specifies the purging or wiping of sensitive information either from a remote command or following
+ ---                         some logic within the device to prevent unauthorized individuals from extracting that information.
+
+ zeroize: aadlinteger 0 .. 9 => 0 applies to (system);
+
+ -- Cyber Attack Properties from TA1
  Configuration_Attack: aadlboolean applies to (system);
  Physical_Theft_Attack: aadlboolean applies to (system);
  Interception_Attack: aadlboolean applies to (system);
@@ -39,50 +383,4 @@ property set VERDICT_Properties is
  Buffer_Attack: aadlboolean applies to (system);
  Flooding_Attack: aadlboolean applies to (system);
 
- -- Cyber Defense Properties
- antiJamming: aadlboolean applies to (system); 
- auditMessageResponses: aadlboolean applies to (system);
- deviceAuthentication: aadlboolean applies to (system);
- dosProtection: aadlboolean applies to (system);
- encryptedStorage: aadlboolean applies to (system);
- heterogeneity: aadlboolean applies to (system);
- inputValidation: aadlboolean applies to (system);
- logging: aadlboolean applies to (system);
- memoryProtection: aadlboolean applies to (system);
- physicalAccessControl: aadlboolean applies to (system);
- removeIdentifyingInformation: aadlboolean applies to (system);
- resourceAvailability: aadlboolean applies to (system);
- resourceIsolation: aadlboolean applies to (system);
- secureBoot: aadlboolean applies to (system);
- sessionAuthenticity: aadlboolean applies to (system);
- staticCodeAnalysis: aadlboolean applies to (system);
- strongCryptoAlgorithms: aadlboolean applies to (system);
- supplyChainSecurity: aadlboolean applies to (system);
- systemAccessControl: aadlboolean applies to (system);
- tamperProtection: aadlboolean applies to (system);
- userAuthentication: aadlboolean applies to (system);
-
- -- DAL for Cyber Defense Properties
- antiJammingDAL: aadlinteger 0 .. 9 applies to (system);
- auditMessageResponsesDAL: aadlinteger 0 .. 9 applies to (system);
- deviceAuthenticationDAL: aadlinteger 0 .. 9 applies to (system);
- dosProtectionDAL: aadlinteger 0 .. 9 applies to (system);
- encryptedStorageDAL: aadlinteger 0 .. 9 applies to (system);
- heterogeneityDAL: aadlinteger 0 .. 9 applies to (system);
- inputValidationDAL: aadlinteger 0 .. 9 applies to (system);
- loggingDAL: aadlinteger 0 .. 9 applies to (system);
- memoryProtectionDAL: aadlinteger 0 .. 9 applies to (system);
- physicalAccessControlDAL: aadlinteger 0 .. 9 applies to (system);
- removeIdentifyingInformationDAL: aadlinteger 0 .. 9 applies to (system);
- resourceAvailabilityDAL: aadlinteger 0 .. 9 applies to (system);
- resourceIsolationDAL: aadlinteger 0 .. 9 applies to (system);
- secureBootDAL: aadlinteger 0 .. 9 applies to (system);
- sessionAuthenticityDAL: aadlinteger 0 .. 9 applies to (system);
- staticCodeAnalysisDAL: aadlinteger 0 .. 9 applies to (system);
- strongCryptoAlgorithmsDAL: aadlinteger 0 .. 9 applies to (system);
- supplyChainSecurityDAL: aadlinteger 0 .. 9 applies to (system);
- systemAccessControlDAL: aadlinteger 0 .. 9 applies to (system);
- tamperProtectionDAL: aadlinteger 0 .. 9 applies to (system);
- userAuthenticationDAL: aadlinteger 0 .. 9 applies to (system);
- 
 end VERDICT_Properties;


### PR DESCRIPTION
Start using a new VERDICT_Properties.aadl in the following models:

      CruiseControl
      DeliveryDrone
      DeliveryDrone_BusBindings
      Thermostat_with_verdict_props

Update some of the models' verdict annexes where necessary due to the
changes in VERDICT_Properties.aadl.