### PR TITLE
Add z3-native-libs to VERDICT backend code

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -40,6 +40,11 @@
                     <version>1.5.1</version>
                 </plugin>
                 <plugin>
+                    <groupId>com.googlecode.maven-download-plugin</groupId>
+                    <artifactId>download-maven-plugin</artifactId>
+                    <version>1.6.0</version>
+                </plugin>
+                <plugin>
                     <groupId>net.codesup.util</groupId>
                     <artifactId>jaxb2-rich-contract-plugin</artifactId>
                     <version>2.0.1</version>
@@ -114,6 +119,11 @@
                     <configuration>
                         <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/tools/verdict-back-ends/verdict-bundle-parent/iml-verdict-translator/src/main/java/edu/uiowa/clc/verdict/vdm/translator/VDMParser.java
+++ b/tools/verdict-back-ends/verdict-bundle-parent/iml-verdict-translator/src/main/java/edu/uiowa/clc/verdict/vdm/translator/VDMParser.java
@@ -80,3332 +80,3338 @@ import verdict.vdm.vdm_model.Severity;
 
 public class VDMParser extends Parser {
 
-	private Model model;
-
-	private List<TypeDeclaration> typeDeclarations;
-	private List<ComponentType> componentTypes;
-	private List<ComponentImpl> componentImpls;
-	private List<CyberReq> cyberRequirements;
-	private List<SafetyReq> safetyRequirements;
-	private List<Mission> missions;
-
-	private ComponentImpl componentImpl;
-	private BlockImpl blockImpl;
-
-	public VDMParser(ArrayList<Token> tokens) {
-		super(tokens);
-		model = new Model();
-		typeDeclarations = model.getTypeDeclaration();
-		componentTypes = model.getComponentType();
-		componentImpls = model.getComponentImpl();
-		cyberRequirements = model.getCyberReq();
-		safetyRequirements = model.getSafetyReq();
-		missions = model.getMission();
-	}
-
-	private void log(String msg) {
-		// System.out.println(msg);
-	}
-
-	// Project Rules:
-
-	// IDENTIFIER ::= IDENTIFIER:name String:value
-	// Return a String.
-	public String Identifier() {
-
-		String identifier_name;
-		String identifier_value;
-
-		identifier_name = token.sd.getName();
-		consume(Type.IDENTIFIER);
-
-		identifier_value = token.getStringValue();
-		consume(Type.String);
-
-		// LOGGER.info(identifier_name + " := " + identifier_value);
-
-		return identifier_value;
-	}
-
-	// DATATYPE ::= {DATA_TYPE:t}* {DATA_TYPE_KIND, kind}
-	// NULL: Plain | NULL:Enum | NULL:Subrange | NULL:ArrayType | NULL:TupleType |
-	// NULL:RecordType
-	// | NULL: UserDefinedType
-	// DATATYPE ::= {DATA_TYPE:t} NULL:Plain_Type | NULL:Enum |
-	// SUB_RANGE_TYPE:subrange | ArrayType
-	// | TupleType | RecordType | UserDefinedType
-	/*
-	 * type DataType { kind: DataTypeKind; plain_type: PlainType; subrange_type:
-	 * SubrangeType; enum_type: EnumType; record_type: RecordType;
-	 * user_defined_type: TypeDeclaration; };
-	 */
-	public DataType dataType() {
-
-		DataType dataType = new DataType();
-		Type type = null;
-
-		while (token.type == Type.DATA_TYPE) {
-			consume(Type.DATA_TYPE);
-
-			String type_name = token.sd.getName();
-			type = Type.get(type_name);
-
-			// Token token = this.token;
-			if (token.type == Type.DATA_TYPE_KIND) {
-				type = getDataTypeKind();
-
-				if (type == Type.ENUM) {
-					EnumType enumType = enumType();
-					dataType.setEnumType(enumType);
-				} else if (type == Type.RECORD) {
-					RecordType recordType = recordType();
-					dataType.setRecordType(recordType);
-				} else if (type == Type.SUBRANGE) {
-					// dataType.setSubrangeType(value);
-				} else if (type == Type.PLAIN) {
-					PlainType plainType = plainType();
-					dataType.setPlainType(plainType);
-					break;
-				} else if (type == Type.USERDEFINED) {
-					dataType = getUserDefinedType();
-					break;
-					// dataType.setUserDefinedType(type_value);
-				}
-			}
-		}
-
-		return dataType;
-	}
-
-	// type DataTypeKind enum { Plain, Subrange, Enum, Record, UserDefined };
-	public Type getDataTypeKind() {
-
-		consume(Type.DATA_TYPE_KIND);
-
-		String type_name = token.sd.getName();
-		Type type = Type.get(type_name);
-
-		if (type == Type.ENUM) {
-			consume(Type.ENUM);
-		} else if (type == Type.SUBRANGE) {
-			consume(Type.SUBRANGE);
-		} else if (type == Type.PLAIN) {
-			consume(Type.PLAIN);
-		} else if (type == Type.RECORD) {
-			consume(Type.RECORD);
-		} else if (type == Type.USERDEFINED) {
-			consume(Type.USERDEFINED);
-		}
-
-		return type;
-	}
-
-	/*
-	 * BoolType: DataType := some(d: DataType) { d.kind = DataTypeKind.Plain &&
-	 * d.plain_type = PlainType.Bool };
-	 *
-	 *
-	 * RealType: DataType := some(d: DataType) { d.kind = DataTypeKind.Plain &&
-	 * d.plain_type = PlainType.Real };
-	 *
-	 * IntegerType: DataType := some(d: DataType) { d.kind = DataTypeKind.Plain &&
-	 * d.plain_type = PlainType.Int };
-	 *
-	 */
-
-	public DataType recordDataType() {
-
-		DataType recordDataType = new DataType();
-
-		while (token.type == Type.DATA_TYPE) {
-
-			consume(Type.DATA_TYPE);
-
-			String type_value = token.sd.getName();
-			Type type = Type.get(type_value);
-
-			if (type == Type.INTEGER_TYPE) {
-				consume(Type.INTEGER_TYPE);
-				recordDataType = dataType();
-			}
-			// Token token = this.token;
-			if (token.type == Type.DATA_TYPE_KIND) {
-				type = getDataTypeKind();
-				//
-				// if(type == Type.PLAIN) {
-				// plainType();
-				// } else {
-				// System.out.println("Error in IntegerType");
-				// }
-				if (type == Type.PLAIN) {
-					PlainType plainType = plainType();
-					recordDataType.setPlainType(plainType);
-					// break;
-				}
-			} else if (token.type == Type.MODEL) {
-				TypeDeclaration typeDeclaration = getTypeDeclaration();
-				recordDataType.setUserDefinedType(typeDeclaration.getName());
-			}
-		}
-
-		return recordDataType;
-	}
-
-	// type PlainType enum { Int, Real, Bool };
-	public PlainType plainType() {
-
-		PlainType plainType = null;
-
-		// while(token.type == Type.DATA_TYPE) {
-
-		consume(Type.DATA_TYPE);
-
-		if (token.type == Type.PLAIN_TYPE) {
-			consume(Type.PLAIN_TYPE);
-
-			String type_value = token.sd.getName();
-			Type type = Type.get(type_value);
-			consume(type);
-
-			if (type == Type.INT) {
-				plainType = PlainType.valueOf("INT");
-			} else if (type == Type.REAL) {
-				plainType = PlainType.valueOf("REAL");
-			} else if (type == Type.BOOL) {
-				plainType = PlainType.valueOf("BOOL");
-			}
-		}
-		// }
-
-		return plainType;
-	}
-
-	// ENUM ::== ENUM*
-	// ENUM ::= {DATA_TYPE:t}* ENUM_TYPE:enum_type INT:length Int:value
-	// | ({DATATYPE:t} ENUMTYPE:enum_type NULL:element Int:index String:value (Bound
-	// by
-	// length)
-	//
-
-	// type EnumType is ArrayList<Identifier>;
-	public EnumType enumType() {
-
-		EnumType enumType = new EnumType();
-
-		int enum_length = 0;
-
-		while (token.type == Type.DATA_TYPE) {
-
-			consume(Type.DATA_TYPE);
-
-			if (token.type == Type.ENUM_TYPE) {
-				consume(Type.ENUM_TYPE);
-
-				if (token.type == Type.INT) {
-					// length
-					consume(Type.INT);
-					enum_length = token.getNumberValue();
-					// value
-					consume(Type.Int);
-
-				} else {
-					// enum
-					consume();
-					int enum_index = token.getNumberValue();
-					// index
-					consume(Type.Int);
-
-					String enum_value = token.getStringValue();
-					consume(Type.String);
-					enumType.getEnumValue().add(enum_index, enum_value);
-				}
-			}
-		}
-
-		return enumType;
-	}
-
-	// type RecordType is ArrayList<RecordField>;
-	public RecordType recordType() {
-
-		RecordType recordType = new RecordType();
-
-		int enum_length = 0;
-
-		while (token.type == Type.DATA_TYPE) {
-
-			consume(Type.DATA_TYPE);
-
-			if (token.type == Type.RECORDTYPE) {
-				consume(Type.RECORDTYPE);
-
-				if (token.type == Type.INT) {
-					// length
-					consume(Type.INT);
-					enum_length = token.getNumberValue();
-					// value
-					consume(Type.Int);
-
-				} else {
-					// enum
-					consume();
-					int rf_index = token.getNumberValue();
-					// index
-					consume(Type.Int);
-					// RecordField.
-					RecordField rf = recordField();
-					recordType.getRecordField().add(rf_index, rf);
-				}
-			}
-		}
-
-		return recordType;
-	}
-
-	public DataType getUserDefinedType() {
-
-		DataType dataType = null;
-
-		// while (token.type == Type.DATA_TYPE) {
-		consume(Type.DATA_TYPE);
-
-		if (token.type == Type.TYPE_DECLARATION) {
-			consume(Type.TYPE_DECLARATION);
-
-			TypeDeclaration typeDeclaration = getTypeDeclaration();
-			dataType = new DataType();
-			dataType.setUserDefinedType(typeDeclaration.getName());
-		}
-		// }
-
-		return dataType;
-	}
-
-	/*
-	 * type RecordField { name: Identifier; dtype: DataType; };
-	 */
-	public RecordField recordField() {
-
-		RecordField recordField = new RecordField();
-		DataType dataType = null;
-
-		while (token.type == Type.RECORD_FILED) {
-
-			consume(Type.RECORD_FILED);
-
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
-				recordField.setName(identifier);
-			} else if (token.type == Type.DATA_TYPE) {
-				// Peek
-				// rf.dtype = IntegerType
-				// OR
-				// m.type_declarations.element[3]
-				dataType = dataType();
-				// consume(Type.DATA_TYPE);
-				//
-				// if (token.type == Type.DATA_TYPE) {
-				// consume(Type.DATA_TYPE);
-				// dataType = dataType();
-				//
-				// } else if (token.type == Type.MODEL) {
-				// TypeDeclaration typeDeclaration = getTypeDeclaration();
-				// dataType = new DataType();
-				// dataType.setUserDefinedType(typeDeclaration.getName());
-				// }
-				recordField.setType(dataType);
-			}
-		}
-
-		return recordField;
-	}
-
-	/*
-	 * type OptionKind enum { Some, None };
-	 *
-	 * type Option<T> { kind: OptionKind; value: T; };
-	 */
-	public Type optionKind() {
-
-		// while(token.type == Type.OPTION) {
-		consume(Type.OPTION);
-
-		// kind
-		consume(Type.DATA_KIND);
-		// Value
-		String type_value = token.sd.getName();
-		Type type = Type.get(type_value);
-
-		if (type == Type.SOME) {
-			consume(Type.SOME);
-			// String type_value = peek().sd.getName();
-			// Type type = Type.get(type_value);
-
-		} else if (type == Type.NONE) {
-
-			consume(Type.NONE);
-		}
-		// }
-		return type;
-	}
-	/*
-	 * <T>mk_some: T -> Option<T> := fun (v:T) { some(o: Option<T>) { o.kind =
-	 * OptionKind.Some && o.value = v }};
-	 *
-	 * <T>mk_none: Option<T> := some(o: Option<T>) { o.kind = OptionKind.None };
-	 */
-
-	// mk_some ::= mk_some:OPTION {DATA_TYPE:t} DATA_TYPE_KIND:kind DATATYPE
-	// Option ::== mk_some or None.
-	// Parametric Option<T> ... Option<DataType>
-	// Option ::= MK_NONE | MK_SOME
-	public Type option() {
-
-		// DataType dataType = null;
-
-		// consume(Type.OPTION);
-
-		String type_value = token.sd.getName();
-		Type type = Type.get(type_value);
-
-		if (type == Type.MK_NONE) {
-			consume(Type.MK_NONE);
-			// Some or NONE
-			type = mk_none();
-			// return null;
-		} else if (type == Type.SOME) {
-			consume(Type.SOME);
-			// dataType = dataType();
-		}
-
-		return type;
-		// return dataType;
-	}
-
-	public Type mk_none() {
-
-		consume(Type.OPTION);
-		return optionKind();
-	}
-
-	public Type mk_some() {
-
-		consume(Type.OPTION);
-		return optionKind();
-	}
-
-	public String optionIdentifier() {
-
-		String identifier = null;
-
-		String type_value = this.token.sd.getName();
-		Type type = Type.get(type_value);
-
-		if (type == Type.MK_NONE) {
-			consume(Type.MK_NONE);
-		} else if (type == Type.SOME) {
-
-			consume(Type.SOME);
-			identifier = Identifier();
-		}
-
-		return identifier;
-	}
-
-	/*
-	 * type Expression { kind: ExpressionKind; identifier: Identifier; and:
-	 * BinaryOperation; equal: BinaryOperation; };
-	 */
-	public Expression expression() {
-
-		Expression expression = new Expression();
-		Type type = null;
-
-		while (token.type == Type.EXPRESSION) {
-			// Kind...
-			consume(Type.EXPRESSION);
-
-			if (token.type == Type.EXPRESSION_KIND) {
-				type = expressionKind();
-			}
-
-			// ID
-			if (type == Type.Id) {
-				return idExpr();
-			} else if (type == Type.INT_Lit) {
-				return intExpr();
-			} else if (type == Type.REAL_Lit) {
-				return realExpr();
-			} else if (type == Type.BOOL_Lit) {
-				return boolExpr();
-			} else if (type == Type.NEG) {
-				Expression neg_expr = expression();
-				expression.setNegative(neg_expr);
-				return expression;
-			} else if (type == Type.NOT) {
-				Expression not_expr = expression();
-				expression.setNot(not_expr);
-				return expression;
-			} else if (type == Type.PRE) {
-				Expression pre_expr = expression();
-				expression.setPre(pre_expr);
-				return expression;
-			} else if (type == Type.EVENT) {
-				Expression event_expr = expression();
-				expression.setEvent(event_expr);
-				return expression;
-			} else if (type == Type.TO_REAL) {
-				Expression real_expr = expression();
-				expression.setToReal(real_expr);
-				return expression;
-			} else if (type == Type.TO_INT) {
-				Expression int_expr = expression();
-				expression.setToInt(int_expr);
-				return expression;
-			} else if (token.type == Type.BINARY_OP) {
-				// OP
-				// EQ
-				// AND
-				BinaryOperation op = binaryOP();
-
-				if (type == Type.EQ) {
-					// BinaryOperation eq = binaryExpression();
-					expression.setEqual(op);
-				} else if (type == Type.AND) {
-					/// BinaryOperation and = binaryExpression();
-					expression.setAnd(op);
-				} else if (type == Type.OR) {
-					// BinaryOperation or = binaryExpression();
-					expression.setOr(op);
-				} else if (type == Type.IMPLIES) {
-					// BinaryOperation implies = binaryExpression();
-					expression.setImplies(op);
-				} else if (type == Type.PLUS) {
-					expression.setPlus(op);
-				} else if (type == Type.MINUS) {
-					expression.setMinus(op);
-				} else if (type == Type.DIV) {
-					expression.setDiv(op);
-				} else if (type == Type.TIMES) {
-					expression.setTimes(op);
-				} else if (type == Type.XOR) {
-					expression.setXor(op);
-				} else if (type == Type.MOD) {
-					expression.setMod(op);
-				} else if (type == Type.LEQ) {
-					// BinaryOperation leq = binaryExpression();
-					expression.setLessThanOrEqualTo(op);
-				} else if (type == Type.LE) {
-					// BinaryOperation leq = binaryExpression();
-					expression.setLessThan(op);
-				} else if (type == Type.GEQ) {
-					// BinaryOperation leq = binaryExpression();
-					expression.setGreaterThanOrEqualTo(op);
-				} else if (type == Type.GE) {
-					// BinaryOperation leq = binaryExpression();
-					expression.setGreaterThan(op);
-				} else if (type == Type.ARROW) {
-					// BinaryOperation arrow = binaryExpression();
-					expression.setArrow(op);
-				} else if (type == Type.NEQ) {
-					// BinaryOperation neq = binaryExpression();
-					expression.setNotEqual(op);
-				}
-			} else if (token.type == Type.ITE) {
-				if (type == Type.CND_EXPR) {
-					IfThenElse ite = ITE();
-					expression.setConditionalExpression(ite);
-				}
-			} else if (token.type == Type.RECORD_PROJECTION) {
-
-				if (type == Type.RECORD_PROJECTION) {
-					RecordProjection record_expr = recordProjection();
-					expression.setRecordProjection(record_expr);
-				}
-			} else if (token.type == Type.RECORD_LITERAL) {
-				if (type == Type.RECORD_LITERAL) {
-					RecordLiteral recordLit = recordLiteral();
-					expression.setRecordLiteral(recordLit);
-				}
-			} else if (token.type == Type.NODE_CALL) {
-				if (type == Type.CALL) {
-					NodeCall nodeCall = nodeCall();
-					expression.setCall(nodeCall);
-				}
-			}
-		}
-
-		return expression;
-	}
-
-	/*
-	 * type ExpressionKind enum { Id, BoolLiteral, IntLiteral, RealLiteral, ToInt,
-	 * ToReal, RecordProjection, RecordLiteral, Minus, Negative, Plus, Times, Div,
-	 * IntDiv, Mod, Not, And, Or, Xor, Implies, LessThan, GreaterThan,
-	 * LessThanOrEqualTo, GreaterThanOrEqualTo, Equal, NotEqual, ConditionalExpr,
-	 * Arrow, Pre, Call, ExpressionList };
-	 */
-	public Type expressionKind() {
-
-		consume(Type.EXPRESSION_KIND);
-
-		String type_value = token.sd.getName();
-		Type type = Type.get(type_value);
-		consume(type);
-
-		// if (type == Type.INT) {
-		// plainType = ExpressionKind.valueOf("INT");
-		// } else if (type == Type.REAL) {
-		// plainType = PlainType.valueOf("REAL");
-		// } else if (type == Type.BOOL) {
-		// plainType = PlainType.valueOf("BOOL");
-		// }
-
-		return type;
-	}
-
-	/*
-	 * mk_id_expr: Identifier -> Expression := fun (id: Identifier) {some (e:
-	 * Expression) { e.kind = ExpressionKind.Id && e.identifier = id }};
-	 */
-	public Expression idExpr() {
-
-		Expression idExpr = new Expression();
-
-		String identifier_name;
-		String identifier_value;
-
-		consume(Type.EXPRESSION);
-
-		identifier_name = token.sd.getName();
-		consume(Type.IDENTIFIER);
-
-		identifier_value = token.getStringValue();
-		consume(Type.String);
-
-		// LOGGER.info(identifier_name + " := " + identifier_value);
-
-		idExpr.setIdentifier(identifier_value);
-
-		return idExpr;
-	}
-
-	public Expression intExpr() {
-
-		Expression intExpr = new Expression();
-
-		consume(Type.EXPRESSION);
-
-		consume(Type.INT);
-		// System.err.println("+++>" + token);
-		int literal_value = token.getNumberValue();
-		consume(Type.Int);
-
-		BigInteger bi = BigInteger.valueOf(literal_value);
-
-		intExpr.setIntLiteral(bi);
-
-		return intExpr;
-	}
-
-	public Expression realExpr() {
-
-		Expression realExpr = new Expression();
-
-		consume(Type.EXPRESSION);
-		consume(Type.REAL);
-		// System.out.println("REAL TOKEN:" + token.getFloatingValue());
-		// BigDecimal literal_value = BigDecimal.valueOf(token.getFloatingValue());
-		BigDecimal literal_value = new BigDecimal(String.format("%f", token.getFloatingValue()));
-
-		consume(Type.Float);
-
-		realExpr.setRealLiteral(literal_value);
-
-		return realExpr;
-	}
-
-	public Expression boolExpr() {
-
-		Expression boolExpr = new Expression();
-
-		consume(Type.EXPRESSION);
-
-		consume(Type.BOOL);
-		boolean literal_value = token.getTruthValue();
-		consume(Type.Boolean);
-
-		boolExpr.setBoolLiteral(literal_value);
-
-		return boolExpr;
-	}
-
-	public IfThenElse ITE() {
-		IfThenElse ite = new IfThenElse();
-
-		while (token.type == Type.ITE) {
-			consume(Type.ITE);
-			String type_value = token.sd.getName();
-			Type type = Type.get(type_value);
-
-			if (type == Type.CONDITION) {
-				Expression condition_expr = expression();
-				ite.setCondition(condition_expr);
-			} else if (type == Type.THEN) {
-				Expression then_expr = expression();
-				ite.setThenBranch(then_expr);
-			} else if (type == Type.ELSE) {
-				Expression else_expr = expression();
-				ite.setElseBranch(else_expr);
-				break;
-			}
-		}
-		return ite;
-	}
-
-	/*
-	 * type NodeCall { node: Identifier -- Indirect Reference arguments:
-	 * ArrayList<Expression>; }
-	 */
-	public NodeCall nodeCall() {
-
-		NodeCall nodeCall = new NodeCall();
-		int array_length = 0;
-
-		while (token.type == Type.NODE_CALL) {
-			consume(Type.NODE_CALL);
-
-			if (token.type == Type.IDENTIFIER) {
-				consume(Type.IDENTIFIER);
-
-				String identifier = token.getStringValue();
-				consume(Type.String);
-				nodeCall.setNodeId(identifier);
-			} else if (token.type == Type.ARRAY_LIST) {
-
-				String type_value = token.sd.getName();
-				Type type = Type.get(type_value);
-
-				if (peek().type == Type.INT) {
-
-					array_length = arrayList_length();
-
-				} else {
-
-					int element_index = arrayList_element();
-
-					Expression expression = expression();
-					nodeCall.getArgument().add(element_index, expression);
-				}
-			}
-		}
-
-		return nodeCall;
-	}
-
-	/*
-	 * lhs_operand: Expression; rhs_operand: Expression;
-	 *
-	 */
-	public BinaryOperation binaryOP() {
-
-		BinaryOperation binaryOperation = new BinaryOperation();
-
-		while (token.type == Type.BINARY_OP) {
-			consume(Type.BINARY_OP);
-
-			String type_value = token.sd.getName();
-			Type type = Type.get(type_value);
-
-			if (type == Type.LHS) {
-				Expression lhr_expr = expression();
-				binaryOperation.setLhsOperand(lhr_expr);
-			} else if (type == Type.RHS) {
-				Expression rhs_expresion = expression();
-				binaryOperation.setRhsOperand(rhs_expresion);
-				break;
-			}
-		}
-
-		return binaryOperation;
-	}
-
-	/*
-	 * type RecordProjection { record_reference: Expression; field_id: Identifier;
-	 * --- Indirect reference }
-	 */
-
-	public RecordProjection recordProjection() {
-
-		RecordProjection recordProjection = new RecordProjection();
-
-		while (token.type == Type.RECORD_PROJECTION) {
-			consume(Type.RECORD_PROJECTION);
-
-			String type_value = token.sd.getName();
-			Type type = Type.get(type_value);
-
-			if (type == Type.RECORD_REF) {
-				Expression expression = expression();
-				recordProjection.setRecordReference(expression);
-			} else if (type == Type.FIELD_ID) {
-				String identifier = Identifier();
-				// consume(Type.IDENTIFIER);
-				// String identifier = token.getStringValue();
-				// consume(Type.String);
-				recordProjection.setFieldId(identifier);
-				break;
-			}
-		}
-
-		return recordProjection;
-	}
-
-	/*
-	 * type FieldDefinition { field_id: Identifier; -- Indirect reference
-	 * field_value: Expression; };
-	 */
-	public FieldDefinition fieldDefinition() {
-		FieldDefinition fieldDefinition = new FieldDefinition();
-
-		while (token.type == Type.FIELD_DEFINITION) {
-			consume(Type.FIELD_DEFINITION);
-
-			String type_value = token.sd.getName();
-			Type type = Type.get(type_value);
-
-			if (type == Type.FIELD_ID) {
-				consume(Type.IDENTIFIER);
-				String identifier = token.getStringValue();
-				consume(Type.String);
-				fieldDefinition.setFieldIdentifier(identifier);
-			} else if (type == Type.FIELD_VALUE) {
-				Expression expression = expression();
-				fieldDefinition.setFieldValue(expression);
-			}
-		}
-
-		return fieldDefinition;
-	}
-
-	/*
-	 * type RecordLiteral { record_type: Identifier; -- Indirect reference
-	 * field_definitions: ArrayList<FieldDefinition>; };
-	 */
-
-	public RecordLiteral recordLiteral() {
-
-		RecordLiteral recordLiteral = new RecordLiteral();
-		int array_length = 0;
-
-		while (token.type == Type.RECORD_LITERAL) {
-			consume(Type.RECORD_LITERAL);
-
-			if (token.type == Type.IDENTIFIER) {
-				consume(Type.IDENTIFIER);
-
-				String identifier = token.getStringValue();
-				consume(Type.String);
-				recordLiteral.setRecordType(identifier);
-
-			} else if (token.type == Type.ARRAY_LIST) {
-
-				String type_value = token.sd.getName();
-				Type type = Type.get(type_value);
-
-				if (peek().type == Type.INT) {
-
-					array_length = arrayList_length();
-
-				} else {
-
-					int element_index = arrayList_element();
-
-					// if(type.FIELD_DEFINITION == Type.FIELD_DEFINITION) {
-					FieldDefinition fieldDefinition = fieldDefinition();
-					recordLiteral.getFieldDefinition().add(element_index, fieldDefinition);
-					// }
-					if (element_index == array_length - 1) {
-						break;
-					}
-				}
-			}
-		}
-		return recordLiteral;
-	}
-
-	public ArrayList<Expression> arrayList_Expression() {
-
-		ArrayList<Expression> expressionList = new ArrayList<Expression>();
-
-		int list_length = 0;
-
-		Type type = this.token.type;
-
-		while (type == Type.ARRAY_LIST) {
-
-			consume(Type.ARRAY_LIST);
-
-			// length
-			if (this.token.type == Type.INT) {
-
-				Token token = this.token;
-				NumberLiteral enumLength_literal = (NumberLiteral) token.value;
-				list_length = enumLength_literal.getValue();
-				consume(Type.INT);
-
-				while (list_length > 0) {
-
-					// NULL:element
-					consume(Type.NULL);
-					list_length--;
-					// element Index
-					token = this.token;
-					NumberLiteral element_index = (NumberLiteral) token.value;
-					consume(Type.INT);
-
-					// //element Value : Expression
-					Expression expression = expression();
-					expressionList.add(element_index.getValue(), expression);
-				}
-			}
-		}
-
-		return expressionList;
-	}
-
-	// o.kind = OptionKind.Some &&
-	// o.value = v
-
-	// TypeDeclaration ::= TYPE_DECLARATION:Name TYPE_DECLARATION:d IDENTIFIER:Name
-	// TYPE_DECLARATION:d
-	// OPTION:Definition OPTION:mk_some DATATYPE:t DATA_TYPE_KIND:kind
-	// null:Enum
-
-	// Type Declaration ::= Type_Declaration:d Identifier:name | Type_Declaration:d
-	// definition:
-	// Option<DataType>
-	public TypeDeclaration typeDeclaration() {
-
-		TypeDeclaration typeDeclaration = new TypeDeclaration();
-		// String ID = this.token.sd.getName();
-
-		while (token.type == Type.TYPE_DECLARATION) {
-			consume(Type.TYPE_DECLARATION);
-
-			if (token.type == Type.IDENTIFIER) {
-
-				String identifier = Identifier();
-				// Renaming dot[.] in Type Declaration Identifier.
-				identifier = identifier.replace(".", "_");
-
-				typeDeclaration.setName(identifier);
-
-			} else if (token.type == Type.OPTION) {
-
-				consume(Type.OPTION);
-
-				Type type = option();
-
-				if (type == Type.SOME) {
-					// Option<DataType>
-					if (token.type == Type.DATA_TYPE) {
-						consume(Type.DATA_TYPE);
-						try {
-
-							DataType dataType = dataType();
-							typeDeclaration.setDefinition(dataType);
-						} catch (IndexOutOfBoundsException exp) {
-
-							String faulty_declaration = typeDeclaration.getName();
-
-							System.out.println("Forward references in datatype declaration is not supported.");
-
-							if (faulty_declaration != null) {
-								faulty_declaration = faulty_declaration.replace("_", ".");
-								System.out.println("Please fix " + faulty_declaration);
-							}
-
-							System.exit(-1);
-
-						}
-					}
-				} else {
-					// System.out.println("Found Data Type with No
-					// Definition!!!!!!!!!!!");
-				}
-			}
-		}
-
-		return typeDeclaration;
-	}
-
-	public TypeDeclaration getTypeDeclaration() {
-
-		TypeDeclaration typeDeclaration = null;
-		// consume(Type.COMPONENT_TYPE);
-		consume(Type.MODEL);
-
-		int typeDeclaration_index = arrayList_element();
-
-//		try {
-		typeDeclaration = typeDeclarations.get(typeDeclaration_index);
-//		} catch (IndexOutOfBoundsException exp) {
-//			System.out.println("Forward reference in datatype declaration is not supported!");
-//			System.exit(-1);
-//		}
-
-		return typeDeclaration;
-	}
-
-	/*
-	 * type ArrayList<T> { length: Int; element: T[length]; };
-	 */
-	public int arrayList_length() {
-
-		int list_length = 0;
-		Type type = this.token.type;
-
-		if (type == Type.ARRAY_LIST) {
-			consume(Type.ARRAY_LIST);
-			// length
-			if (this.token.type == Type.INT) {
-				consume(Type.INT);
-
-				Token token = this.token;
-				NumberLiteral enumLength_literal = (NumberLiteral) token.value;
-				list_length = enumLength_literal.getValue();
-				consume(Type.Int);
-			}
-		}
-
-		return list_length;
-	}
-
-	// name: Identifier;
-	// dtype: DataType;
-	// definition: Option<Expression>;
-
-	public ConstantDeclaration constantDeclaration() {
-
-		ConstantDeclaration constantDeclaration = new ConstantDeclaration();
-		DataType dataType = null;
-		// String ID = this.token.sd.getName();
-		// constantDeclaration.setId(ID);
-
-		while (token.type == Type.CONSTANT_DECLARATION) {
-
-			consume(Type.CONSTANT_DECLARATION);
-
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
-				constantDeclaration.setName(identifier);
-			} else if (token.type == Type.DATA_TYPE) {
-
-				consume(Type.DATA_TYPE);
-
-				if (token.type == Type.DATA_TYPE) {
-					// consume(Type.DATA_TYPE);
-					dataType = dataType();
-
-				} else if (token.type == Type.MODEL) {
-					TypeDeclaration typeDeclaration = getTypeDeclaration();
-					dataType = new DataType();
-					dataType.setUserDefinedType(typeDeclaration.getName());
-				}
-
-				// DataType dataType_value = dataType();
-				constantDeclaration.setDataType(dataType);
-			} else if (token.type == Type.OPTION) {
-				consume(Type.OPTION);
-
-				Type type = option();
-
-				if (type == Type.SOME) {
-					Expression expression = expression();
-					constantDeclaration.setDefinition(expression);
-				}
-				// skip None
-			}
-		}
-
-		return constantDeclaration;
-	}
-
-	/*
-	 * type VariableDeclaration { name: Identifier; dtype: DataType; };
-	 */
-	public VariableDeclaration variableDeclaration() {
-
-		VariableDeclaration variableDeclaration = new VariableDeclaration();
-		DataType dataType = null;
-
-		while (token.type == Type.VARIABLE_DECLARATION) {
-
-			consume(Type.VARIABLE_DECLARATION);
-
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
-				variableDeclaration.setName(identifier);
-			} else if (token.type == Type.DATA_TYPE) {
-
-				consume(Type.DATA_TYPE);
-
-				if (token.type == Type.DATA_TYPE) {
-					// consume(Type.DATA_TYPE);
-					dataType = dataType();
-
-				} else if (token.type == Type.MODEL) {
-					TypeDeclaration typeDeclaration = getTypeDeclaration();
-					dataType = new DataType();
-					dataType.setUserDefinedType(typeDeclaration.getName());
-				}
-
-				// DataType dataType_value = dataType();
-				variableDeclaration.setDataType(dataType);
-			}
-		}
-
-		return variableDeclaration;
-	}
-
-	// type Port {
-	// name: Identifier;
-	// mode: PortMode;
-	// is_event: Bool;
-	// ptype: Option<DataType>;
-	// probe: Bool;
-	// };
-
-	public Port port(String componentID) {
-
-		Port port = new Port();
-
-		// String ID = this.token.sd.getName();
-		// port.setId(ID);
-
-		while (token.type == Type.PORT) {
-
-			consume(Type.PORT);
-
-			if (token.type == Type.IDENTIFIER) {
-
-				String identifier = Identifier();
-				port.setName(identifier);
-				port.setId(componentID + "." + identifier);
-
-			} else if (token.type == Type.PORT_MODE) {
-				PortMode portMode = portMode();
-				port.setMode(portMode);
-			} else if (token.type == Type.BOOL) {
-
-				// consume(Type.BOOL);
-
-				String type_value = this.token.sd.getName();
-				Type type = Type.get(type_value);
-
-				if (type == Type.PROBE) {
-					consume(Type.PROBE);
-
-					boolean is_probe = token.getTruthValue();
-
-					port.setProbe(is_probe);
-					consume(Type.Boolean);
-
-				} else if (type == Type.IS_EVENT) {
-					consume(Type.IS_EVENT);
-
-					boolean is_event = token.getTruthValue();
-
-					port.setEvent(is_event);
-					consume(Type.Boolean);
-				}
-
-			} else if (token.type == Type.OPTION) {
-				consume(Type.OPTION);
-
-				Type type = option();
-				// SOME
-				if (type == Type.SOME) {
-					DataType dataType = null;
-
-					if (token.type == Type.MODEL) {
-						TypeDeclaration typeDeclaration = getTypeDeclaration();
-						dataType = new DataType();
-						dataType.setUserDefinedType(typeDeclaration.getName());
-					} else if (token.type == Type.DATA_TYPE) {
-						dataType = dataType();
-					}
-					port.setType(dataType);
-				}
-				// Skip None
-			}
-		}
-
-		return port;
-	}
-
-	// type GenericAttribute {
-	// name: String;
-	// atype: AttributeType;
-	// value: String;
-	// };
-
-	public GenericAttribute genericAttribute() {
-
-		GenericAttribute gAttribute = new GenericAttribute();
-
-		// String ID = this.token.sd.getName();
-		// port.setId(ID);
-
-		while (token.type == Type.GENERIC_ATTRIBUTE) {
-
-			consume(Type.GENERIC_ATTRIBUTE);
-
-			if (token.type == Type.STRING) {
-
-				String type_value = this.token.sd.getName();
-				Type type = Type.get(type_value);
-
-				if (type == Type.NAME) {
-					consume(Type.NAME);
-
-					String identifier = token.getStringValue();
-					gAttribute.setName(identifier);
-
-					consume(Type.String);
-
-				} else if (type == Type.VALUE) {
-					consume(Type.VALUE);
-
-					String value = token.getStringValue();
-					gAttribute.setValue(value);
-
-					consume(Type.String);
-				}
-
-			} else if (token.type == Type.ATTRIBUTE_TYPE) {
-				QName attributeType = attributeType();
-				gAttribute.setType(attributeType);
-			}
-		}
-
-		return gAttribute;
-	}
-
-	// Array_List ::= ARRAY_LIST:<T> INT:length Int:value |
-	// ARRAY_LIST:<T> NULL:element Int:index T:value
-
-	public int arrayList_element() {
-
-		int e_index = -1;
-
-		// ComponentTypes
-		consume(Type.ARRAY_LIST);
-
-		// NULL:element
-		consume();
-
-		// element Index
-		// token = this.token;
-		NumberLiteral element_index = (NumberLiteral) token.value;
-		e_index = element_index.getValue();
-		consume(Type.Int);
-
-		// Port port = port(component_ID);
-		// portList.add(, port);
-
-		return e_index;
-	}
-
-	/** type PortMode enum { In, Out }; */
-	public PortMode portMode() {
-
-		PortMode portMode = null;
-
-		Type type = token.type;
-		consume(Type.PORT_MODE);
-		// Enum
-		String type_value = this.token.sd.getName();
-		type = Type.get(type_value);
-
-		if (type == Type.IN) {
-			portMode = PortMode.valueOf("IN");
-			consume();
-
-		} else if (type == Type.OUT) {
-
-			portMode = PortMode.valueOf("OUT");
-			consume();
-		}
-
-		return portMode;
-	}
-
-	/** type AttributeType enum {Int, Real, Bool, String}; */
-	public QName attributeType() {
-
-		QName attributeType = null;
-
-		Type type = token.type;
-		consume(Type.ATTRIBUTE_TYPE);
-		// Enum
-		// String type_value = this.token.type;
-		type = this.token.type;
-
-		if (type == Type.INT) {
-			attributeType = new QName("Int");
-			consume();
-		} else if (type == Type.BOOL) {
-			attributeType = new QName("Bool");
-			consume();
-		} else if (type == Type.REAL) {
-			attributeType = new QName("Real");
-			consume();
-		} else if (type == Type.STRING) {
-			attributeType = new QName("String");
-			consume();
-		}
-
-		return attributeType;
-	}
-
-	/*
-	 *
-	 * type ContractSpec { constant_declarations: ArrayList<SymbolDefinition>;
-	 * variable_declarations: ArrayList<SymbolDefinition>; assumes:
-	 * ArrayList<ContractItem>; guarantees: ArrayList<ContractItem>; modes:
-	 * ArrayList<ContractMode>; imports: ArrayList<ContractImport>; };
-	 */
-	public ContractSpec contractSpec() {
-
-		ContractSpec contractSpec = new ContractSpec();
-		int array_length = 0;
-		// String ID = this.token.sd.getName();
-		// contractSpec.setId(ID);
-
-		while (this.token.type == Type.CONTRACT_SPEC) {
-
-			consume(Type.CONTRACT_SPEC);
-
-			if (token.type == Type.ARRAY_LIST) {
-
-				String type_value = this.token.sd.getName();
-				Type type = Type.get(type_value);
-
-				if (peek().type == Type.INT) {
-					array_length = arrayList_length();
-				} else {
-
-					if (type == Type.CONSTANT_DECLARATIONS) {
-						int constantDeclaration_index = arrayList_element();
-
-						SymbolDefinition symbolDefinition = symbolDefinition();
-						contractSpec.getSymbol().add(constantDeclaration_index, symbolDefinition);
-					} else if (type == Type.VARIABLE_DECLARATIONS) {
-						int variableDeclaration_index = arrayList_element();
-
-						SymbolDefinition symbolDefinition = symbolDefinition();
-						contractSpec.getSymbol().add(variableDeclaration_index, symbolDefinition);
-
-					} else if (type == Type.ASSUMES) {
-						int assume_index = arrayList_element();
-						ContractItem contractItem = contractItem();
-						contractSpec.getAssume().add(assume_index, contractItem);
-					} else if (type == Type.GURANTEES) {
-						int gurantee_index = arrayList_element();
-						ContractItem contractItem = contractItem();
-						// LOGGER.info(
-						// "guarantees - ["
-						// + gurantee_index
-						// + "] = "
-						// + contractItem.getName());
-						contractSpec.getGuarantee().add(gurantee_index, contractItem);
-
-					} else if (type == Type.MODES) {
-						int mode_index = arrayList_element();
-
-						// ContractMode contractMode = contractMode();
-						// contractSpec.getMode().add(mode_index,
-						// contractMode);
-
-					} else if (type == Type.IMPORTS) {
-						int import_index = arrayList_element();
-
-						ContractImport contractImport = contractImport();
-						contractSpec.getImport().add(import_index, contractImport);
-					}
-				}
-			}
-		}
-
-		return contractSpec;
-	}
-
-	/*
-	 * type ContractImport { contract: Contract; input_arguments:
-	 * ArrayList<Expression>; input_arguments: ArrayList<Expression>; }
-	 */
-	public ContractImport contractImport() {
-
-		ContractImport contractImport = new ContractImport();
-
-		// String ID = this.token.sd.getName();
-		// contractImport.setId(ID);
-
-		Type type = this.token.type;
-
-		while (type == Type.CONTRACT_IMPORT) {
-			consume(Type.CONTRACT_IMPORT);
-
-			String type_value = this.token.sd.getName();
-			type = Type.get(type_value);
-
-			if (type == Type.CONTRACT) {
-				Contract contract = contract();
-				// contractImport.setContractId(contract);
-			} else if (type == Type.INPUT_ARGUMENTS) {
-				ArrayList<Expression> input_arguments = arrayList_Expression();
-
-			} else if (type == Type.OUTPUT_ARGUMENTS) {
-				ArrayList<Expression> output_arguments = arrayList_Expression();
-			}
-		}
-
-		return contractImport;
-	}
-
-	/*
-	 * type Contract { name: Identifier; input_paramenters:
-	 * ArrayList<NodeParameter>; output_paramenters: ArrayList<NodeParameter>;
-	 * specification: ContractSpec; };
-	 */
-	public Contract contract() {
-
-		Contract contract = new Contract();
-
-		String ID = this.token.sd.getName();
-		// contract.setId(ID);
-
-		while (this.token.type == Type.CONTRACT) {
-
-			consume(Type.CONTRACT);
-
-			String type_value = this.token.sd.getName();
-			Type type = Type.get(type_value);
-
-			if (type == Type.IDENTIFIER) {
-				String identifier = Identifier();
-				contract.setName(identifier);
-			} else if (type == Type.INPUT_NODE_PARAMETER) {
-				// ArrayList<NodeParameter> input_parameters = nodeParameter();
-				// contract.getInputParamater().addAll(input_parameters);
-			} else if (type == Type.OUTPUT_NODE_PARAMETER) {
-				// ArrayList<NodeParameter> output_parameters = nodeParameter();
-				// contract.getInputParamater().addAll(output_parameters);
-			} else if (type == Type.CONTRACT_SPEC) {
-				ContractSpec specification = contractSpec();
-				contract.getSpecification().add(specification);
-			}
-		}
-
-		return contract;
-	}
-
-	/*
-	 * type ContractItem { name: Option<Identifier>; expression: Expression; }
-	 */
-	public ContractItem contractItem() {
-
-		ContractItem contractItem = new ContractItem();
-
-		// String ID = this.token.sd.getName();
-
-		while (this.token.type == Type.CONTRACT_ITEM) {
-			consume(Type.CONTRACT_ITEM);
-
-			if (this.token.type == Type.OPTION) {
-				consume(Type.OPTION);
-
-				Type type = option();
-
-				if (type == Type.SOME) {
-					String identifier = token.getStringValue();
-					contractItem.setName(identifier);
-					consume(Type.String);
-					// LOGGER.info("Contract ITEM: " + identifier);
-				}
-			} else if (this.token.type == Type.EXPRESSION) {
-				Expression expression = expression();
-				contractItem.setExpression(expression);
-			}
-		}
-
-		return contractItem;
-	}
-
-	/*
-	 * type SymbolDefinition { name: Identifier; is_constant: Bool; dtype: DataType;
-	 * definition: Expression; };
-	 */
-	public SymbolDefinition symbolDefinition() {
-
-		SymbolDefinition symbolDefinition = new SymbolDefinition();
-		DataType dataType = null;
-
-		String ID = this.token.sd.getName();
-		// symbolDefinition.setId(ID);
-
-		while (this.token.type == Type.SYMBOL_DEFINITION) {
-
-			consume(Type.SYMBOL_DEFINITION);
-
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
-				symbolDefinition.setName(identifier);
-			} else if (token.type == Type.DATA_TYPE) {
-
-				consume(Type.DATA_TYPE);
-
-				if (token.type == Type.DATA_TYPE) {
-					// consume(Type.DATA_TYPE);
-					dataType = dataType();
-					symbolDefinition.setDataType(dataType);
-
-				} else if (token.type == Type.MODEL) {
-					TypeDeclaration typeDeclaration = getTypeDeclaration();
-					dataType = new DataType();
-					dataType.setUserDefinedType(typeDeclaration.getName());
-				}
-
-				// DataType dataType_value = dataType();
-				symbolDefinition.setDataType(dataType);
-			} else if (token.type == Type.BOOL) {
-				consume(Type.BOOL);
-
-				boolean value = token.getTruthValue();
-				consume(Type.Boolean);
-				// DATA this field into VDM Lustre in NodeParameter.
-				symbolDefinition.setIsConstant(truthValue());
-			} else if (token.type == Type.EXPRESSION) {
-				Expression expression = expression();
-				symbolDefinition.setDefinition(expression);
-			}
-		}
-
-		return symbolDefinition;
-	}
-
-	/** True or False */
-	public boolean truthValue() {
-
-		boolean flag = false;
-
-		TruthValue truthValue = (TruthValue) this.token.value;
-		consume(Type.Boolean);
-
-		if (truthValue.isTRUE()) {
-			flag = true;
-		}
-
-		return flag;
-	}
-
-	/*
-	 * name: Identifier; ports: ArrayList<Port>; contract: Option<ContractSpec>;
-	 * cyber_relations: ArrayList<CyberRel>;
-	 *
-	 */
-	// type ComponentType {
-	// name: Identifier;
-	// ports: ArrayList<Port>;
-	// compCateg: Option<String>;
-	// contract: Option<ContractSpec>;
-	// cyber_relations: ArrayList<CyberRel>;
-	// safety_relations: ArrayList<SafetyRel>;
-	// safety_events: ArrayList<SafetyEvent>;
-	// };
-	public ComponentType componentType() {
-
-		ComponentType componentType = new ComponentType();
-		List<Port> ports = componentType.getPort();
-		List<CyberRel> cyber_relations = componentType.getCyberRel();
-		List<SafetyRel> safety_relations = componentType.getSafetyRel();
-		List<Event> events = componentType.getEvent();
-
-		int list_size = 0;
-		Type type;
-
-		// @TODO: Check ID.
-		// String ID = token.sd.getName();
-		//
-
-		while (token.type == Type.COMPONENT_TYPE) {
-
-			consume(Type.COMPONENT_TYPE);
-
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
-				componentType.setName(identifier);
-				componentType.setId(identifier);
-				// LOGGER.info("COMPONENT TYPE: >>>>>>>>>>>" + identifier);
-			}
-			// PORT ARRAY LIST.
-			else if (token.type == Type.ARRAY_LIST) {
-
-				String type_name = this.token.sd.getName();
-				type = Type.get(type_name);
-
-				if (peek().type == Type.INT) {
-
-					list_size = arrayList_length();
-
-				} else {
-
-					if (type == Type.PORTS) {
-						int port_index = arrayList_element();
-						Port port = port(componentType.getId());
-						ports.add(port_index, port);
-						// LOGGER.info("["+ port_index + "," + port.getName()+"]");
-					} else if (type == Type.CYBER_RELATIONS) {
-						log("cyber_rel" + token);
-						int rel_index = arrayList_element();
-
-						CyberRel cyberRel = cyber_rel();
-						cyber_relations.add(rel_index, cyberRel);
-					} else if (type == Type.SAFETY_RELATIONS) {
-						log("safety_rel: " + token);
-						int rel_index = arrayList_element();
-
-						SafetyRel safetyRel = safety_rel();
-						safety_relations.add(rel_index, safetyRel);
-					} else if (type == Type.SAFETY_EVENTS) {
-						log("safety event: " + token);
-						int event_index = arrayList_element();
-
-						Event event = safetyevent();
-						events.add(event_index, event);
-					}
-				}
-				// Confirm length of ports match with elements.
-			} else if (token.type == Type.OPTION) {
-
-				consume(Type.OPTION);
-
-				type = option();
-				// Some
-				if (type == Type.SOME) {
-
-					if (token.type == Type.CONTRACT_SPEC) {
-						ContractSpec contract = contractSpec();
-						componentType.setContract(contract);
-					} else if (token.type == Type.String) {
-						String categ = token.getStringValue();
-						componentType.setCompCateg(categ);
-						consume(Type.String);
-					}
-				}
-				// Skip None
-			}
-		}
-
-		return componentType;
-	}
-
-	/*
-	 * type CyberExpr { kind: CyberExprKind; port: CIAPort; and:
-	 * ArrayList<CyberExpr>; or: ArrayList<CyberExpr>; not: CyberExpr; };
-	 */
-
-	public CyberExpr cyberExpr() {
-
-		CyberExpr cyberExpr = new CyberExpr();
-		CyberExprKind kind = null;
-
-		while (this.token.type == Type.CYBER_EXP) {
-
-			consume(Type.CYBER_EXP);
-
-			if (token.type == Type.CIA_PORT) {
-
-				CIAPort ciaPort = cia_port();
-				cyberExpr.setPort(ciaPort);
-			}
-			if (token.type == Type.CYBER_EXP_KIND) {
-				kind = cyberExprKind();
-			}
-
-			if (kind == CyberExprKind.NOT) {
-				CyberExpr not_expr = new CyberExpr();
-				not_expr.setNot(not_expr);
-				return not_expr;
-			}
-
-			if (kind == CyberExprKind.OR) {
-
-				CyberExprList or_exprs = cyberExprList();
-				cyberExpr.setOr(or_exprs);
-			}
-			if (kind == CyberExprKind.AND) {
-
-				CyberExprList and_exprs = cyberExprList();
-				cyberExpr.setAnd(and_exprs);
-			}
-			if (kind == CyberExprKind.PORT) {
-				return cyberExpr();
-				// CIAPort ciaPort = cia_port();
-				// cyberExpr.setPort(ciaPort);
-			}
-
-			//
-			// return cyberExprList;
-
-		}
-
-		return cyberExpr;
-	}
-
-	public CyberExprList cyberExprList() {
-
-		CyberExprList cyberExprList = new CyberExprList();
-
-		int array_length = 0;
-
-		while (this.token.type == Type.CYBER_EXP) {
-
-			consume(Type.CYBER_EXP);
-			if (token.type == Type.ARRAY_LIST) {
-
-				// String type_value = token.sd.getName();
-				// Type type = Type.get(type_value);
-
-				if (peek().type == Type.INT) {
-
-					array_length = arrayList_length();
-
-				} else {
-
-					while (array_length > 0) {
-
-						array_length--;
-
-						int element_index = arrayList_element();
-
-						CyberExpr expr = cyberExpr();
-						cyberExprList.getExpr().add(element_index, expr);
-					}
-				}
-			}
-		}
-
-		return cyberExprList;
-	}
-
-	/** Handle safety requirement expressions */
-	public SafetyReqExpr safetyReqExpr() {
-
-		SafetyReqExpr safetyReqExpr = new SafetyReqExpr();
-		SafetyReqExprKind kind = null;
-
-		while (this.token.type == Type.SAFETY_EXP) {
-
-			consume(Type.SAFETY_EXP);
-
-			if (token.type == Type.IA_PORT) {
-
-				IAPort iaPort = ia_port();
-				safetyReqExpr.setPort(iaPort);
-			}
-			if (token.type == Type.SAFETY_EXP_KIND) {
-				kind = safetyReqExprKind();
-			}
-			if (kind == SafetyReqExprKind.NOT) {
-				SafetyReqExpr not_expr = new SafetyReqExpr();
-				not_expr.setNot(not_expr);
-				return not_expr;
-			}
-			if (kind == SafetyReqExprKind.OR) {
-
-				SafetyReqExprList or_exprs = safetyReqExprList();
-				safetyReqExpr.setOr(or_exprs);
-			}
-			if (kind == SafetyReqExprKind.AND) {
-
-				SafetyReqExprList and_exprs = safetyReqExprList();
-				safetyReqExpr.setAnd(and_exprs);
-			}
-			if (kind == SafetyReqExprKind.PORT) {
-				return safetyReqExpr();
-			}
-		}
-
-		return safetyReqExpr;
-	}
-
-	public SafetyReqExprList safetyReqExprList() {
-
-		SafetyReqExprList safetyReqExprList = new SafetyReqExprList();
-
-		int array_length = 0;
-
-		while (this.token.type == Type.SAFETY_EXP) {
-
-			consume(Type.SAFETY_EXP);
-			if (token.type == Type.ARRAY_LIST) {
-				if (peek().type == Type.INT) {
-					array_length = arrayList_length();
-				} else {
-
-					while (array_length > 0) {
-
-						array_length--;
-
-						int element_index = arrayList_element();
-						SafetyReqExpr reqExpr = safetyReqExpr();
-						safetyReqExprList.getExpr().add(element_index, reqExpr);
-					}
-				}
-			}
-		}
-
-		return safetyReqExprList;
-	}
-
-	// type SafetyRel {
-	// id: String;
-	// output: IAPort;
-	// faultSrc: Option<SafetyExpr>;
-	// comment: Option<String>;
-	// description : Option<String>;
-	// };
-
-	/** Handle safety relations */
-	public SafetyRel safety_rel() {
-
-		SafetyRel safetyRel = new SafetyRel();
-
-		while (this.token.type == Type.SAFETY_REL) {
-
-			consume(Type.SAFETY_REL);
-
-			if (token.type == Type.STRING) {
-
-				String identifier = id_value();
-				log("safety_rel id = " + identifier);
-				safetyRel.setId(identifier);
-
-			} else if (token.type == Type.IA_PORT) {
-
-				IAPort iaPort = ia_port();
-				safetyRel.setOutput(iaPort);
-			} else if (token.type == Type.OPTION) {
-
-				String type_value = token.sd.getName();
-				Type type = Type.get(type_value);
-				consume(Type.OPTION);
-
-				log("safety rel type_value = " + type_value);
-
-				if (type == Type.FAULTSRC) {
-					SafetyRelExpr expr_value = safetyRelExpr();
-					safetyRel.setFaultSrc(expr_value);
-
-				} else if (type == Type.COMMENT) {
-
-					String comment = str_value();
-					log("safety rel comment = " + comment);
-					safetyRel.setComment(comment);
-
-				} else if (type == Type.DESCRIPTION) {
-
-					String description = str_value();
-					safetyRel.setDescription(description);
-
-				} else if (type == Type.PHASES) {
-
-					String phases = str_value();
-					safetyRel.setPhases(phases);
-
-				} else if (type == Type.EXTERN) {
-
-					String extern = str_value();
-					safetyRel.setExtern(extern);
-				}
-			}
-		}
-
-		return safetyRel;
-	}
-
-	// type SafetyExpr {
-	// kind: SafetyExprKind;
-	// port: IAPort;
-	// fault: String;
-	// and: ArrayList<SafetyExpr>;
-	// or: ArrayList<SafetyExpr>;
-	// not: SafetyExpr;
-	// };
-	public SafetyRelExpr safetyRelExpr() {
-
-		SafetyRelExpr safetyRelExpr = new SafetyRelExpr();
-		SafetyRelExprKind kind = null;
-
-		// Check length bound and terminate.
-		int array_length = 0;
-
-		while (this.token.type == Type.SAFETY_EXP) {
-
-			consume(Type.SAFETY_EXP);
-
-			if (token.type == Type.IA_PORT) {
-
-				IAPort iaPort = ia_port();
-				safetyRelExpr.setPort(iaPort);
-			}
-			if (token.type == Type.SAFETY_EXP_KIND) {
-				kind = safetyRelExprKind();
-			}
-			if (kind == SafetyRelExprKind.NOT) {
-				SafetyRelExpr not_expr = new SafetyRelExpr();
-				not_expr.setNot(not_expr);
-				return not_expr;
-			}
-			if (kind == SafetyRelExprKind.OR) {
-
-				SafetyRelExprList or_exprs = safetyRelExprList();
-				safetyRelExpr.setOr(or_exprs);
-			}
-			if (kind == SafetyRelExprKind.AND) {
-
-				SafetyRelExprList and_exprs = safetyRelExprList();
-				safetyRelExpr.setAnd(and_exprs);
-			}
-			if (kind == SafetyRelExprKind.PORT) {
-				return safetyRelExpr();
-			}
-			if (kind == SafetyRelExprKind.FAULT) {
-
-				EventHappens event = eventHappens();
-				safetyRelExpr.setFault(event);
-				safetyRelExpr();
-			}
-		}
-
-		return safetyRelExpr;
-	}
-
-	public SafetyRelExprList safetyRelExprList() {
-
-		SafetyRelExprList safetyRelExprList = new SafetyRelExprList();
-
-		int array_length = 0;
-
-		while (this.token.type == Type.SAFETY_EXP) {
-
-			consume(Type.SAFETY_EXP);
-			if (token.type == Type.ARRAY_LIST) {
-				if (peek().type == Type.INT) {
-					array_length = arrayList_length();
-				} else {
-
-					while (array_length > 0) {
-
-						array_length--;
-
-						int element_index = arrayList_element();
-						SafetyRelExpr relExpr = safetyRelExpr();
-						safetyRelExprList.getExpr().add(element_index, relExpr);
-					}
-				}
-			}
-		}
-
-		return safetyRelExprList;
-	}
-
-	/*
-	 * type CyberRel { id : String; output : CIAPort; inputs : Option<CyberExpr>;
-	 * comment: Option<String>; description : Option<String>; phases :
-	 * Option<String>; extern : Option<String>; };
-	 */
-	public CyberRel cyber_rel() {
-
-		CyberRel cyberRel = new CyberRel();
-
-		while (this.token.type == Type.CYB_REL) {
-
-			consume(Type.CYB_REL);
-
-			if (token.type == Type.STRING) {
-
-				String identifier = id_value();
-				cyberRel.setId(identifier);
-
-			} else if (token.type == Type.CIA_PORT) {
-
-				CIAPort ciaPort = cia_port();
-				cyberRel.setOutput(ciaPort);
-
-			} else if (token.type == Type.OPTION) {
-
-				String type_value = token.sd.getName();
-				Type type = Type.get(type_value);
-				consume(Type.OPTION);
-
-				if (type == Type.INPUTS) {
-					CyberExpr expr_value = cyberExpr();
-					cyberRel.setInputs(expr_value);
-
-				} else if (type == Type.COMMENT) {
-
-					String comment = str_value();
-					cyberRel.setComment(comment);
-
-				} else if (type == Type.DESCRIPTION) {
-
-					String description = str_value();
-					cyberRel.setDescription(description);
-
-				} else if (type == Type.PHASES) {
-
-					String phases = str_value();
-					cyberRel.setPhases(phases);
-
-				} else if (type == Type.EXTERN) {
-
-					String extern = str_value();
-					cyberRel.setExtern(extern);
-				}
-			}
-		}
-
-		return cyberRel;
-	}
-
-	// IDENTIFIER ::= IDENTIFIER:name String:value
-	// Return a String.
-	public String id_value() {
-
-		String identifier_name;
-		String identifier_value;
-
-		identifier_name = token.sd.getName();
-		consume(Type.STRING);
+    private Model model;
+
+    private List<TypeDeclaration> typeDeclarations;
+    private List<ComponentType> componentTypes;
+    private List<ComponentImpl> componentImpls;
+    private List<CyberReq> cyberRequirements;
+    private List<SafetyReq> safetyRequirements;
+    private List<Mission> missions;
+
+    private ComponentImpl componentImpl;
+    private BlockImpl blockImpl;
+
+    public VDMParser(ArrayList<Token> tokens) {
+        super(tokens);
+        model = new Model();
+        typeDeclarations = model.getTypeDeclaration();
+        componentTypes = model.getComponentType();
+        componentImpls = model.getComponentImpl();
+        cyberRequirements = model.getCyberReq();
+        safetyRequirements = model.getSafetyReq();
+        missions = model.getMission();
+    }
+
+    private void log(String msg) {
+        // System.out.println(msg);
+    }
+
+    // Project Rules:
+
+    // IDENTIFIER ::= IDENTIFIER:name String:value
+    // Return a String.
+    public String Identifier() {
+
+        String identifier_name;
+        String identifier_value;
+
+        identifier_name = token.sd.getName();
+        consume(Type.IDENTIFIER);
+
+        identifier_value = token.getStringValue();
+        consume(Type.String);
+
+        // LOGGER.info(identifier_name + " := " + identifier_value);
+
+        return identifier_value;
+    }
+
+    // DATATYPE ::= {DATA_TYPE:t}* {DATA_TYPE_KIND, kind}
+    // NULL: Plain | NULL:Enum | NULL:Subrange | NULL:ArrayType | NULL:TupleType |
+    // NULL:RecordType
+    // | NULL: UserDefinedType
+    // DATATYPE ::= {DATA_TYPE:t} NULL:Plain_Type | NULL:Enum |
+    // SUB_RANGE_TYPE:subrange | ArrayType
+    // | TupleType | RecordType | UserDefinedType
+    /*
+     * type DataType { kind: DataTypeKind; plain_type: PlainType; subrange_type:
+     * SubrangeType; enum_type: EnumType; record_type: RecordType;
+     * user_defined_type: TypeDeclaration; };
+     */
+    public DataType dataType() {
+
+        DataType dataType = new DataType();
+        Type type = null;
+
+        while (token.type == Type.DATA_TYPE) {
+            consume(Type.DATA_TYPE);
+
+            String type_name = token.sd.getName();
+            type = Type.get(type_name);
+
+            // Token token = this.token;
+            if (token.type == Type.DATA_TYPE_KIND) {
+                type = getDataTypeKind();
+
+                if (type == Type.ENUM) {
+                    EnumType enumType = enumType();
+                    dataType.setEnumType(enumType);
+                } else if (type == Type.RECORD) {
+                    RecordType recordType = recordType();
+                    dataType.setRecordType(recordType);
+                } else if (type == Type.SUBRANGE) {
+                    // dataType.setSubrangeType(value);
+                } else if (type == Type.PLAIN) {
+                    PlainType plainType = plainType();
+                    dataType.setPlainType(plainType);
+                    break;
+                } else if (type == Type.USERDEFINED) {
+                    dataType = getUserDefinedType();
+                    break;
+                    // dataType.setUserDefinedType(type_value);
+                }
+            }
+        }
+
+        return dataType;
+    }
+
+    // type DataTypeKind enum { Plain, Subrange, Enum, Record, UserDefined };
+    public Type getDataTypeKind() {
+
+        consume(Type.DATA_TYPE_KIND);
+
+        String type_name = token.sd.getName();
+        Type type = Type.get(type_name);
+
+        if (type == Type.ENUM) {
+            consume(Type.ENUM);
+        } else if (type == Type.SUBRANGE) {
+            consume(Type.SUBRANGE);
+        } else if (type == Type.PLAIN) {
+            consume(Type.PLAIN);
+        } else if (type == Type.RECORD) {
+            consume(Type.RECORD);
+        } else if (type == Type.USERDEFINED) {
+            consume(Type.USERDEFINED);
+        }
+
+        return type;
+    }
+
+    /*
+     * BoolType: DataType := some(d: DataType) { d.kind = DataTypeKind.Plain &&
+     * d.plain_type = PlainType.Bool };
+     *
+     *
+     * RealType: DataType := some(d: DataType) { d.kind = DataTypeKind.Plain &&
+     * d.plain_type = PlainType.Real };
+     *
+     * IntegerType: DataType := some(d: DataType) { d.kind = DataTypeKind.Plain &&
+     * d.plain_type = PlainType.Int };
+     *
+     */
+
+    public DataType recordDataType() {
+
+        DataType recordDataType = new DataType();
+
+        while (token.type == Type.DATA_TYPE) {
+
+            consume(Type.DATA_TYPE);
+
+            String type_value = token.sd.getName();
+            Type type = Type.get(type_value);
+
+            if (type == Type.INTEGER_TYPE) {
+                consume(Type.INTEGER_TYPE);
+                recordDataType = dataType();
+            }
+            // Token token = this.token;
+            if (token.type == Type.DATA_TYPE_KIND) {
+                type = getDataTypeKind();
+                //
+                // if(type == Type.PLAIN) {
+                // plainType();
+                // } else {
+                // System.out.println("Error in IntegerType");
+                // }
+                if (type == Type.PLAIN) {
+                    PlainType plainType = plainType();
+                    recordDataType.setPlainType(plainType);
+                    // break;
+                }
+            } else if (token.type == Type.MODEL) {
+                TypeDeclaration typeDeclaration = getTypeDeclaration();
+                recordDataType.setUserDefinedType(typeDeclaration.getName());
+            }
+        }
+
+        return recordDataType;
+    }
+
+    // type PlainType enum { Int, Real, Bool };
+    public PlainType plainType() {
+
+        PlainType plainType = null;
+
+        // while(token.type == Type.DATA_TYPE) {
+
+        consume(Type.DATA_TYPE);
+
+        if (token.type == Type.PLAIN_TYPE) {
+            consume(Type.PLAIN_TYPE);
+
+            String type_value = token.sd.getName();
+            Type type = Type.get(type_value);
+            consume(type);
+
+            if (type == Type.INT) {
+                plainType = PlainType.valueOf("INT");
+            } else if (type == Type.REAL) {
+                plainType = PlainType.valueOf("REAL");
+            } else if (type == Type.BOOL) {
+                plainType = PlainType.valueOf("BOOL");
+            }
+        }
+        // }
+
+        return plainType;
+    }
+
+    // ENUM ::== ENUM*
+    // ENUM ::= {DATA_TYPE:t}* ENUM_TYPE:enum_type INT:length Int:value
+    // | ({DATATYPE:t} ENUMTYPE:enum_type NULL:element Int:index String:value (Bound
+    // by
+    // length)
+    //
+
+    // type EnumType is ArrayList<Identifier>;
+    public EnumType enumType() {
+
+        EnumType enumType = new EnumType();
+
+        int enum_length = 0;
+
+        while (token.type == Type.DATA_TYPE) {
+
+            consume(Type.DATA_TYPE);
+
+            if (token.type == Type.ENUM_TYPE) {
+                consume(Type.ENUM_TYPE);
+
+                if (token.type == Type.INT) {
+                    // length
+                    consume(Type.INT);
+                    enum_length = token.getNumberValue();
+                    // value
+                    consume(Type.Int);
+
+                } else {
+                    // enum
+                    consume();
+                    int enum_index = token.getNumberValue();
+                    // index
+                    consume(Type.Int);
+
+                    String enum_value = token.getStringValue();
+                    consume(Type.String);
+                    enumType.getEnumValue().add(enum_index, enum_value);
+                }
+            }
+        }
+
+        return enumType;
+    }
+
+    // type RecordType is ArrayList<RecordField>;
+    public RecordType recordType() {
+
+        RecordType recordType = new RecordType();
+
+        int enum_length = 0;
+
+        while (token.type == Type.DATA_TYPE) {
+
+            consume(Type.DATA_TYPE);
+
+            if (token.type == Type.RECORDTYPE) {
+                consume(Type.RECORDTYPE);
+
+                if (token.type == Type.INT) {
+                    // length
+                    consume(Type.INT);
+                    enum_length = token.getNumberValue();
+                    // value
+                    consume(Type.Int);
+
+                } else {
+                    // enum
+                    consume();
+                    int rf_index = token.getNumberValue();
+                    // index
+                    consume(Type.Int);
+                    // RecordField.
+                    RecordField rf = recordField();
+                    recordType.getRecordField().add(rf_index, rf);
+                }
+            }
+        }
+
+        return recordType;
+    }
+
+    public DataType getUserDefinedType() {
+
+        DataType dataType = null;
+
+        // while (token.type == Type.DATA_TYPE) {
+        consume(Type.DATA_TYPE);
+
+        if (token.type == Type.TYPE_DECLARATION) {
+            consume(Type.TYPE_DECLARATION);
+
+            TypeDeclaration typeDeclaration = getTypeDeclaration();
+            dataType = new DataType();
+            dataType.setUserDefinedType(typeDeclaration.getName());
+        }
+        // }
+
+        return dataType;
+    }
+
+    /*
+     * type RecordField { name: Identifier; dtype: DataType; };
+     */
+    public RecordField recordField() {
+
+        RecordField recordField = new RecordField();
+        DataType dataType = null;
+
+        while (token.type == Type.RECORD_FILED) {
+
+            consume(Type.RECORD_FILED);
+
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
+                recordField.setName(identifier);
+            } else if (token.type == Type.DATA_TYPE) {
+                // Peek
+                // rf.dtype = IntegerType
+                // OR
+                // m.type_declarations.element[3]
+                dataType = dataType();
+                // consume(Type.DATA_TYPE);
+                //
+                // if (token.type == Type.DATA_TYPE) {
+                // consume(Type.DATA_TYPE);
+                // dataType = dataType();
+                //
+                // } else if (token.type == Type.MODEL) {
+                // TypeDeclaration typeDeclaration = getTypeDeclaration();
+                // dataType = new DataType();
+                // dataType.setUserDefinedType(typeDeclaration.getName());
+                // }
+                recordField.setType(dataType);
+            }
+        }
+
+        return recordField;
+    }
+
+    /*
+     * type OptionKind enum { Some, None };
+     *
+     * type Option<T> { kind: OptionKind; value: T; };
+     */
+    public Type optionKind() {
+
+        // while(token.type == Type.OPTION) {
+        consume(Type.OPTION);
+
+        // kind
+        consume(Type.DATA_KIND);
+        // Value
+        String type_value = token.sd.getName();
+        Type type = Type.get(type_value);
+
+        if (type == Type.SOME) {
+            consume(Type.SOME);
+            // String type_value = peek().sd.getName();
+            // Type type = Type.get(type_value);
+
+        } else if (type == Type.NONE) {
+
+            consume(Type.NONE);
+        }
+        // }
+        return type;
+    }
+    /*
+     * <T>mk_some: T -> Option<T> := fun (v:T) { some(o: Option<T>) { o.kind =
+     * OptionKind.Some && o.value = v }};
+     *
+     * <T>mk_none: Option<T> := some(o: Option<T>) { o.kind = OptionKind.None };
+     */
+
+    // mk_some ::= mk_some:OPTION {DATA_TYPE:t} DATA_TYPE_KIND:kind DATATYPE
+    // Option ::== mk_some or None.
+    // Parametric Option<T> ... Option<DataType>
+    // Option ::= MK_NONE | MK_SOME
+    public Type option() {
+
+        // DataType dataType = null;
+
+        // consume(Type.OPTION);
+
+        String type_value = token.sd.getName();
+        Type type = Type.get(type_value);
+
+        if (type == Type.MK_NONE) {
+            consume(Type.MK_NONE);
+            // Some or NONE
+            type = mk_none();
+            // return null;
+        } else if (type == Type.SOME) {
+            consume(Type.SOME);
+            // dataType = dataType();
+        }
+
+        return type;
+        // return dataType;
+    }
+
+    public Type mk_none() {
+
+        consume(Type.OPTION);
+        return optionKind();
+    }
+
+    public Type mk_some() {
+
+        consume(Type.OPTION);
+        return optionKind();
+    }
+
+    public String optionIdentifier() {
+
+        String identifier = null;
+
+        String type_value = this.token.sd.getName();
+        Type type = Type.get(type_value);
+
+        if (type == Type.MK_NONE) {
+            consume(Type.MK_NONE);
+        } else if (type == Type.SOME) {
+
+            consume(Type.SOME);
+            identifier = Identifier();
+        }
+
+        return identifier;
+    }
+
+    /*
+     * type Expression { kind: ExpressionKind; identifier: Identifier; and:
+     * BinaryOperation; equal: BinaryOperation; };
+     */
+    public Expression expression() {
+
+        Expression expression = new Expression();
+        Type type = null;
+
+        while (token.type == Type.EXPRESSION) {
+            // Kind...
+            consume(Type.EXPRESSION);
+
+            if (token.type == Type.EXPRESSION_KIND) {
+                type = expressionKind();
+            }
+
+            // ID
+            if (type == Type.Id) {
+                return idExpr();
+            } else if (type == Type.INT_Lit) {
+                return intExpr();
+            } else if (type == Type.REAL_Lit) {
+                return realExpr();
+            } else if (type == Type.BOOL_Lit) {
+                return boolExpr();
+            } else if (type == Type.NEG) {
+                Expression neg_expr = expression();
+                expression.setNegative(neg_expr);
+                return expression;
+            } else if (type == Type.NOT) {
+                Expression not_expr = expression();
+                expression.setNot(not_expr);
+                return expression;
+            } else if (type == Type.PRE) {
+                Expression pre_expr = expression();
+                expression.setPre(pre_expr);
+                return expression;
+            } else if (type == Type.EVENT) {
+                Expression event_expr = expression();
+                expression.setEvent(event_expr);
+                return expression;
+            } else if (type == Type.TO_REAL) {
+                Expression real_expr = expression();
+                expression.setToReal(real_expr);
+                return expression;
+            } else if (type == Type.TO_INT) {
+                Expression int_expr = expression();
+                expression.setToInt(int_expr);
+                return expression;
+            } else if (token.type == Type.BINARY_OP) {
+                // OP
+                // EQ
+                // AND
+                BinaryOperation op = binaryOP();
+
+                if (type == Type.EQ) {
+                    // BinaryOperation eq = binaryExpression();
+                    expression.setEqual(op);
+                } else if (type == Type.AND) {
+                    /// BinaryOperation and = binaryExpression();
+                    expression.setAnd(op);
+                } else if (type == Type.OR) {
+                    // BinaryOperation or = binaryExpression();
+                    expression.setOr(op);
+                } else if (type == Type.IMPLIES) {
+                    // BinaryOperation implies = binaryExpression();
+                    expression.setImplies(op);
+                } else if (type == Type.PLUS) {
+                    expression.setPlus(op);
+                } else if (type == Type.MINUS) {
+                    expression.setMinus(op);
+                } else if (type == Type.DIV) {
+                    expression.setDiv(op);
+                } else if (type == Type.TIMES) {
+                    expression.setTimes(op);
+                } else if (type == Type.XOR) {
+                    expression.setXor(op);
+                } else if (type == Type.MOD) {
+                    expression.setMod(op);
+                } else if (type == Type.LEQ) {
+                    // BinaryOperation leq = binaryExpression();
+                    expression.setLessThanOrEqualTo(op);
+                } else if (type == Type.LE) {
+                    // BinaryOperation leq = binaryExpression();
+                    expression.setLessThan(op);
+                } else if (type == Type.GEQ) {
+                    // BinaryOperation leq = binaryExpression();
+                    expression.setGreaterThanOrEqualTo(op);
+                } else if (type == Type.GE) {
+                    // BinaryOperation leq = binaryExpression();
+                    expression.setGreaterThan(op);
+                } else if (type == Type.ARROW) {
+                    // BinaryOperation arrow = binaryExpression();
+                    expression.setArrow(op);
+                } else if (type == Type.NEQ) {
+                    // BinaryOperation neq = binaryExpression();
+                    expression.setNotEqual(op);
+                }
+            } else if (token.type == Type.ITE) {
+                if (type == Type.CND_EXPR) {
+                    IfThenElse ite = ITE();
+                    expression.setConditionalExpression(ite);
+                }
+            } else if (token.type == Type.RECORD_PROJECTION) {
+
+                if (type == Type.RECORD_PROJECTION) {
+                    RecordProjection record_expr = recordProjection();
+                    expression.setRecordProjection(record_expr);
+                }
+            } else if (token.type == Type.RECORD_LITERAL) {
+                if (type == Type.RECORD_LITERAL) {
+                    RecordLiteral recordLit = recordLiteral();
+                    expression.setRecordLiteral(recordLit);
+                }
+            } else if (token.type == Type.NODE_CALL) {
+                if (type == Type.CALL) {
+                    NodeCall nodeCall = nodeCall();
+                    expression.setCall(nodeCall);
+                }
+            }
+        }
+
+        return expression;
+    }
+
+    /*
+     * type ExpressionKind enum { Id, BoolLiteral, IntLiteral, RealLiteral, ToInt,
+     * ToReal, RecordProjection, RecordLiteral, Minus, Negative, Plus, Times, Div,
+     * IntDiv, Mod, Not, And, Or, Xor, Implies, LessThan, GreaterThan,
+     * LessThanOrEqualTo, GreaterThanOrEqualTo, Equal, NotEqual, ConditionalExpr,
+     * Arrow, Pre, Call, ExpressionList };
+     */
+    public Type expressionKind() {
+
+        consume(Type.EXPRESSION_KIND);
+
+        String type_value = token.sd.getName();
+        Type type = Type.get(type_value);
+        consume(type);
+
+        // if (type == Type.INT) {
+        // plainType = ExpressionKind.valueOf("INT");
+        // } else if (type == Type.REAL) {
+        // plainType = PlainType.valueOf("REAL");
+        // } else if (type == Type.BOOL) {
+        // plainType = PlainType.valueOf("BOOL");
+        // }
+
+        return type;
+    }
+
+    /*
+     * mk_id_expr: Identifier -> Expression := fun (id: Identifier) {some (e:
+     * Expression) { e.kind = ExpressionKind.Id && e.identifier = id }};
+     */
+    public Expression idExpr() {
+
+        Expression idExpr = new Expression();
+
+        String identifier_name;
+        String identifier_value;
+
+        consume(Type.EXPRESSION);
+
+        identifier_name = token.sd.getName();
+        consume(Type.IDENTIFIER);
+
+        identifier_value = token.getStringValue();
+        consume(Type.String);
+
+        // LOGGER.info(identifier_name + " := " + identifier_value);
+
+        idExpr.setIdentifier(identifier_value);
+
+        return idExpr;
+    }
+
+    public Expression intExpr() {
+
+        Expression intExpr = new Expression();
+
+        consume(Type.EXPRESSION);
+
+        consume(Type.INT);
+        // System.err.println("+++>" + token);
+        int literal_value = token.getNumberValue();
+        consume(Type.Int);
+
+        BigInteger bi = BigInteger.valueOf(literal_value);
+
+        intExpr.setIntLiteral(bi);
+
+        return intExpr;
+    }
+
+    public Expression realExpr() {
+
+        Expression realExpr = new Expression();
+
+        consume(Type.EXPRESSION);
+        consume(Type.REAL);
+        // System.out.println("REAL TOKEN:" + token.getFloatingValue());
+        // BigDecimal literal_value = BigDecimal.valueOf(token.getFloatingValue());
+        BigDecimal literal_value = new BigDecimal(String.format("%f", token.getFloatingValue()));
+
+        consume(Type.Float);
+
+        realExpr.setRealLiteral(literal_value);
+
+        return realExpr;
+    }
+
+    public Expression boolExpr() {
+
+        Expression boolExpr = new Expression();
+
+        consume(Type.EXPRESSION);
+
+        consume(Type.BOOL);
+        boolean literal_value = token.getTruthValue();
+        consume(Type.Boolean);
+
+        boolExpr.setBoolLiteral(literal_value);
+
+        return boolExpr;
+    }
+
+    public IfThenElse ITE() {
+        IfThenElse ite = new IfThenElse();
+
+        while (token.type == Type.ITE) {
+            consume(Type.ITE);
+            String type_value = token.sd.getName();
+            Type type = Type.get(type_value);
+
+            if (type == Type.CONDITION) {
+                Expression condition_expr = expression();
+                ite.setCondition(condition_expr);
+            } else if (type == Type.THEN) {
+                Expression then_expr = expression();
+                ite.setThenBranch(then_expr);
+            } else if (type == Type.ELSE) {
+                Expression else_expr = expression();
+                ite.setElseBranch(else_expr);
+                break;
+            }
+        }
+        return ite;
+    }
+
+    /*
+     * type NodeCall { node: Identifier -- Indirect Reference arguments:
+     * ArrayList<Expression>; }
+     */
+    public NodeCall nodeCall() {
+
+        NodeCall nodeCall = new NodeCall();
+        int array_length = 0;
+
+        while (token.type == Type.NODE_CALL) {
+            consume(Type.NODE_CALL);
+
+            if (token.type == Type.IDENTIFIER) {
+                consume(Type.IDENTIFIER);
+
+                String identifier = token.getStringValue();
+                consume(Type.String);
+                nodeCall.setNodeId(identifier);
+            } else if (token.type == Type.ARRAY_LIST) {
+
+                String type_value = token.sd.getName();
+                Type type = Type.get(type_value);
+
+                if (peek().type == Type.INT) {
+
+                    array_length = arrayList_length();
+
+                } else {
+
+                    int element_index = arrayList_element();
+
+                    Expression expression = expression();
+                    nodeCall.getArgument().add(element_index, expression);
+                }
+            }
+        }
+
+        return nodeCall;
+    }
+
+    /*
+     * lhs_operand: Expression; rhs_operand: Expression;
+     *
+     */
+    public BinaryOperation binaryOP() {
+
+        BinaryOperation binaryOperation = new BinaryOperation();
+
+        while (token.type == Type.BINARY_OP) {
+            consume(Type.BINARY_OP);
+
+            String type_value = token.sd.getName();
+            Type type = Type.get(type_value);
+
+            if (type == Type.LHS) {
+                Expression lhr_expr = expression();
+                binaryOperation.setLhsOperand(lhr_expr);
+            } else if (type == Type.RHS) {
+                Expression rhs_expresion = expression();
+                binaryOperation.setRhsOperand(rhs_expresion);
+                break;
+            }
+        }
+
+        return binaryOperation;
+    }
+
+    /*
+     * type RecordProjection { record_reference: Expression; field_id: Identifier;
+     * --- Indirect reference }
+     */
+
+    public RecordProjection recordProjection() {
+
+        RecordProjection recordProjection = new RecordProjection();
+
+        while (token.type == Type.RECORD_PROJECTION) {
+            consume(Type.RECORD_PROJECTION);
+
+            String type_value = token.sd.getName();
+            Type type = Type.get(type_value);
+
+            if (type == Type.RECORD_REF) {
+                Expression expression = expression();
+                recordProjection.setRecordReference(expression);
+            } else if (type == Type.FIELD_ID) {
+                String identifier = Identifier();
+                // consume(Type.IDENTIFIER);
+                // String identifier = token.getStringValue();
+                // consume(Type.String);
+                recordProjection.setFieldId(identifier);
+                break;
+            }
+        }
+
+        return recordProjection;
+    }
+
+    /*
+     * type FieldDefinition { field_id: Identifier; -- Indirect reference
+     * field_value: Expression; };
+     */
+    public FieldDefinition fieldDefinition() {
+        FieldDefinition fieldDefinition = new FieldDefinition();
+
+        while (token.type == Type.FIELD_DEFINITION) {
+            consume(Type.FIELD_DEFINITION);
+
+            String type_value = token.sd.getName();
+            Type type = Type.get(type_value);
+
+            if (type == Type.FIELD_ID) {
+                consume(Type.IDENTIFIER);
+                String identifier = token.getStringValue();
+                consume(Type.String);
+                fieldDefinition.setFieldIdentifier(identifier);
+            } else if (type == Type.FIELD_VALUE) {
+                Expression expression = expression();
+                fieldDefinition.setFieldValue(expression);
+            }
+        }
+
+        return fieldDefinition;
+    }
+
+    /*
+     * type RecordLiteral { record_type: Identifier; -- Indirect reference
+     * field_definitions: ArrayList<FieldDefinition>; };
+     */
+
+    public RecordLiteral recordLiteral() {
+
+        RecordLiteral recordLiteral = new RecordLiteral();
+        int array_length = 0;
+
+        while (token.type == Type.RECORD_LITERAL) {
+            consume(Type.RECORD_LITERAL);
+
+            if (token.type == Type.IDENTIFIER) {
+                consume(Type.IDENTIFIER);
+
+                String identifier = token.getStringValue();
+                consume(Type.String);
+                recordLiteral.setRecordType(identifier);
+
+            } else if (token.type == Type.ARRAY_LIST) {
+
+                String type_value = token.sd.getName();
+                Type type = Type.get(type_value);
+
+                if (peek().type == Type.INT) {
+
+                    array_length = arrayList_length();
+
+                } else {
+
+                    int element_index = arrayList_element();
+
+                    // if(type.FIELD_DEFINITION == Type.FIELD_DEFINITION) {
+                    FieldDefinition fieldDefinition = fieldDefinition();
+                    recordLiteral.getFieldDefinition().add(element_index, fieldDefinition);
+                    // }
+                    if (element_index == array_length - 1) {
+                        break;
+                    }
+                }
+            }
+        }
+        return recordLiteral;
+    }
+
+    public ArrayList<Expression> arrayList_Expression() {
+
+        ArrayList<Expression> expressionList = new ArrayList<Expression>();
+
+        int list_length = 0;
+
+        Type type = this.token.type;
+
+        while (type == Type.ARRAY_LIST) {
+
+            consume(Type.ARRAY_LIST);
+
+            // length
+            if (this.token.type == Type.INT) {
+
+                Token token = this.token;
+                NumberLiteral enumLength_literal = (NumberLiteral) token.value;
+                list_length = enumLength_literal.getValue();
+                consume(Type.INT);
+
+                while (list_length > 0) {
+
+                    // NULL:element
+                    consume(Type.NULL);
+                    list_length--;
+                    // element Index
+                    token = this.token;
+                    NumberLiteral element_index = (NumberLiteral) token.value;
+                    consume(Type.INT);
+
+                    // //element Value : Expression
+                    Expression expression = expression();
+                    expressionList.add(element_index.getValue(), expression);
+                }
+            }
+        }
+
+        return expressionList;
+    }
+
+    // o.kind = OptionKind.Some &&
+    // o.value = v
+
+    // TypeDeclaration ::= TYPE_DECLARATION:Name TYPE_DECLARATION:d IDENTIFIER:Name
+    // TYPE_DECLARATION:d
+    // OPTION:Definition OPTION:mk_some DATATYPE:t DATA_TYPE_KIND:kind
+    // null:Enum
+
+    // Type Declaration ::= Type_Declaration:d Identifier:name | Type_Declaration:d
+    // definition:
+    // Option<DataType>
+    public TypeDeclaration typeDeclaration() {
+
+        TypeDeclaration typeDeclaration = new TypeDeclaration();
+        // String ID = this.token.sd.getName();
+
+        while (token.type == Type.TYPE_DECLARATION) {
+            consume(Type.TYPE_DECLARATION);
+
+            if (token.type == Type.IDENTIFIER) {
+
+                String identifier = Identifier();
+                // Renaming dot[.] in Type Declaration Identifier.
+                identifier = identifier.replace(".", "_");
+
+                typeDeclaration.setName(identifier);
+
+            } else if (token.type == Type.OPTION) {
+
+                consume(Type.OPTION);
+
+                Type type = option();
+
+                if (type == Type.SOME) {
+                    // Option<DataType>
+                    if (token.type == Type.DATA_TYPE) {
+                        consume(Type.DATA_TYPE);
+                        try {
+
+                            DataType dataType = dataType();
+                            typeDeclaration.setDefinition(dataType);
+                        } catch (IndexOutOfBoundsException exp) {
+
+                            String faulty_declaration = typeDeclaration.getName();
+
+                            System.out.println(
+                                    "Forward references in datatype declaration is not supported.");
+
+                            if (faulty_declaration != null) {
+                                faulty_declaration = faulty_declaration.replace("_", ".");
+                                System.out.println("Please fix " + faulty_declaration);
+                            }
+
+                            System.exit(-1);
+                        }
+                    }
+                } else {
+                    // System.out.println("Found Data Type with No
+                    // Definition!!!!!!!!!!!");
+                }
+            }
+        }
+
+        return typeDeclaration;
+    }
+
+    public TypeDeclaration getTypeDeclaration() {
+
+        TypeDeclaration typeDeclaration = null;
+        // consume(Type.COMPONENT_TYPE);
+        consume(Type.MODEL);
+
+        int typeDeclaration_index = arrayList_element();
+
+        //		try {
+        typeDeclaration = typeDeclarations.get(typeDeclaration_index);
+        //		} catch (IndexOutOfBoundsException exp) {
+        //			System.out.println("Forward reference in datatype declaration is not supported!");
+        //			System.exit(-1);
+        //		}
+
+        return typeDeclaration;
+    }
+
+    /*
+     * type ArrayList<T> { length: Int; element: T[length]; };
+     */
+    public int arrayList_length() {
+
+        int list_length = 0;
+        Type type = this.token.type;
+
+        if (type == Type.ARRAY_LIST) {
+            consume(Type.ARRAY_LIST);
+            // length
+            if (this.token.type == Type.INT) {
+                consume(Type.INT);
+
+                Token token = this.token;
+                NumberLiteral enumLength_literal = (NumberLiteral) token.value;
+                list_length = enumLength_literal.getValue();
+                consume(Type.Int);
+            }
+        }
+
+        return list_length;
+    }
+
+    // name: Identifier;
+    // dtype: DataType;
+    // definition: Option<Expression>;
+
+    public ConstantDeclaration constantDeclaration() {
+
+        ConstantDeclaration constantDeclaration = new ConstantDeclaration();
+        DataType dataType = null;
+        // String ID = this.token.sd.getName();
+        // constantDeclaration.setId(ID);
+
+        while (token.type == Type.CONSTANT_DECLARATION) {
+
+            consume(Type.CONSTANT_DECLARATION);
+
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
+                constantDeclaration.setName(identifier);
+            } else if (token.type == Type.DATA_TYPE) {
+
+                consume(Type.DATA_TYPE);
+
+                if (token.type == Type.DATA_TYPE) {
+                    // consume(Type.DATA_TYPE);
+                    dataType = dataType();
+
+                } else if (token.type == Type.MODEL) {
+                    TypeDeclaration typeDeclaration = getTypeDeclaration();
+                    dataType = new DataType();
+                    dataType.setUserDefinedType(typeDeclaration.getName());
+                }
+
+                // DataType dataType_value = dataType();
+                constantDeclaration.setDataType(dataType);
+            } else if (token.type == Type.OPTION) {
+                consume(Type.OPTION);
+
+                Type type = option();
+
+                if (type == Type.SOME) {
+                    Expression expression = expression();
+                    constantDeclaration.setDefinition(expression);
+                }
+                // skip None
+            }
+        }
+
+        return constantDeclaration;
+    }
+
+    /*
+     * type VariableDeclaration { name: Identifier; dtype: DataType; };
+     */
+    public VariableDeclaration variableDeclaration() {
+
+        VariableDeclaration variableDeclaration = new VariableDeclaration();
+        DataType dataType = null;
+
+        while (token.type == Type.VARIABLE_DECLARATION) {
+
+            consume(Type.VARIABLE_DECLARATION);
+
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
+                variableDeclaration.setName(identifier);
+            } else if (token.type == Type.DATA_TYPE) {
+
+                consume(Type.DATA_TYPE);
+
+                if (token.type == Type.DATA_TYPE) {
+                    // consume(Type.DATA_TYPE);
+                    dataType = dataType();
+
+                } else if (token.type == Type.MODEL) {
+                    TypeDeclaration typeDeclaration = getTypeDeclaration();
+                    dataType = new DataType();
+                    dataType.setUserDefinedType(typeDeclaration.getName());
+                }
+
+                // DataType dataType_value = dataType();
+                variableDeclaration.setDataType(dataType);
+            }
+        }
+
+        return variableDeclaration;
+    }
+
+    // type Port {
+    // name: Identifier;
+    // mode: PortMode;
+    // is_event: Bool;
+    // ptype: Option<DataType>;
+    // probe: Bool;
+    // };
+
+    public Port port(String componentID) {
+
+        Port port = new Port();
+
+        // String ID = this.token.sd.getName();
+        // port.setId(ID);
+
+        while (token.type == Type.PORT) {
+
+            consume(Type.PORT);
+
+            if (token.type == Type.IDENTIFIER) {
+
+                String identifier = Identifier();
+                port.setName(identifier);
+                port.setId(componentID + "." + identifier);
+
+            } else if (token.type == Type.PORT_MODE) {
+                PortMode portMode = portMode();
+                port.setMode(portMode);
+            } else if (token.type == Type.BOOL) {
+
+                // consume(Type.BOOL);
+
+                String type_value = this.token.sd.getName();
+                Type type = Type.get(type_value);
+
+                if (type == Type.PROBE) {
+                    consume(Type.PROBE);
+
+                    boolean is_probe = token.getTruthValue();
+
+                    port.setProbe(is_probe);
+                    consume(Type.Boolean);
+
+                } else if (type == Type.IS_EVENT) {
+                    consume(Type.IS_EVENT);
+
+                    boolean is_event = token.getTruthValue();
+
+                    port.setEvent(is_event);
+                    consume(Type.Boolean);
+                }
+
+            } else if (token.type == Type.OPTION) {
+                consume(Type.OPTION);
+
+                Type type = option();
+                // SOME
+                if (type == Type.SOME) {
+                    DataType dataType = null;
+
+                    if (token.type == Type.MODEL) {
+                        TypeDeclaration typeDeclaration = getTypeDeclaration();
+                        dataType = new DataType();
+                        dataType.setUserDefinedType(typeDeclaration.getName());
+                    } else if (token.type == Type.DATA_TYPE) {
+                        dataType = dataType();
+                    }
+                    port.setType(dataType);
+                }
+                // Skip None
+            }
+        }
+
+        return port;
+    }
+
+    // type GenericAttribute {
+    // name: String;
+    // atype: AttributeType;
+    // value: String;
+    // };
+
+    public GenericAttribute genericAttribute() {
+
+        GenericAttribute gAttribute = new GenericAttribute();
+
+        // String ID = this.token.sd.getName();
+        // port.setId(ID);
+
+        while (token.type == Type.GENERIC_ATTRIBUTE) {
+
+            consume(Type.GENERIC_ATTRIBUTE);
+
+            if (token.type == Type.STRING) {
+
+                String type_value = this.token.sd.getName();
+                Type type = Type.get(type_value);
+
+                if (type == Type.NAME) {
+                    consume(Type.NAME);
+
+                    String identifier = token.getStringValue();
+                    gAttribute.setName(identifier);
+
+                    consume(Type.String);
+
+                } else if (type == Type.VALUE) {
+                    consume(Type.VALUE);
+
+                    String value = token.getStringValue();
+                    gAttribute.setValue(value);
+
+                    consume(Type.String);
+                }
+
+            } else if (token.type == Type.ATTRIBUTE_TYPE) {
+                QName attributeType = attributeType();
+                gAttribute.setType(attributeType);
+            }
+        }
+
+        return gAttribute;
+    }
+
+    // Array_List ::= ARRAY_LIST:<T> INT:length Int:value |
+    // ARRAY_LIST:<T> NULL:element Int:index T:value
+
+    public int arrayList_element() {
+
+        int e_index = -1;
+
+        // ComponentTypes
+        consume(Type.ARRAY_LIST);
+
+        // NULL:element
+        consume();
+
+        // element Index
+        // token = this.token;
+        NumberLiteral element_index = (NumberLiteral) token.value;
+        e_index = element_index.getValue();
+        consume(Type.Int);
+
+        // Port port = port(component_ID);
+        // portList.add(, port);
+
+        return e_index;
+    }
+
+    /** type PortMode enum { In, Out }; */
+    public PortMode portMode() {
+
+        PortMode portMode = null;
+
+        Type type = token.type;
+        consume(Type.PORT_MODE);
+        // Enum
+        String type_value = this.token.sd.getName();
+        type = Type.get(type_value);
+
+        if (type == Type.IN) {
+            portMode = PortMode.valueOf("IN");
+            consume();
+
+        } else if (type == Type.OUT) {
+
+            portMode = PortMode.valueOf("OUT");
+            consume();
+        }
+
+        return portMode;
+    }
+
+    /** type AttributeType enum {Int, Real, Bool, String}; */
+    public QName attributeType() {
+
+        QName attributeType = null;
+
+        Type type = token.type;
+        consume(Type.ATTRIBUTE_TYPE);
+        // Enum
+        // String type_value = this.token.type;
+        type = this.token.type;
+
+        if (type == Type.INT) {
+            attributeType = new QName("Int");
+            consume();
+        } else if (type == Type.BOOL) {
+            attributeType = new QName("Bool");
+            consume();
+        } else if (type == Type.REAL) {
+            attributeType = new QName("Real");
+            consume();
+        } else if (type == Type.STRING) {
+            attributeType = new QName("String");
+            consume();
+        }
+
+        return attributeType;
+    }
+
+    /*
+     *
+     * type ContractSpec { constant_declarations: ArrayList<SymbolDefinition>;
+     * variable_declarations: ArrayList<SymbolDefinition>; assumes:
+     * ArrayList<ContractItem>; guarantees: ArrayList<ContractItem>; modes:
+     * ArrayList<ContractMode>; imports: ArrayList<ContractImport>; };
+     */
+    public ContractSpec contractSpec() {
+
+        ContractSpec contractSpec = new ContractSpec();
+        int array_length = 0;
+        // String ID = this.token.sd.getName();
+        // contractSpec.setId(ID);
+
+        while (this.token.type == Type.CONTRACT_SPEC) {
+
+            consume(Type.CONTRACT_SPEC);
+
+            if (token.type == Type.ARRAY_LIST) {
+
+                String type_value = this.token.sd.getName();
+                Type type = Type.get(type_value);
+
+                if (peek().type == Type.INT) {
+                    array_length = arrayList_length();
+                } else {
+
+                    if (type == Type.CONSTANT_DECLARATIONS) {
+                        int constantDeclaration_index = arrayList_element();
+
+                        SymbolDefinition symbolDefinition = symbolDefinition();
+                        contractSpec.getSymbol().add(constantDeclaration_index, symbolDefinition);
+                    } else if (type == Type.VARIABLE_DECLARATIONS) {
+                        int variableDeclaration_index = arrayList_element();
+
+                        SymbolDefinition symbolDefinition = symbolDefinition();
+                        contractSpec.getSymbol().add(variableDeclaration_index, symbolDefinition);
+
+                    } else if (type == Type.ASSUMES) {
+                        int assume_index = arrayList_element();
+                        ContractItem contractItem = contractItem();
+                        contractSpec.getAssume().add(assume_index, contractItem);
+                    } else if (type == Type.GURANTEES) {
+                        int gurantee_index = arrayList_element();
+                        ContractItem contractItem = contractItem();
+                        // LOGGER.info(
+                        // "guarantees - ["
+                        // + gurantee_index
+                        // + "] = "
+                        // + contractItem.getName());
+                        contractSpec.getGuarantee().add(gurantee_index, contractItem);
+
+                    } else if (type == Type.MODES) {
+                        int mode_index = arrayList_element();
+
+                        // ContractMode contractMode = contractMode();
+                        // contractSpec.getMode().add(mode_index,
+                        // contractMode);
+
+                    } else if (type == Type.IMPORTS) {
+                        int import_index = arrayList_element();
+
+                        ContractImport contractImport = contractImport();
+                        contractSpec.getImport().add(import_index, contractImport);
+                    }
+                }
+            }
+        }
+
+        return contractSpec;
+    }
+
+    /*
+     * type ContractImport { contract: Contract; input_arguments:
+     * ArrayList<Expression>; input_arguments: ArrayList<Expression>; }
+     */
+    public ContractImport contractImport() {
+
+        ContractImport contractImport = new ContractImport();
+
+        // String ID = this.token.sd.getName();
+        // contractImport.setId(ID);
+
+        Type type = this.token.type;
+
+        while (type == Type.CONTRACT_IMPORT) {
+            consume(Type.CONTRACT_IMPORT);
+
+            String type_value = this.token.sd.getName();
+            type = Type.get(type_value);
+
+            if (type == Type.CONTRACT) {
+                Contract contract = contract();
+                // contractImport.setContractId(contract);
+            } else if (type == Type.INPUT_ARGUMENTS) {
+                ArrayList<Expression> input_arguments = arrayList_Expression();
+
+            } else if (type == Type.OUTPUT_ARGUMENTS) {
+                ArrayList<Expression> output_arguments = arrayList_Expression();
+            }
+        }
+
+        return contractImport;
+    }
+
+    /*
+     * type Contract { name: Identifier; input_paramenters:
+     * ArrayList<NodeParameter>; output_paramenters: ArrayList<NodeParameter>;
+     * specification: ContractSpec; };
+     */
+    public Contract contract() {
+
+        Contract contract = new Contract();
+
+        String ID = this.token.sd.getName();
+        // contract.setId(ID);
+
+        while (this.token.type == Type.CONTRACT) {
+
+            consume(Type.CONTRACT);
+
+            String type_value = this.token.sd.getName();
+            Type type = Type.get(type_value);
+
+            if (type == Type.IDENTIFIER) {
+                String identifier = Identifier();
+                contract.setName(identifier);
+            } else if (type == Type.INPUT_NODE_PARAMETER) {
+                // ArrayList<NodeParameter> input_parameters = nodeParameter();
+                // contract.getInputParamater().addAll(input_parameters);
+            } else if (type == Type.OUTPUT_NODE_PARAMETER) {
+                // ArrayList<NodeParameter> output_parameters = nodeParameter();
+                // contract.getInputParamater().addAll(output_parameters);
+            } else if (type == Type.CONTRACT_SPEC) {
+                ContractSpec specification = contractSpec();
+                contract.getSpecification().add(specification);
+            }
+        }
+
+        return contract;
+    }
+
+    /*
+     * type ContractItem { name: Option<Identifier>; expression: Expression; }
+     */
+    public ContractItem contractItem() {
+
+        ContractItem contractItem = new ContractItem();
+
+        // String ID = this.token.sd.getName();
+
+        while (this.token.type == Type.CONTRACT_ITEM) {
+            consume(Type.CONTRACT_ITEM);
+
+            if (this.token.type == Type.OPTION) {
+                consume(Type.OPTION);
+
+                Type type = option();
+
+                if (type == Type.SOME) {
+                    String identifier = token.getStringValue();
+                    contractItem.setName(identifier);
+                    consume(Type.String);
+                    // LOGGER.info("Contract ITEM: " + identifier);
+                }
+            } else if (this.token.type == Type.EXPRESSION) {
+                Expression expression = expression();
+                contractItem.setExpression(expression);
+            }
+        }
+
+        return contractItem;
+    }
+
+    /*
+     * type SymbolDefinition { name: Identifier; is_constant: Bool; dtype: DataType;
+     * definition: Expression; };
+     */
+    public SymbolDefinition symbolDefinition() {
+
+        SymbolDefinition symbolDefinition = new SymbolDefinition();
+        DataType dataType = null;
+
+        String ID = this.token.sd.getName();
+        // symbolDefinition.setId(ID);
+
+        while (this.token.type == Type.SYMBOL_DEFINITION) {
+
+            consume(Type.SYMBOL_DEFINITION);
+
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
+                symbolDefinition.setName(identifier);
+            } else if (token.type == Type.DATA_TYPE) {
+
+                consume(Type.DATA_TYPE);
+
+                if (token.type == Type.DATA_TYPE) {
+                    // consume(Type.DATA_TYPE);
+                    dataType = dataType();
+                    symbolDefinition.setDataType(dataType);
+
+                } else if (token.type == Type.MODEL) {
+                    TypeDeclaration typeDeclaration = getTypeDeclaration();
+                    dataType = new DataType();
+                    dataType.setUserDefinedType(typeDeclaration.getName());
+                }
+
+                // DataType dataType_value = dataType();
+                symbolDefinition.setDataType(dataType);
+            } else if (token.type == Type.BOOL) {
+                consume(Type.BOOL);
+
+                boolean value = token.getTruthValue();
+                consume(Type.Boolean);
+                // DATA this field into VDM Lustre in NodeParameter.
+                symbolDefinition.setIsConstant(truthValue());
+            } else if (token.type == Type.EXPRESSION) {
+                Expression expression = expression();
+                symbolDefinition.setDefinition(expression);
+            }
+        }
+
+        return symbolDefinition;
+    }
+
+    /** True or False */
+    public boolean truthValue() {
+
+        boolean flag = false;
+
+        TruthValue truthValue = (TruthValue) this.token.value;
+        consume(Type.Boolean);
+
+        if (truthValue.isTRUE()) {
+            flag = true;
+        }
+
+        return flag;
+    }
+
+    /*
+     * name: Identifier; ports: ArrayList<Port>; contract: Option<ContractSpec>;
+     * cyber_relations: ArrayList<CyberRel>;
+     *
+     */
+    // type ComponentType {
+    // name: Identifier;
+    // ports: ArrayList<Port>;
+    // compCateg: Option<String>;
+    // contract: Option<ContractSpec>;
+    // cyber_relations: ArrayList<CyberRel>;
+    // safety_relations: ArrayList<SafetyRel>;
+    // safety_events: ArrayList<SafetyEvent>;
+    // };
+    public ComponentType componentType() {
+
+        ComponentType componentType = new ComponentType();
+        List<Port> ports = componentType.getPort();
+        List<CyberRel> cyber_relations = componentType.getCyberRel();
+        List<SafetyRel> safety_relations = componentType.getSafetyRel();
+        List<Event> events = componentType.getEvent();
+
+        int list_size = 0;
+        Type type;
+
+        // @TODO: Check ID.
+        // String ID = token.sd.getName();
+        //
+
+        while (token.type == Type.COMPONENT_TYPE) {
+
+            consume(Type.COMPONENT_TYPE);
+
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
+                componentType.setName(identifier);
+                componentType.setId(identifier);
+                // LOGGER.info("COMPONENT TYPE: >>>>>>>>>>>" + identifier);
+            }
+            // PORT ARRAY LIST.
+            else if (token.type == Type.ARRAY_LIST) {
+
+                String type_name = this.token.sd.getName();
+                type = Type.get(type_name);
+
+                if (peek().type == Type.INT) {
+
+                    list_size = arrayList_length();
+
+                } else {
+
+                    if (type == Type.PORTS) {
+                        int port_index = arrayList_element();
+                        Port port = port(componentType.getId());
+                        ports.add(port_index, port);
+                        // LOGGER.info("["+ port_index + "," + port.getName()+"]");
+                    } else if (type == Type.CYBER_RELATIONS) {
+                        log("cyber_rel" + token);
+                        int rel_index = arrayList_element();
+
+                        CyberRel cyberRel = cyber_rel();
+                        cyber_relations.add(rel_index, cyberRel);
+                    } else if (type == Type.SAFETY_RELATIONS) {
+                        log("safety_rel: " + token);
+                        int rel_index = arrayList_element();
+
+                        SafetyRel safetyRel = safety_rel();
+                        safety_relations.add(rel_index, safetyRel);
+                    } else if (type == Type.SAFETY_EVENTS) {
+                        log("safety event: " + token);
+                        int event_index = arrayList_element();
+
+                        Event event = safetyevent();
+                        events.add(event_index, event);
+                    }
+                }
+                // Confirm length of ports match with elements.
+            } else if (token.type == Type.OPTION) {
+
+                consume(Type.OPTION);
+
+                type = option();
+                // Some
+                if (type == Type.SOME) {
+
+                    if (token.type == Type.CONTRACT_SPEC) {
+                        ContractSpec contract = contractSpec();
+                        componentType.setContract(contract);
+                    } else if (token.type == Type.String) {
+                        String categ = token.getStringValue();
+                        componentType.setCompCateg(categ);
+                        consume(Type.String);
+                    }
+                }
+                // Skip None
+            }
+        }
+
+        return componentType;
+    }
+
+    /*
+     * type CyberExpr { kind: CyberExprKind; port: CIAPort; and:
+     * ArrayList<CyberExpr>; or: ArrayList<CyberExpr>; not: CyberExpr; };
+     */
+
+    public CyberExpr cyberExpr() {
+
+        CyberExpr cyberExpr = new CyberExpr();
+        CyberExprKind kind = null;
+
+        while (this.token.type == Type.CYBER_EXP) {
+
+            consume(Type.CYBER_EXP);
+
+            if (token.type == Type.CIA_PORT) {
+
+                CIAPort ciaPort = cia_port();
+                cyberExpr.setPort(ciaPort);
+            }
+            if (token.type == Type.CYBER_EXP_KIND) {
+                kind = cyberExprKind();
+            }
+
+            if (kind == CyberExprKind.NOT) {
+                CyberExpr not_expr = new CyberExpr();
+                not_expr.setNot(not_expr);
+                return not_expr;
+            }
+
+            if (kind == CyberExprKind.OR) {
+
+                CyberExprList or_exprs = cyberExprList();
+                cyberExpr.setOr(or_exprs);
+            }
+            if (kind == CyberExprKind.AND) {
+
+                CyberExprList and_exprs = cyberExprList();
+                cyberExpr.setAnd(and_exprs);
+            }
+            if (kind == CyberExprKind.PORT) {
+                return cyberExpr();
+                // CIAPort ciaPort = cia_port();
+                // cyberExpr.setPort(ciaPort);
+            }
+
+            //
+            // return cyberExprList;
+
+        }
+
+        return cyberExpr;
+    }
+
+    public CyberExprList cyberExprList() {
+
+        CyberExprList cyberExprList = new CyberExprList();
+
+        int array_length = 0;
+
+        while (this.token.type == Type.CYBER_EXP) {
+
+            consume(Type.CYBER_EXP);
+            if (token.type == Type.ARRAY_LIST) {
+
+                // String type_value = token.sd.getName();
+                // Type type = Type.get(type_value);
+
+                if (peek().type == Type.INT) {
+
+                    array_length = arrayList_length();
+
+                } else {
+
+                    while (array_length > 0) {
+
+                        array_length--;
+
+                        int element_index = arrayList_element();
+
+                        CyberExpr expr = cyberExpr();
+                        cyberExprList.getExpr().add(element_index, expr);
+                    }
+                }
+            }
+        }
+
+        return cyberExprList;
+    }
+
+    /** Handle safety requirement expressions */
+    public SafetyReqExpr safetyReqExpr() {
+
+        SafetyReqExpr safetyReqExpr = new SafetyReqExpr();
+        SafetyReqExprKind kind = null;
+
+        while (this.token.type == Type.SAFETY_EXP) {
+
+            consume(Type.SAFETY_EXP);
+
+            if (token.type == Type.IA_PORT) {
+
+                IAPort iaPort = ia_port();
+                safetyReqExpr.setPort(iaPort);
+            }
+            if (token.type == Type.SAFETY_EXP_KIND) {
+                kind = safetyReqExprKind();
+            }
+            if (kind == SafetyReqExprKind.NOT) {
+                SafetyReqExpr not_expr = new SafetyReqExpr();
+                not_expr.setNot(not_expr);
+                return not_expr;
+            }
+            if (kind == SafetyReqExprKind.OR) {
+
+                SafetyReqExprList or_exprs = safetyReqExprList();
+                safetyReqExpr.setOr(or_exprs);
+            }
+            if (kind == SafetyReqExprKind.AND) {
+
+                SafetyReqExprList and_exprs = safetyReqExprList();
+                safetyReqExpr.setAnd(and_exprs);
+            }
+            if (kind == SafetyReqExprKind.PORT) {
+                return safetyReqExpr();
+            }
+        }
+
+        return safetyReqExpr;
+    }
+
+    public SafetyReqExprList safetyReqExprList() {
+
+        SafetyReqExprList safetyReqExprList = new SafetyReqExprList();
+
+        int array_length = 0;
+
+        while (this.token.type == Type.SAFETY_EXP) {
+
+            consume(Type.SAFETY_EXP);
+            if (token.type == Type.ARRAY_LIST) {
+                if (peek().type == Type.INT) {
+                    array_length = arrayList_length();
+                } else {
+
+                    while (array_length > 0) {
+
+                        array_length--;
+
+                        int element_index = arrayList_element();
+                        SafetyReqExpr reqExpr = safetyReqExpr();
+                        safetyReqExprList.getExpr().add(element_index, reqExpr);
+                    }
+                }
+            }
+        }
+
+        return safetyReqExprList;
+    }
+
+    // type SafetyRel {
+    // id: String;
+    // output: IAPort;
+    // faultSrc: Option<SafetyExpr>;
+    // comment: Option<String>;
+    // description : Option<String>;
+    // };
+
+    /** Handle safety relations */
+    public SafetyRel safety_rel() {
+
+        SafetyRel safetyRel = new SafetyRel();
+
+        while (this.token.type == Type.SAFETY_REL) {
+
+            consume(Type.SAFETY_REL);
+
+            if (token.type == Type.STRING) {
+
+                String identifier = id_value();
+                log("safety_rel id = " + identifier);
+                safetyRel.setId(identifier);
+
+            } else if (token.type == Type.IA_PORT) {
+
+                IAPort iaPort = ia_port();
+                safetyRel.setOutput(iaPort);
+            } else if (token.type == Type.OPTION) {
+
+                String type_value = token.sd.getName();
+                Type type = Type.get(type_value);
+                consume(Type.OPTION);
+
+                log("safety rel type_value = " + type_value);
+
+                if (type == Type.FAULTSRC) {
+                    SafetyRelExpr expr_value = safetyRelExpr();
+                    safetyRel.setFaultSrc(expr_value);
+
+                } else if (type == Type.COMMENT) {
+
+                    String comment = str_value();
+                    log("safety rel comment = " + comment);
+                    safetyRel.setComment(comment);
+
+                } else if (type == Type.DESCRIPTION) {
+
+                    String description = str_value();
+                    safetyRel.setDescription(description);
+
+                } else if (type == Type.PHASES) {
+
+                    String phases = str_value();
+                    safetyRel.setPhases(phases);
+
+                } else if (type == Type.EXTERN) {
+
+                    String extern = str_value();
+                    safetyRel.setExtern(extern);
+                }
+            }
+        }
+
+        return safetyRel;
+    }
+
+    // type SafetyExpr {
+    // kind: SafetyExprKind;
+    // port: IAPort;
+    // fault: String;
+    // and: ArrayList<SafetyExpr>;
+    // or: ArrayList<SafetyExpr>;
+    // not: SafetyExpr;
+    // };
+    public SafetyRelExpr safetyRelExpr() {
+
+        SafetyRelExpr safetyRelExpr = new SafetyRelExpr();
+        SafetyRelExprKind kind = null;
+
+        // Check length bound and terminate.
+        int array_length = 0;
+
+        while (this.token.type == Type.SAFETY_EXP) {
+
+            consume(Type.SAFETY_EXP);
+
+            if (token.type == Type.IA_PORT) {
+
+                IAPort iaPort = ia_port();
+                safetyRelExpr.setPort(iaPort);
+            }
+            if (token.type == Type.SAFETY_EXP_KIND) {
+                kind = safetyRelExprKind();
+            }
+            if (kind == SafetyRelExprKind.NOT) {
+                SafetyRelExpr not_expr = new SafetyRelExpr();
+                not_expr.setNot(not_expr);
+                return not_expr;
+            }
+            if (kind == SafetyRelExprKind.OR) {
+
+                SafetyRelExprList or_exprs = safetyRelExprList();
+                safetyRelExpr.setOr(or_exprs);
+            }
+            if (kind == SafetyRelExprKind.AND) {
+
+                SafetyRelExprList and_exprs = safetyRelExprList();
+                safetyRelExpr.setAnd(and_exprs);
+            }
+            if (kind == SafetyRelExprKind.PORT) {
+                return safetyRelExpr();
+            }
+            if (kind == SafetyRelExprKind.FAULT) {
+
+                EventHappens event = eventHappens();
+                safetyRelExpr.setFault(event);
+                safetyRelExpr();
+            }
+        }
+
+        return safetyRelExpr;
+    }
+
+    public SafetyRelExprList safetyRelExprList() {
+
+        SafetyRelExprList safetyRelExprList = new SafetyRelExprList();
+
+        int array_length = 0;
+
+        while (this.token.type == Type.SAFETY_EXP) {
+
+            consume(Type.SAFETY_EXP);
+            if (token.type == Type.ARRAY_LIST) {
+                if (peek().type == Type.INT) {
+                    array_length = arrayList_length();
+                } else {
+
+                    while (array_length > 0) {
+
+                        array_length--;
+
+                        int element_index = arrayList_element();
+                        SafetyRelExpr relExpr = safetyRelExpr();
+                        safetyRelExprList.getExpr().add(element_index, relExpr);
+                    }
+                }
+            }
+        }
+
+        return safetyRelExprList;
+    }
+
+    /*
+     * type CyberRel { id : String; output : CIAPort; inputs : Option<CyberExpr>;
+     * comment: Option<String>; description : Option<String>; phases :
+     * Option<String>; extern : Option<String>; };
+     */
+    public CyberRel cyber_rel() {
+
+        CyberRel cyberRel = new CyberRel();
+
+        while (this.token.type == Type.CYB_REL) {
+
+            consume(Type.CYB_REL);
+
+            if (token.type == Type.STRING) {
+
+                String identifier = id_value();
+                cyberRel.setId(identifier);
+
+            } else if (token.type == Type.CIA_PORT) {
+
+                CIAPort ciaPort = cia_port();
+                cyberRel.setOutput(ciaPort);
+
+            } else if (token.type == Type.OPTION) {
+
+                String type_value = token.sd.getName();
+                Type type = Type.get(type_value);
+                consume(Type.OPTION);
+
+                if (type == Type.INPUTS) {
+                    CyberExpr expr_value = cyberExpr();
+                    cyberRel.setInputs(expr_value);
+
+                } else if (type == Type.COMMENT) {
+
+                    String comment = str_value();
+                    cyberRel.setComment(comment);
+
+                } else if (type == Type.DESCRIPTION) {
+
+                    String description = str_value();
+                    cyberRel.setDescription(description);
+
+                } else if (type == Type.PHASES) {
+
+                    String phases = str_value();
+                    cyberRel.setPhases(phases);
+
+                } else if (type == Type.EXTERN) {
+
+                    String extern = str_value();
+                    cyberRel.setExtern(extern);
+                }
+            }
+        }
+
+        return cyberRel;
+    }
+
+    // IDENTIFIER ::= IDENTIFIER:name String:value
+    // Return a String.
+    public String id_value() {
+
+        String identifier_name;
+        String identifier_value;
+
+        identifier_name = token.sd.getName();
+        consume(Type.STRING);
+
+        identifier_value = token.getStringValue();
+        consume(Type.String);
+
+        // LOGGER.info(identifier_name + " := " + identifier_value);
+
+        return identifier_value;
+    }
+
+    public String str_value() {
+        String value = token.getStringValue();
+        consume();
+        return value;
+    }
 
-		identifier_value = token.getStringValue();
-		consume(Type.String);
-
-		// LOGGER.info(identifier_name + " := " + identifier_value);
+    /*
+     * type CyberReq { id: String; cia: CIA; severity: Severity; condition:
+     * CyberExpr; comment: Option<String>; description : Option<String>; phases :
+     * Option<String>; extern : Option<String>; };
+     *
+     */
+    public CyberReq cyber_req() {
 
-		return identifier_value;
-	}
+        CyberReq cyberReq = new CyberReq();
 
-	public String str_value() {
-		String value = token.getStringValue();
-		consume();
-		return value;
-	}
+        while (this.token.type == Type.CYB_REQ) {
+            consume(Type.CYB_REQ);
 
-	/*
-	 * type CyberReq { id: String; cia: CIA; severity: Severity; condition:
-	 * CyberExpr; comment: Option<String>; description : Option<String>; phases :
-	 * Option<String>; extern : Option<String>; };
-	 *
-	 */
-	public CyberReq cyber_req() {
+            if (token.type == Type.STRING) {
 
-		CyberReq cyberReq = new CyberReq();
+                String identifier = id_value();
+                cyberReq.setId(identifier);
 
-		while (this.token.type == Type.CYB_REQ) {
-			consume(Type.CYB_REQ);
+            } else if (token.type == Type.CIA) {
 
-			if (token.type == Type.STRING) {
+                CIA cia = cia();
+                cyberReq.setCia(cia);
 
-				String identifier = id_value();
-				cyberReq.setId(identifier);
+            } else if (token.type == Type.SEVERITY) {
 
-			} else if (token.type == Type.CIA) {
+                Severity severity = severity();
+                cyberReq.setSeverity(severity);
 
-				CIA cia = cia();
-				cyberReq.setCia(cia);
+            } else if (token.type == Type.CYBER_EXP) {
 
-			} else if (token.type == Type.SEVERITY) {
+                CyberExpr expr = cyberExpr();
+                cyberReq.setCondition(expr);
 
-				Severity severity = severity();
-				cyberReq.setSeverity(severity);
+            } else if (token.type == Type.OPTION) {
 
-			} else if (token.type == Type.CYBER_EXP) {
+                String type_value = token.sd.getName();
+                Type type = Type.get(type_value);
+                // consume(Type.BOOL);
+                consume(Type.OPTION);
 
-				CyberExpr expr = cyberExpr();
-				cyberReq.setCondition(expr);
+                if (type == Type.COMMENT) {
 
-			} else if (token.type == Type.OPTION) {
+                    String comment = str_value();
+                    cyberReq.setComment(comment);
 
-				String type_value = token.sd.getName();
-				Type type = Type.get(type_value);
-				// consume(Type.BOOL);
-				consume(Type.OPTION);
+                } else if (type == Type.DESCRIPTION) {
 
-				if (type == Type.COMMENT) {
+                    String description = str_value();
+                    cyberReq.setDescription(description);
 
-					String comment = str_value();
-					cyberReq.setComment(comment);
+                } else if (type == Type.PHASES) {
 
-				} else if (type == Type.DESCRIPTION) {
+                    String phases = str_value();
+                    cyberReq.setPhases(phases);
 
-					String description = str_value();
-					cyberReq.setDescription(description);
+                } else if (type == Type.EXTERN) {
 
-				} else if (type == Type.PHASES) {
+                    String extern = str_value();
+                    cyberReq.setExtern(extern);
+                }
+            }
+        }
 
-					String phases = str_value();
-					cyberReq.setPhases(phases);
+        return cyberReq;
+    }
 
-				} else if (type == Type.EXTERN) {
+    public SafetyReq safety_req() {
 
-					String extern = str_value();
-					cyberReq.setExtern(extern);
-				}
-			}
-		}
+        SafetyReq safetyReq = new SafetyReq();
 
-		return cyberReq;
-	}
+        while (this.token.type == Type.SAFETY_REQ) {
+            consume(Type.SAFETY_REQ);
 
-	public SafetyReq safety_req() {
+            if (token.type == Type.STRING) {
 
-		SafetyReq safetyReq = new SafetyReq();
+                String identifier = id_value();
+                safetyReq.setId(identifier);
 
-		while (this.token.type == Type.SAFETY_REQ) {
-			consume(Type.SAFETY_REQ);
+            } else if (token.type == Type.SAFETY_EXP) {
 
-			if (token.type == Type.STRING) {
+                SafetyReqExpr safetyExpr = safetyReqExpr();
+                safetyReq.setCondition(safetyExpr);
 
-				String identifier = id_value();
-				safetyReq.setId(identifier);
+            } else if (token.type == Type.OPTION) {
 
-			} else if (token.type == Type.SAFETY_EXP) {
+                String type_value = token.sd.getName();
+                Type type = Type.get(type_value);
+                consume(Type.OPTION);
 
-				SafetyReqExpr safetyExpr = safetyReqExpr();
-				safetyReq.setCondition(safetyExpr);
+                if (type == Type.COMMENT) {
 
-			} else if (token.type == Type.OPTION) {
+                    String comment = str_value();
+                    safetyReq.setComment(comment);
 
-				String type_value = token.sd.getName();
-				Type type = Type.get(type_value);
-				consume(Type.OPTION);
+                } else if (type == Type.DESCRIPTION) {
 
-				if (type == Type.COMMENT) {
+                    String description = str_value();
+                    safetyReq.setDescription(description);
 
-					String comment = str_value();
-					safetyReq.setComment(comment);
+                } else if (type == Type.PHASES) {
 
-				} else if (type == Type.DESCRIPTION) {
+                    String phases = str_value();
+                    safetyReq.setPhases(phases);
 
-					String description = str_value();
-					safetyReq.setDescription(description);
+                } else if (type == Type.EXTERN) {
 
-				} else if (type == Type.PHASES) {
+                    String extern = str_value();
+                    safetyReq.setExtern(extern);
 
-					String phases = str_value();
-					safetyReq.setPhases(phases);
+                } else if (type == Type.TARGET_PROBABILITY) {
 
-				} else if (type == Type.EXTERN) {
+                    String targetProbability = str_value();
+                    safetyReq.setTargetProbability(targetProbability);
+                }
+            }
+        }
 
-					String extern = str_value();
-					safetyReq.setExtern(extern);
+        return safetyReq;
+    }
 
-				} else if (type == Type.TARGET_PROBABILITY) {
+    public Mission mission() {
+        Mission mission = new Mission();
 
-					String targetProbability = str_value();
-					safetyReq.setTargetProbability(targetProbability);
-				}
-			}
-		}
+        while (this.token.type == Type.MISSION) {
+            consume(Type.MISSION);
 
-		return safetyReq;
-	}
+            if (token.type == Type.STRING) {
 
-	public Mission mission() {
-		Mission mission = new Mission();
+                String identifier = id_value();
+                mission.setId(identifier);
 
-		while (this.token.type == Type.MISSION) {
-			consume(Type.MISSION);
+            } else if (token.type == Type.ARRAY_LIST) {
 
-			if (token.type == Type.STRING) {
+                int array_length = 0;
 
-				String identifier = id_value();
-				mission.setId(identifier);
+                String type_name = this.token.sd.getName();
+                Type type = Type.get(type_name);
 
-			} else if (token.type == Type.ARRAY_LIST) {
+                if (peek().type == Type.INT) {
+                    array_length = arrayList_length();
+                } else {
+                    if (type == Type.CYBER_REQS) {
+                        int cyberReq_index = arrayList_element();
 
-				int array_length = 0;
+                        String req = str_value();
+                        mission.getCyberReqs().add(req);
+                    }
+                }
 
-				String type_name = this.token.sd.getName();
-				Type type = Type.get(type_name);
+            } else if (token.type == Type.OPTION) {
 
-				if (peek().type == Type.INT) {
-					array_length = arrayList_length();
-				} else {
-					if (type == Type.CYBER_REQS) {
-						int cyberReq_index = arrayList_element();
+                Type type = Type.get(token.sd.getName());
+                consume(Type.OPTION);
+                Type optType = option();
 
-						String req = str_value();
-						mission.getCyberReqs().add(req);
-					}
-				}
+                if (optType == Type.SOME) {
+                    // Only consume if this is Some, not None
+                    if (type == Type.DESCRIPTION) {
 
-			} else if (token.type == Type.OPTION) {
+                        String description = str_value();
+                        mission.setDescription(description);
 
-				Type type = Type.get(token.sd.getName());
-				consume(Type.OPTION);
-				Type optType = option();
+                    } else if (type == Type.COMMENT) {
 
-				if (optType == Type.SOME) {
-					// Only consume if this is Some, not None
-					if (type == Type.DESCRIPTION) {
+                        String comment = str_value();
+                        mission.setComment(comment);
+                    }
+                }
+            }
+        }
 
-						String description = str_value();
-						mission.setDescription(description);
+        return mission;
+    }
 
-					} else if (type == Type.COMMENT) {
+    // type SafetyEvent {
+    // id: String;
+    // probability: String;
+    // comment: Option<String>;
+    // description : Option<String>;
+    // };
+    public Event safetyevent() {
 
-						String comment = str_value();
-						mission.setComment(comment);
-					}
-				}
-			}
-		}
+        Event event = new Event();
 
-		return mission;
-	}
+        while (this.token.type == Type.SAFETY_EVENT) {
 
-	// type SafetyEvent {
-	// id: String;
-	// probability: String;
-	// comment: Option<String>;
-	// description : Option<String>;
-	// };
-	public Event safetyevent() {
+            consume(Type.SAFETY_EVENT);
 
-		Event event = new Event();
+            if (token.type == Type.STRING) {
 
-		while (this.token.type == Type.SAFETY_EVENT) {
+                String str_type_value = token.sd.getName();
+                Type str_type = Type.get(str_type_value);
 
-			consume(Type.SAFETY_EVENT);
+                if (str_type == Type.EVENT_ID) {
+                    String identifier = id_value();
+                    event.setId(identifier);
+                } else if (str_type == Type.PROBABILITY) {
+                    String prob = id_value();
+                    event.setProbability(prob);
+                }
 
-			if (token.type == Type.STRING) {
+            } else if (token.type == Type.OPTION) {
 
-				String str_type_value = token.sd.getName();
-				Type str_type = Type.get(str_type_value);
+                String type_value = token.sd.getName();
+                Type type = Type.get(type_value);
+                consume(Type.OPTION);
 
-				if (str_type == Type.EVENT_ID) {
-					String identifier = id_value();
-					event.setId(identifier);
-				} else if (str_type == Type.PROBABILITY) {
-					String prob = id_value();
-					event.setProbability(prob);
-				}
+                if (type == Type.COMMENT) {
 
-			} else if (token.type == Type.OPTION) {
+                    String comment = str_value();
+                    event.setComment(comment);
 
-				String type_value = token.sd.getName();
-				Type type = Type.get(type_value);
-				consume(Type.OPTION);
+                } else if (type == Type.DESCRIPTION) {
 
-				if (type == Type.COMMENT) {
+                    String description = str_value();
+                    event.setDescription(description);
+                }
+            }
+        }
 
-					String comment = str_value();
-					event.setComment(comment);
+        return event;
+    }
 
-				} else if (type == Type.DESCRIPTION) {
+    /*
+     * type CIAPort { name: String; cia: CIA; }
+     */
+    public CIAPort cia_port() {
+        CIAPort ciaPort = new CIAPort();
 
-					String description = str_value();
-					event.setDescription(description);
-				}
-			}
-		}
+        while (this.token.type == Type.CIA_PORT) {
+            consume(Type.CIA_PORT);
 
-		return event;
-	}
+            if (token.type == Type.STRING) {
 
-	/*
-	 * type CIAPort { name: String; cia: CIA; }
-	 */
-	public CIAPort cia_port() {
-		CIAPort ciaPort = new CIAPort();
+                String identifier = id_value();
+                ciaPort.setName(identifier);
 
-		while (this.token.type == Type.CIA_PORT) {
-			consume(Type.CIA_PORT);
+            } else if (token.type == Type.CIA) {
+                CIA cia = cia();
+                ciaPort.setCia(cia);
+            }
+        }
 
-			if (token.type == Type.STRING) {
+        return ciaPort;
+    }
 
-				String identifier = id_value();
-				ciaPort.setName(identifier);
+    // SAFETY
+    public IAPort ia_port() {
+        IAPort iaPort = new IAPort();
 
-			} else if (token.type == Type.CIA) {
-				CIA cia = cia();
-				ciaPort.setCia(cia);
-			}
-		}
+        while (this.token.type == Type.IA_PORT) {
+            consume(Type.IA_PORT);
 
-		return ciaPort;
-	}
+            if (token.type == Type.STRING) {
 
-	// SAFETY
-	public IAPort ia_port() {
-		IAPort iaPort = new IAPort();
+                String identifier = id_value();
+                iaPort.setName(identifier);
 
-		while (this.token.type == Type.IA_PORT) {
-			consume(Type.IA_PORT);
+            } else if (token.type == Type.IA) {
+                IA ia = ia();
+                iaPort.setIa(ia);
+            }
+        }
 
-			if (token.type == Type.STRING) {
+        return iaPort;
+    }
 
-				String identifier = id_value();
-				iaPort.setName(identifier);
+    public EventHappens eventHappens() {
+        EventHappens event = new EventHappens();
 
-			} else if (token.type == Type.IA) {
-				IA ia = ia();
-				iaPort.setIa(ia);
-			}
-		}
+        // while (this.token.type == Type.HAPPENS) {
+        // consume(Type.HAPPENS);
+        consume();
+        if (token.type == Type.STRING) {
+            String identifier = id_value();
+            event.setEventName(identifier);
+            // } else {
+            // System.out.println("Event happens: toeken " + token);
+            // }
+        }
+        // consume();
 
-		return iaPort;
-	}
+        return event;
+    }
 
-	public EventHappens eventHappens() {
-		EventHappens event = new EventHappens();
+    /*
+     * type CIA enum {Confidentiality, Integrity, Availability};
+     */
+    public CIA cia() {
 
-		// while (this.token.type == Type.HAPPENS) {
-		// consume(Type.HAPPENS);
-		consume();
-		if (token.type == Type.STRING) {
-			String identifier = id_value();
-			event.setEventName(identifier);
-			// } else {
-			// System.out.println("Event happens: toeken " + token);
-			// }
-		}
-		// consume();
+        consume(Type.CIA);
 
-		return event;
-	}
+        String type_name = token.sd.getName();
 
-	/*
-	 * type CIA enum {Confidentiality, Integrity, Availability};
-	 */
-	public CIA cia() {
+        CIA cia_type = CIA.fromValue(type_name);
 
-		consume(Type.CIA);
+        consume();
 
-		String type_name = token.sd.getName();
+        return cia_type;
+    }
 
-		CIA cia_type = CIA.fromValue(type_name);
+    public IA ia() {
 
-		consume();
+        consume(Type.IA);
 
-		return cia_type;
-	}
+        String type_name = token.sd.getName();
 
-	public IA ia() {
+        IA ia_type = IA.fromValue(type_name);
 
-		consume(Type.IA);
+        consume();
 
-		String type_name = token.sd.getName();
+        return ia_type;
+    }
 
-		IA ia_type = IA.fromValue(type_name);
+    /*
+     * type Severity enum {None, Minor, Major, Hazardous, Catastrophic};
+     */
+    public Severity severity() {
 
-		consume();
+        consume(Type.SEVERITY);
 
-		return ia_type;
-	}
+        String type_name = token.sd.getName();
 
-	/*
-	 * type Severity enum {None, Minor, Major, Hazardous, Catastrophic};
-	 */
-	public Severity severity() {
+        Severity severity_type = Severity.fromValue(type_name);
 
-		consume(Type.SEVERITY);
+        consume();
 
-		String type_name = token.sd.getName();
+        return severity_type;
+    }
 
-		Severity severity_type = Severity.fromValue(type_name);
+    /*
+     * type CyberExprKind enum {Port, And, Or, Not};
+     */
 
-		consume();
+    public CyberExprKind cyberExprKind() {
 
-		return severity_type;
-	}
+        consume(Type.CYBER_EXP_KIND);
 
-	/*
-	 * type CyberExprKind enum {Port, And, Or, Not};
-	 */
+        String type_name = token.sd.getName();
 
-	public CyberExprKind cyberExprKind() {
+        CyberExprKind cyberExprKind = CyberExprKind.fromValue(type_name);
 
-		consume(Type.CYBER_EXP_KIND);
+        consume();
 
-		String type_name = token.sd.getName();
+        return cyberExprKind;
+    }
 
-		CyberExprKind cyberExprKind = CyberExprKind.fromValue(type_name);
+    public SafetyReqExprKind safetyReqExprKind() {
 
-		consume();
+        consume(Type.SAFETY_EXP_KIND);
 
-		return cyberExprKind;
-	}
+        String type_name = token.sd.getName();
 
-	public SafetyReqExprKind safetyReqExprKind() {
+        SafetyReqExprKind safetyReqExprKind = SafetyReqExprKind.fromValue(type_name);
 
-		consume(Type.SAFETY_EXP_KIND);
+        consume();
 
-		String type_name = token.sd.getName();
+        return safetyReqExprKind;
+    }
 
-		SafetyReqExprKind safetyReqExprKind = SafetyReqExprKind.fromValue(type_name);
+    public SafetyRelExprKind safetyRelExprKind() {
 
-		consume();
+        consume(Type.SAFETY_EXP_KIND);
 
-		return safetyReqExprKind;
-	}
+        String type_name = token.sd.getName();
 
-	public SafetyRelExprKind safetyRelExprKind() {
+        SafetyRelExprKind safetyRelExprKind = SafetyRelExprKind.fromValue(type_name);
 
-		consume(Type.SAFETY_EXP_KIND);
+        consume();
 
-		String type_name = token.sd.getName();
+        return safetyRelExprKind;
+    }
 
-		SafetyRelExprKind safetyRelExprKind = SafetyRelExprKind.fromValue(type_name);
+    // type Connection {
+    // name: Identifier;
+    // attributes: ArrayList<GenericAttribute>;
+    // source: ConnectionEnd;
+    // destination: ConnectionEnd;
+    // };
 
-		consume();
+    public Connection connection() {
 
-		return safetyRelExprKind;
-	}
+        Connection connection = new Connection();
+        List<GenericAttribute> connectionAttributes = connection.getAttribute();
 
-	// type Connection {
-	// name: Identifier;
-	// attributes: ArrayList<GenericAttribute>;
-	// source: ConnectionEnd;
-	// destination: ConnectionEnd;
-	// };
+        int list_size = 0;
+        Type type;
 
-	public Connection connection() {
+        while (this.token.type == Type.CONNECTION) {
 
-		Connection connection = new Connection();
-		List<GenericAttribute> connectionAttributes = connection.getAttribute();
+            consume(Type.CONNECTION);
 
-		int list_size = 0;
-		Type type;
+            if (token.type == Type.IDENTIFIER) {
 
-		while (this.token.type == Type.CONNECTION) {
+                String identifier = Identifier();
+                connection.setName(identifier);
 
-			consume(Type.CONNECTION);
+            } else if (token.type == Type.ARRAY_LIST) {
 
-			if (token.type == Type.IDENTIFIER) {
+                String type_name = this.token.sd.getName();
+                type = Type.get(type_name);
 
-				String identifier = Identifier();
-				connection.setName(identifier);
+                if (peek().type == Type.INT) {
+                    list_size = arrayList_length();
 
-			} else if (token.type == Type.ARRAY_LIST) {
+                } else {
+                    // while (list_size > 0) {
+                    // list_size--;
+                    // if (type == Type.GENERIC_ATTRIBUTE) {
+                    int attr_index = arrayList_element();
 
-				String type_name = this.token.sd.getName();
-				type = Type.get(type_name);
+                    GenericAttribute gattribute = genericAttribute();
+                    connectionAttributes.add(attr_index, gattribute);
+                    // }
+                    // }
+                }
 
-				if (peek().type == Type.INT) {
-					list_size = arrayList_length();
+            } else if (token.type == Type.CONNECTION_END) {
 
-				} else {
-					// while (list_size > 0) {
-					// list_size--;
-					// if (type == Type.GENERIC_ATTRIBUTE) {
-					int attr_index = arrayList_element();
+                String type_value = token.sd.getName();
+                type = Type.get(type_value);
 
-					GenericAttribute gattribute = genericAttribute();
-					connectionAttributes.add(attr_index, gattribute);
-					// }
-					// }
-				}
+                if (type == Type.SOURCE) {
+                    consume(Type.SOURCE);
+                    ConnectionEnd source = connectionEnd();
+                    connection.setSource(source);
+                } else if (type == Type.DESTINATION) {
+                    consume(Type.DESTINATION);
+                    ConnectionEnd destination = connectionEnd();
+                    connection.setDestination(destination);
+                }
+            }
+        }
 
-			} else if (token.type == Type.CONNECTION_END) {
+        return connection;
+    }
 
-				String type_value = token.sd.getName();
-				type = Type.get(type_value);
+    // ConnectionEnd
+    /*
+     * type ConnectionEnd { kind: ConnectionEndKind; component_port: Port;
+     * subcomponent_port: CompInstPort; };
+     */
+    public ConnectionEnd connectionEnd() {
 
-				if (type == Type.SOURCE) {
-					consume(Type.SOURCE);
-					ConnectionEnd source = connectionEnd();
-					connection.setSource(source);
-				} else if (type == Type.DESTINATION) {
-					consume(Type.DESTINATION);
-					ConnectionEnd destination = connectionEnd();
-					connection.setDestination(destination);
-				}
-			}
-		}
+        ConnectionEnd connectionEnd = new ConnectionEnd();
 
-		return connection;
-	}
+        while (token.type == Type.CONNECTION_END) {
+            consume(Type.CONNECTION_END);
 
-	// ConnectionEnd
-	/*
-	 * type ConnectionEnd { kind: ConnectionEndKind; component_port: Port;
-	 * subcomponent_port: CompInstPort; };
-	 */
-	public ConnectionEnd connectionEnd() {
+            if (token.type == Type.CONNECTION_END_KIND) {
+                // ComponentCE OR SubcomponentCE
+                connectionEndKind();
+            }
+            if (token.type == Type.PORT) {
+                consume(Type.PORT);
 
-		ConnectionEnd connectionEnd = new ConnectionEnd();
+                ComponentType type = getComponentType();
+                int port_index = arrayList_element();
+                Port port = type.getPort().get(port_index);
+                connectionEnd.setComponentPort(port);
+                // Port component_port = port();
+                // connectionEnd.setComponentPort(component_port);
+            } else if (token.type == Type.COMPONENT_INSTANCE_PORT) {
+                CompInstancePort subcomponent_port = compInstancePort();
+                connectionEnd.setSubcomponentPort(subcomponent_port);
+            }
+        }
 
-		while (token.type == Type.CONNECTION_END) {
-			consume(Type.CONNECTION_END);
+        return connectionEnd;
+    }
 
-			if (token.type == Type.CONNECTION_END_KIND) {
-				// ComponentCE OR SubcomponentCE
-				connectionEndKind();
-			}
-			if (token.type == Type.PORT) {
-				consume(Type.PORT);
+    // public ComponentType getComponentType() {
+    //
+    // ComponentType componentType;
+    // consume(Type.COMPONENT_TYPE);
+    // consume(Type.MODEL);
+    //
+    // int componet_type_index = arrayList_element();
+    // componentType = model.getComponentType().get(componet_type_index);
+    //
+    // return componentType;
+    //
+    // }
 
-				ComponentType type = getComponentType();
-				int port_index = arrayList_element();
-				Port port = type.getPort().get(port_index);
-				connectionEnd.setComponentPort(port);
-				// Port component_port = port();
-				// connectionEnd.setComponentPort(component_port);
-			} else if (token.type == Type.COMPONENT_INSTANCE_PORT) {
-				CompInstancePort subcomponent_port = compInstancePort();
-				connectionEnd.setSubcomponentPort(subcomponent_port);
-			}
-		}
+    // type ConnectionEndKind enum { ComponentCE, SubcomponentCE };
+    public Type connectionEndKind() {
 
-		return connectionEnd;
-	}
+        consume(Type.CONNECTION_END_KIND);
 
-	// public ComponentType getComponentType() {
-	//
-	// ComponentType componentType;
-	// consume(Type.COMPONENT_TYPE);
-	// consume(Type.MODEL);
-	//
-	// int componet_type_index = arrayList_element();
-	// componentType = model.getComponentType().get(componet_type_index);
-	//
-	// return componentType;
-	//
-	// }
+        String type_name = token.sd.getName();
+        Type type = Type.get(type_name);
 
-	// type ConnectionEndKind enum { ComponentCE, SubcomponentCE };
-	public Type connectionEndKind() {
+        if (type == Type.COMPONENT_CE) {
+            consume(Type.COMPONENT_CE);
+        } else if (type == Type.SUBCOMPONENT_CE) {
+            consume(Type.SUBCOMPONENT_CE);
+        }
 
-		consume(Type.CONNECTION_END_KIND);
+        return type;
+    }
 
-		String type_name = token.sd.getName();
-		Type type = Type.get(type_name);
+    /*
+     * type CompInstPort { subcomponent: ComponentInstance; port: Port; };
+     */
+    public CompInstancePort compInstancePort() {
 
-		if (type == Type.COMPONENT_CE) {
-			consume(Type.COMPONENT_CE);
-		} else if (type == Type.SUBCOMPONENT_CE) {
-			consume(Type.SUBCOMPONENT_CE);
-		}
+        CompInstancePort compInstancePort = new CompInstancePort();
 
-		return type;
-	}
+        while (this.token.type == Type.COMPONENT_INSTANCE_PORT) {
+            consume(Type.COMPONENT_INSTANCE_PORT);
 
-	/*
-	 * type CompInstPort { subcomponent: ComponentInstance; port: Port; };
-	 */
-	public CompInstancePort compInstancePort() {
+            if (token.type == Type.COMPONENT_INSTANCE) {
+                consume(Type.COMPONENT_INSTANCE);
 
-		CompInstancePort compInstancePort = new CompInstancePort();
+                ComponentInstance subcomponent = getComponentInstance();
+                compInstancePort.setSubcomponent(subcomponent);
+            } else if (token.type == Type.PORT) {
+                consume(Type.PORT);
 
-		while (this.token.type == Type.COMPONENT_INSTANCE_PORT) {
-			consume(Type.COMPONENT_INSTANCE_PORT);
+                ComponentType componentType = getComponentType();
+                int port_index = arrayList_element();
+                Port port = componentType.getPort().get(port_index);
 
-			if (token.type == Type.COMPONENT_INSTANCE) {
-				consume(Type.COMPONENT_INSTANCE);
+                compInstancePort.setPort(port);
+            }
+        }
 
-				ComponentInstance subcomponent = getComponentInstance();
-				compInstancePort.setSubcomponent(subcomponent);
-			} else if (token.type == Type.PORT) {
-				consume(Type.PORT);
+        return compInstancePort;
+    }
 
-				ComponentType componentType = getComponentType();
-				int port_index = arrayList_element();
-				Port port = componentType.getPort().get(port_index);
+    /*
+     * type ComponentInstance { name: Identifier;
+     *
+     * kind: ComponentInstanceKind;
+     *
+     * specification: ComponentType; implementation: ComponentImpl;
+     *
+     * has_sensitive_info: Option<Bool>; inside_trusted_boundary: Option<Bool>;
+     * broadcast_from_outside_tb: Option<Bool>; unenc_wifi_from_outside_tb:
+     * Option<Bool>; heterogeneity: Option<Bool>; encryption: Option<Bool>;
+     * anti_jamming: Option<Bool>; anti_flooding: Option<Bool>; anti_fuzzing:
+     * Option<Bool>;
+     *
+     * heterogeneity_dal: Option<Int>; encryption_dal: Option<Int>;
+     * anti_jamming_dal: Option<Int>; anti_flooding_dal: Option<Int>;
+     * anti_fuzzing_dal: Option<Int>; };
+     */
+    // type ComponentInstance {
+    // name: Identifier;
+    // kind: ComponentInstanceKind;
+    // specification: ComponentType;
+    // implementation: ComponentImpl;
+    // attributes: ArrayList<GenericAttribute>;
+    // };
 
-				compInstancePort.setPort(port);
-			}
-		}
+    public ComponentInstance componentInstance() {
 
-		return compInstancePort;
-	}
+        ComponentInstance componentInstance = new ComponentInstance();
+        List<GenericAttribute> componentAttributes = componentInstance.getAttribute();
 
-	/*
-	 * type ComponentInstance { name: Identifier;
-	 *
-	 * kind: ComponentInstanceKind;
-	 *
-	 * specification: ComponentType; implementation: ComponentImpl;
-	 *
-	 * has_sensitive_info: Option<Bool>; inside_trusted_boundary: Option<Bool>;
-	 * broadcast_from_outside_tb: Option<Bool>; unenc_wifi_from_outside_tb:
-	 * Option<Bool>; heterogeneity: Option<Bool>; encryption: Option<Bool>;
-	 * anti_jamming: Option<Bool>; anti_flooding: Option<Bool>; anti_fuzzing:
-	 * Option<Bool>;
-	 *
-	 * heterogeneity_dal: Option<Int>; encryption_dal: Option<Int>;
-	 * anti_jamming_dal: Option<Int>; anti_flooding_dal: Option<Int>;
-	 * anti_fuzzing_dal: Option<Int>; };
-	 */
-	// type ComponentInstance {
-	// name: Identifier;
-	// kind: ComponentInstanceKind;
-	// specification: ComponentType;
-	// implementation: ComponentImpl;
-	// attributes: ArrayList<GenericAttribute>;
-	// };
+        int list_size = 0;
+        Type type;
 
-	public ComponentInstance componentInstance() {
+        while (this.token.type == Type.COMPONENT_INSTANCE) {
+            consume(Type.COMPONENT_INSTANCE);
 
-		ComponentInstance componentInstance = new ComponentInstance();
-		List<GenericAttribute> componentAttributes = componentInstance.getAttribute();
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
+                componentInstance.setName(identifier);
+                componentInstance.setId(identifier);
+            } else if (token.type == Type.COMPONENT_INSTANCE_KIND) {
+                // Specification or Implementation
+                componentInstanceKind();
+            } else if (token.type == Type.COMPONENT_TYPE) {
+                consume(Type.COMPONENT_TYPE);
+                ComponentType specification = getComponentType();
+                componentInstance.setSpecification(specification);
+            } else if (token.type == Type.COMPONENT_IMPL_TYPE) {
+                consume(Type.COMPONENT_IMPL_TYPE);
+                ComponentImpl componentImpl = getComponentImpl();
+                componentInstance.setImplementation(componentImpl);
+            } else if (token.type == Type.ARRAY_LIST) {
 
-		int list_size = 0;
-		Type type;
+                String type_name = this.token.sd.getName();
+                type = Type.get(type_name);
 
-		while (this.token.type == Type.COMPONENT_INSTANCE) {
-			consume(Type.COMPONENT_INSTANCE);
+                if (peek().type == Type.INT) {
+                    list_size = arrayList_length();
 
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
-				componentInstance.setName(identifier);
-				componentInstance.setId(identifier);
-			} else if (token.type == Type.COMPONENT_INSTANCE_KIND) {
-				// Specification or Implementation
-				componentInstanceKind();
-			} else if (token.type == Type.COMPONENT_TYPE) {
-				consume(Type.COMPONENT_TYPE);
-				ComponentType specification = getComponentType();
-				componentInstance.setSpecification(specification);
-			} else if (token.type == Type.COMPONENT_IMPL_TYPE) {
-				consume(Type.COMPONENT_IMPL_TYPE);
-				ComponentImpl componentImpl = getComponentImpl();
-				componentInstance.setImplementation(componentImpl);
-			} else if (token.type == Type.ARRAY_LIST) {
+                } else {
 
-				String type_name = this.token.sd.getName();
-				type = Type.get(type_name);
+                    // while (list_size > 0) {
+                    // list_size--;
 
-				if (peek().type == Type.INT) {
-					list_size = arrayList_length();
+                    // if (type == Type.GENERIC_ATTRIBUTE) {
+                    int attr_index = arrayList_element();
 
-				} else {
+                    GenericAttribute gattribute = genericAttribute();
+                    componentAttributes.add(attr_index, gattribute);
+                    // }
+                }
+            }
+        }
 
-					// while (list_size > 0) {
-					// list_size--;
+        return componentInstance;
+    }
 
-					// if (type == Type.GENERIC_ATTRIBUTE) {
-					int attr_index = arrayList_element();
+    // type ComponentInstanceKind enum { Specification, Implementation };
+    public Type componentInstanceKind() {
 
-					GenericAttribute gattribute = genericAttribute();
-					componentAttributes.add(attr_index, gattribute);
-					// }
-				}
-			}
-		}
+        consume(Type.COMPONENT_INSTANCE_KIND);
 
-		return componentInstance;
-	}
+        String type_name = token.sd.getName();
+        Type type = Type.get(type_name);
 
-	// type ComponentInstanceKind enum { Specification, Implementation };
-	public Type componentInstanceKind() {
+        if (type == Type.SPECIFICATION) {
+            consume(Type.SPECIFICATION);
+        } else if (type == Type.IMPLEMENTATION) {
+            consume(Type.IMPLEMENTATION);
+        }
 
-		consume(Type.COMPONENT_INSTANCE_KIND);
+        return type;
+    }
 
-		String type_name = token.sd.getName();
-		Type type = Type.get(type_name);
+    public String category() {
 
-		if (type == Type.SPECIFICATION) {
-			consume(Type.SPECIFICATION);
-		} else if (type == Type.IMPLEMENTATION) {
-			consume(Type.IMPLEMENTATION);
-		}
+        String category_value = token.getStringValue();
+        consume(Type.String);
 
-		return type;
-	}
+        return category_value;
+    }
 
-	public String category() {
+    public int integerValue() {
 
-		String category_value = token.getStringValue();
-		consume(Type.String);
+        int int_value;
+        Token token = this.token;
+        NumberLiteral value = (NumberLiteral) token.value;
+        int_value = value.getValue();
+        consume(Type.INT);
 
-		return category_value;
-	}
+        return int_value;
+    }
+    // type ConnectionEndKind enum { ComponentCE, SubcomponentCE };
+    // public ConnectionEnd
 
-	public int integerValue() {
+    /*
+     * type ComponentImpl { name: Identifier; ctype: ComponentType; kind:
+     * ComponentImplKind; block_impl: BlockImpl; dataflow_impl: NodeBody; };
+     */
+    public ComponentImpl componentImpl() {
 
-		int int_value;
-		Token token = this.token;
-		NumberLiteral value = (NumberLiteral) token.value;
-		int_value = value.getValue();
-		consume(Type.INT);
+        componentImpl = new ComponentImpl();
 
-		return int_value;
-	}
-	// type ConnectionEndKind enum { ComponentCE, SubcomponentCE };
-	// public ConnectionEnd
+        // @TODO: Check ID.
+        /// String ID = this.token.sd.getName();
 
-	/*
-	 * type ComponentImpl { name: Identifier; ctype: ComponentType; kind:
-	 * ComponentImplKind; block_impl: BlockImpl; dataflow_impl: NodeBody; };
-	 */
-	public ComponentImpl componentImpl() {
+        while (token.type == Type.COMPONENT_IMPL_TYPE) {
+            consume(Type.COMPONENT_IMPL_TYPE);
 
-		componentImpl = new ComponentImpl();
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
+                componentImpl.setName(identifier);
+                componentImpl.setId(identifier);
+            } else if (token.type == Type.COMPONENT_TYPE) {
+                consume(Type.COMPONENT_TYPE);
+                ComponentType componentType = getComponentType();
+                componentImpl.setType(componentType);
 
-		// @TODO: Check ID.
-		/// String ID = this.token.sd.getName();
+            } else if (token.type == Type.COMPONENT_IMPL_KIND) {
+                // Not Restricting Type Yet [DataFlow or BlockType]
+                componentImplKind();
+            } else if (token.type == Type.BLOCK_IMPL) {
+                blockImpl = blockImpl();
+                componentImpl.setBlockImpl(blockImpl);
+            } else if (token.type == Type.NODE_BODY) {
+                // consume(Type.COMPONENT_IMPL_TYPE);
 
-		while (token.type == Type.COMPONENT_IMPL_TYPE) {
-			consume(Type.COMPONENT_IMPL_TYPE);
+                NodeBody nodeBody = nodeBody();
+                componentImpl.setDataflowImpl(nodeBody);
+            }
+        }
 
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
-				componentImpl.setName(identifier);
-				componentImpl.setId(identifier);
-			} else if (token.type == Type.COMPONENT_TYPE) {
-				consume(Type.COMPONENT_TYPE);
-				ComponentType componentType = getComponentType();
-				componentImpl.setType(componentType);
+        return componentImpl;
+    }
 
-			} else if (token.type == Type.COMPONENT_IMPL_KIND) {
-				// Not Restricting Type Yet [DataFlow or BlockType]
-				componentImplKind();
-			} else if (token.type == Type.BLOCK_IMPL) {
-				blockImpl = blockImpl();
-				componentImpl.setBlockImpl(blockImpl);
-			} else if (token.type == Type.NODE_BODY) {
-				// consume(Type.COMPONENT_IMPL_TYPE);
+    // type ComponentImplKind enum { Block_Impl, Dataflow_Impl };
+    public Type componentImplKind() {
 
-				NodeBody nodeBody = nodeBody();
-				componentImpl.setDataflowImpl(nodeBody);
-			}
-		}
+        consume(Type.COMPONENT_IMPL_KIND);
+        String type_name = token.sd.getName();
+        Type type = Type.get(type_name);
 
-		return componentImpl;
-	}
+        if (type == Type.Block_IMPL) {
+            consume(Type.Block_IMPL);
+        }
+        if (type == Type.DATA_FLOW_IML) {
+            consume(Type.DATA_FLOW_IML);
+        }
 
-	// type ComponentImplKind enum { Block_Impl, Dataflow_Impl };
-	public Type componentImplKind() {
+        return type;
+    }
 
-		consume(Type.COMPONENT_IMPL_KIND);
-		String type_name = token.sd.getName();
-		Type type = Type.get(type_name);
+    public ComponentType getComponentType() {
 
-		if (type == Type.Block_IMPL) {
-			consume(Type.Block_IMPL);
-		}
-		if (type == Type.DATA_FLOW_IML) {
-			consume(Type.DATA_FLOW_IML);
-		}
+        ComponentType componentType;
+        // consume(Type.COMPONENT_TYPE);
+        consume(Type.MODEL);
 
-		return type;
-	}
+        int componet_type_index = arrayList_element();
+        componentType = model.getComponentType().get(componet_type_index);
 
-	public ComponentType getComponentType() {
+        return componentType;
+    }
 
-		ComponentType componentType;
-		// consume(Type.COMPONENT_TYPE);
-		consume(Type.MODEL);
+    public ComponentImpl getComponentImpl() {
 
-		int componet_type_index = arrayList_element();
-		componentType = model.getComponentType().get(componet_type_index);
+        ComponentImpl componentImpl;
 
-		return componentType;
-	}
+        consume(Type.MODEL);
 
-	public ComponentImpl getComponentImpl() {
+        int componet_type_index = arrayList_element();
+        componentImpl = model.getComponentImpl().get(componet_type_index);
 
-		ComponentImpl componentImpl;
+        return componentImpl;
+    }
 
-		consume(Type.MODEL);
+    public ComponentInstance getComponentInstance() {
 
-		int componet_type_index = arrayList_element();
-		componentImpl = model.getComponentImpl().get(componet_type_index);
+        ComponentInstance componentInstance;
+        consume(Type.BLOCK_IMPL);
 
-		return componentImpl;
-	}
+        int component_instance_index = arrayList_element();
 
-	public ComponentInstance getComponentInstance() {
+        componentInstance = blockImpl.getSubcomponent().get(component_instance_index);
 
-		ComponentInstance componentInstance;
-		consume(Type.BLOCK_IMPL);
+        return componentInstance;
+    }
 
-		int component_instance_index = arrayList_element();
+    /*
+     * type BlockImpl { subcomponents: ArrayList<ComponentInstance>; connections:
+     * ArrayList<Connection>; };
+     */
+    public BlockImpl blockImpl() {
 
-		componentInstance = blockImpl.getSubcomponent().get(component_instance_index);
+        blockImpl = new BlockImpl();
+        List<ComponentInstance> subcomponents = blockImpl.getSubcomponent();
+        List<Connection> connections = blockImpl.getConnection();
 
-		return componentInstance;
-	}
+        int array_length = -1;
 
-	/*
-	 * type BlockImpl { subcomponents: ArrayList<ComponentInstance>; connections:
-	 * ArrayList<Connection>; };
-	 */
-	public BlockImpl blockImpl() {
+        while (this.token.type == Type.BLOCK_IMPL) {
+            consume(Type.BLOCK_IMPL);
 
-		blockImpl = new BlockImpl();
-		List<ComponentInstance> subcomponents = blockImpl.getSubcomponent();
-		List<Connection> connections = blockImpl.getConnection();
+            if (token.type == Type.ARRAY_LIST) {
 
-		int array_length = -1;
+                String type_name = this.token.sd.getName();
+                Type type = Type.get(type_name);
 
-		while (this.token.type == Type.BLOCK_IMPL) {
-			consume(Type.BLOCK_IMPL);
+                if (peek().type == Type.INT) {
 
-			if (token.type == Type.ARRAY_LIST) {
+                    array_length = arrayList_length();
 
-				String type_name = this.token.sd.getName();
-				Type type = Type.get(type_name);
+                } else {
 
-				if (peek().type == Type.INT) {
+                    int element_index = arrayList_element();
 
-					array_length = arrayList_length();
+                    if (token.type == Type.COMPONENT_INSTANCE) {
 
-				} else {
+                        ComponentInstance componentInstance = componentInstance();
+                        subcomponents.add(element_index, componentInstance);
+                    } else if (token.type == Type.CONNECTION) {
 
-					int element_index = arrayList_element();
+                        Connection connection = connection();
+                        connections.add(element_index, connection);
+                    }
+                }
+            }
+        }
 
-					if (token.type == Type.COMPONENT_INSTANCE) {
+        return blockImpl;
+    }
 
-						ComponentInstance componentInstance = componentInstance();
-						subcomponents.add(element_index, componentInstance);
-					} else if (token.type == Type.CONNECTION) {
+    /*
+     * type NodeBody { constant_declarations: ArrayList<ConstantDeclaration>;
+     * variable_declarations: ArrayList<VariableDeclaration>; assertions:
+     * ArrayList<Expression>; equations: ArrayList<NodeEquation>; properties:
+     * ArrayList<NodeProperty>; };
+     */
+    public NodeBody nodeBody() {
 
-						Connection connection = connection();
-						connections.add(element_index, connection);
-					}
-				}
-			}
-		}
+        NodeBody nodeBody = new NodeBody();
+        int array_length = 0;
 
-		return blockImpl;
-	}
+        while (token.type == Type.NODE_BODY) {
 
-	/*
-	 * type NodeBody { constant_declarations: ArrayList<ConstantDeclaration>;
-	 * variable_declarations: ArrayList<VariableDeclaration>; assertions:
-	 * ArrayList<Expression>; equations: ArrayList<NodeEquation>; properties:
-	 * ArrayList<NodeProperty>; };
-	 */
-	public NodeBody nodeBody() {
+            consume(Type.NODE_BODY);
 
-		NodeBody nodeBody = new NodeBody();
-		int array_length = 0;
+            if (token.type == Type.ARRAY_LIST) {
 
-		while (token.type == Type.NODE_BODY) {
+                String type_value = this.token.sd.getName();
+                Type type = Type.get(type_value);
 
-			consume(Type.NODE_BODY);
+                if (peek().type == Type.INT) {
+                    array_length = arrayList_length();
+                } else {
 
-			if (token.type == Type.ARRAY_LIST) {
+                    if (type == Type.CONSTANT_DECLARATIONS) {
+                        int constantDeclaration_index = arrayList_element();
 
-				String type_value = this.token.sd.getName();
-				Type type = Type.get(type_value);
+                        ConstantDeclaration constantDeclaration = constantDeclaration();
+                        nodeBody.getConstantDeclaration()
+                                .add(constantDeclaration_index, constantDeclaration);
+                    } else if (type == Type.VARIABLE_DECLARATIONS) {
+                        int variableDeclaration_index = arrayList_element();
 
-				if (peek().type == Type.INT) {
-					array_length = arrayList_length();
-				} else {
+                        VariableDeclaration variableDeclaration = variableDeclaration();
+                        nodeBody.getVariableDeclaration()
+                                .add(variableDeclaration_index, variableDeclaration);
 
-					if (type == Type.CONSTANT_DECLARATIONS) {
-						int constantDeclaration_index = arrayList_element();
+                    } else if (type == Type.ASSERTIONS) {
+                        int expression_index = arrayList_element();
+                        Expression expression = expression();
+                        nodeBody.getAssertion().add(expression_index, expression);
+                    } else if (type == Type.EQUATIONS) {
+                        int nodeEquation_index = arrayList_element();
+                        NodeEquation nodeEquation = nodeEquation();
+                        // LOGGER.info("NODE EQUATION: [" + nodeEquation_index +"] = "+
+                        // nodeEquation.getName());
+                        nodeBody.getEquation().add(nodeEquation_index, nodeEquation);
 
-						ConstantDeclaration constantDeclaration = constantDeclaration();
-						nodeBody.getConstantDeclaration().add(constantDeclaration_index, constantDeclaration);
-					} else if (type == Type.VARIABLE_DECLARATIONS) {
-						int variableDeclaration_index = arrayList_element();
+                    } else if (type == Type.PROPERTIES) {
+                        int property_index = arrayList_element();
+                        NodeProperty nodeProperty = nodeProperty();
+                        nodeBody.getProperty().add(property_index, nodeProperty);
+                    }
+                }
+            }
+        }
 
-						VariableDeclaration variableDeclaration = variableDeclaration();
-						nodeBody.getVariableDeclaration().add(variableDeclaration_index, variableDeclaration);
+        return nodeBody;
+    }
+    /*
+     * type NodeProperty { name: Option<Identifier>; expression: Expression; };
+     */
 
-					} else if (type == Type.ASSERTIONS) {
-						int expression_index = arrayList_element();
-						Expression expression = expression();
-						nodeBody.getAssertion().add(expression_index, expression);
-					} else if (type == Type.EQUATIONS) {
-						int nodeEquation_index = arrayList_element();
-						NodeEquation nodeEquation = nodeEquation();
-						// LOGGER.info("NODE EQUATION: [" + nodeEquation_index +"] = "+
-						// nodeEquation.getName());
-						nodeBody.getEquation().add(nodeEquation_index, nodeEquation);
+    public NodeProperty nodeProperty() {
+        NodeProperty nodeProperty = new NodeProperty();
 
-					} else if (type == Type.PROPERTIES) {
-						int property_index = arrayList_element();
-						NodeProperty nodeProperty = nodeProperty();
-						nodeBody.getProperty().add(property_index, nodeProperty);
-					}
-				}
-			}
-		}
+        while (this.token.type == Type.NODE_PROPERTY) {
+            consume(Type.NODE_PROPERTY);
 
-		return nodeBody;
-	}
-	/*
-	 * type NodeProperty { name: Option<Identifier>; expression: Expression; };
-	 */
+            if (peek().type == Type.OPTION) {
+                String identifier = optionIdentifier();
+                nodeProperty.setName(identifier);
+            } else if (peek().type == Type.EXPRESSION) {
+                Expression expression = expression();
+                nodeProperty.setExpression(expression);
+            }
+        }
+        return nodeProperty;
+    }
 
-	public NodeProperty nodeProperty() {
-		NodeProperty nodeProperty = new NodeProperty();
+    public ArrayList<NodeProperty> arrayList_NodeProperty() {
 
-		while (this.token.type == Type.NODE_PROPERTY) {
-			consume(Type.NODE_PROPERTY);
+        ArrayList<NodeProperty> nodePropertyList = new ArrayList<NodeProperty>();
 
-			if (peek().type == Type.OPTION) {
-				String identifier = optionIdentifier();
-				nodeProperty.setName(identifier);
-			} else if (peek().type == Type.EXPRESSION) {
-				Expression expression = expression();
-				nodeProperty.setExpression(expression);
-			}
-		}
-		return nodeProperty;
-	}
+        int list_length = 0;
 
-	public ArrayList<NodeProperty> arrayList_NodeProperty() {
+        Type type = this.token.type;
 
-		ArrayList<NodeProperty> nodePropertyList = new ArrayList<NodeProperty>();
+        while (type == Type.ARRAY_LIST) {
 
-		int list_length = 0;
+            consume(Type.ARRAY_LIST);
 
-		Type type = this.token.type;
+            // length
+            if (this.token.type == Type.INT) {
 
-		while (type == Type.ARRAY_LIST) {
+                Token token = this.token;
+                NumberLiteral enumLength_literal = (NumberLiteral) token.value;
+                list_length = enumLength_literal.getValue();
+                consume(Type.INT);
 
-			consume(Type.ARRAY_LIST);
+                while (list_length > 0) {
 
-			// length
-			if (this.token.type == Type.INT) {
+                    // NULL:element
+                    consume(Type.NULL);
+                    list_length--;
+                    // element Index
+                    token = this.token;
+                    NumberLiteral element_index = (NumberLiteral) token.value;
+                    consume(Type.INT);
 
-				Token token = this.token;
-				NumberLiteral enumLength_literal = (NumberLiteral) token.value;
-				list_length = enumLength_literal.getValue();
-				consume(Type.INT);
+                    // //element Value : PORT
+                    // token = this.token;
+                    NodeProperty nodeProperty = nodeProperty();
+                    // consume(Type.String);
+                    nodePropertyList.add(element_index.getValue(), nodeProperty);
+                }
+            }
+        }
 
-				while (list_length > 0) {
+        return nodePropertyList;
+    }
 
-					// NULL:element
-					consume(Type.NULL);
-					list_length--;
-					// element Index
-					token = this.token;
-					NumberLiteral element_index = (NumberLiteral) token.value;
-					consume(Type.INT);
+    /*
+     * type NodeEquation { lhs: ArrayList<Identifier>; -- Indirect Reference rhs:
+     * Expression; };
+     */
+    public NodeEquation nodeEquation() {
 
-					// //element Value : PORT
-					// token = this.token;
-					NodeProperty nodeProperty = nodeProperty();
-					// consume(Type.String);
-					nodePropertyList.add(element_index.getValue(), nodeProperty);
-				}
-			}
-		}
+        NodeEquation nodeEquation = new NodeEquation();
+        NodeEquationLHS nodeEquationLHS = new NodeEquationLHS();
+        int length = 0;
 
-		return nodePropertyList;
-	}
+        while (token.type == Type.NODE_EQUATION) {
+            consume(Type.NODE_EQUATION);
 
-	/*
-	 * type NodeEquation { lhs: ArrayList<Identifier>; -- Indirect Reference rhs:
-	 * Expression; };
-	 */
-	public NodeEquation nodeEquation() {
+            // String type_value = token.sd.getName();
+            // Type type = Type.get(type_value);
 
-		NodeEquation nodeEquation = new NodeEquation();
-		NodeEquationLHS nodeEquationLHS = new NodeEquationLHS();
-		int length = 0;
+            if (token.type == Type.ARRAY_LIST) {
+                consume(Type.ARRAY_LIST);
 
-		while (token.type == Type.NODE_EQUATION) {
-			consume(Type.NODE_EQUATION);
+                // if(type == Type.Lhs) {
 
-			// String type_value = token.sd.getName();
-			// Type type = Type.get(type_value);
+                // String type_name = this.token.sd.getName();
+                // Type type = Type.get(type_name);
 
-			if (token.type == Type.ARRAY_LIST) {
-				consume(Type.ARRAY_LIST);
+                if (token.type == Type.INT) {
+                    // length
+                    consume(Type.INT);
+                    length = token.getNumberValue();
+                    // value
+                    consume(Type.Int);
 
-				// if(type == Type.Lhs) {
+                } else {
+                    // enum
+                    consume();
+                    int id_index = token.getNumberValue();
+                    // index
+                    consume(Type.Int);
 
-				// String type_name = this.token.sd.getName();
-				// Type type = Type.get(type_name);
+                    String identifier = token.getStringValue();
+                    consume(Type.String);
+                    nodeEquationLHS.getIdentifier().add(id_index, identifier);
 
-				if (token.type == Type.INT) {
-					// length
-					consume(Type.INT);
-					length = token.getNumberValue();
-					// value
-					consume(Type.Int);
+                    if (length == id_index + 1) {
+                        nodeEquation.setLhs(nodeEquationLHS);
+                    }
+                }
 
-				} else {
-					// enum
-					consume();
-					int id_index = token.getNumberValue();
-					// index
-					consume(Type.Int);
+                // }
+            } else if (token.type == Type.EXPRESSION) {
+                // if(type == Type.Rhs) {
+                consume(Type.EXPRESSION);
+                Expression expression = expression();
+                nodeEquation.setRhs(expression);
+                // }
+            }
+        }
 
-					String identifier = token.getStringValue();
-					consume(Type.String);
-					nodeEquationLHS.getIdentifier().add(id_index, identifier);
+        return nodeEquation;
+    }
 
-					if (length == id_index + 1) {
-						nodeEquation.setLhs(nodeEquationLHS);
-					}
-				}
+    // public NodeEquationLHS nodeEquationLHS() {
+    //
+    // NodeEquationLHS nodeEquationLHS = new NodeEquationLHS();
+    // int length = 0;
+    //
+    // while (token.type == Type.NODE_EQUATION) {
+    // consume(Type.NODE_EQUATION);
+    //
+    //
+    // }
+    //
+    // return nodeEquationLHS;
+    //
+    // }
 
-				// }
-			} else if (token.type == Type.EXPRESSION) {
-				// if(type == Type.Rhs) {
-				consume(Type.EXPRESSION);
-				Expression expression = expression();
-				nodeEquation.setRhs(expression);
-				// }
-			}
-		}
+    /*
+     * type Model { name: Identifier; type_declarations: ArrayList<TypeDeclaration>;
+     * component_types: ArrayList<ComponentType>; component_impl:
+     * ArrayList<ComponentImpl>; dataflow_code: Option<LustreProgram>;
+     * cyber_requirements: ArrayList<CyberReq>; };
+     */
 
-		return nodeEquation;
-	}
+    public Model model() {
 
-	// public NodeEquationLHS nodeEquationLHS() {
-	//
-	// NodeEquationLHS nodeEquationLHS = new NodeEquationLHS();
-	// int length = 0;
-	//
-	// while (token.type == Type.NODE_EQUATION) {
-	// consume(Type.NODE_EQUATION);
-	//
-	//
-	// }
-	//
-	// return nodeEquationLHS;
-	//
-	// }
+        int array_length = 0;
 
-	/*
-	 * type Model { name: Identifier; type_declarations: ArrayList<TypeDeclaration>;
-	 * component_types: ArrayList<ComponentType>; component_impl:
-	 * ArrayList<ComponentImpl>; dataflow_code: Option<LustreProgram>;
-	 * cyber_requirements: ArrayList<CyberReq>; };
-	 */
+        while (token.type == Type.MODEL) {
 
-	public Model model() {
+            consume(Type.MODEL);
 
-		int array_length = 0;
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
+                model.setName(identifier);
+            } else if (token.type == Type.ARRAY_LIST) {
 
-		while (token.type == Type.MODEL) {
+                String type_name = this.token.sd.getName();
+                Type type = Type.get(type_name);
 
-			consume(Type.MODEL);
+                if (peek().type == Type.INT) {
 
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
-				model.setName(identifier);
-			} else if (token.type == Type.ARRAY_LIST) {
+                    array_length = arrayList_length();
 
-				String type_name = this.token.sd.getName();
-				Type type = Type.get(type_name);
+                } else {
 
-				if (peek().type == Type.INT) {
+                    if (type == Type.TYPE_DECLARATIONS) {
 
-					array_length = arrayList_length();
+                        int typeDeclaration_index = arrayList_element();
 
-				} else {
+                        TypeDeclaration typeDeclaration = typeDeclaration();
+                        typeDeclarations.add(typeDeclaration_index, typeDeclaration);
 
-					if (type == Type.TYPE_DECLARATIONS) {
+                    } else if (type == Type.COMPONENT_TYPES) {
 
-						int typeDeclaration_index = arrayList_element();
+                        int component_index = arrayList_element();
 
-						TypeDeclaration typeDeclaration = typeDeclaration();
-						typeDeclarations.add(typeDeclaration_index, typeDeclaration);
+                        ComponentType componentType = componentType();
+                        componentTypes.add(component_index, componentType);
 
-					} else if (type == Type.COMPONENT_TYPES) {
+                    } else if (type == Type.COMPONENT_IMPL) {
 
-						int component_index = arrayList_element();
+                        int componet_impl_index = arrayList_element();
 
-						ComponentType componentType = componentType();
-						componentTypes.add(component_index, componentType);
+                        componentImpl = componentImpl();
+                        componentImpls.add(componet_impl_index, componentImpl);
 
-					} else if (type == Type.COMPONENT_IMPL) {
+                    } else if (type == Type.CYBER_REQUIREMENTS) {
 
-						int componet_impl_index = arrayList_element();
+                        int cyberReq_index = arrayList_element();
 
-						componentImpl = componentImpl();
-						componentImpls.add(componet_impl_index, componentImpl);
+                        CyberReq cyberReq = cyber_req();
+                        cyberRequirements.add(cyberReq_index, cyberReq);
 
-					} else if (type == Type.CYBER_REQUIREMENTS) {
+                    } else if (type == Type.SAFETY_REQUIREMENTS) {
+                        log("safety_req: " + token);
+                        int safetyReq_index = arrayList_element();
 
-						int cyberReq_index = arrayList_element();
+                        SafetyReq safetyReq = safety_req();
+                        safetyRequirements.add(safetyReq_index, safetyReq);
 
-						CyberReq cyberReq = cyber_req();
-						cyberRequirements.add(cyberReq_index, cyberReq);
+                    } else if (type == Type.MISSIONS) {
 
-					} else if (type == Type.SAFETY_REQUIREMENTS) {
-						log("safety_req: " + token);
-						int safetyReq_index = arrayList_element();
+                        int mission_index = arrayList_element();
 
-						SafetyReq safetyReq = safety_req();
-						safetyRequirements.add(safetyReq_index, safetyReq);
+                        Mission mission = mission();
+                        missions.add(mission_index, mission);
+                    }
+                }
 
-					} else if (type == Type.MISSIONS) {
+            } else if (token.type == Type.OPTION) {
 
-						int mission_index = arrayList_element();
+                consume(Type.OPTION);
 
-						Mission mission = mission();
-						missions.add(mission_index, mission);
-					}
-				}
+                Type type = option();
 
-			} else if (token.type == Type.OPTION) {
+                if (type == Type.SOME) {
+                    if (token.type == Type.LUSTRE_PRG) {
+                        LustreProgram lustreProgram = lustreProgram();
+                        model.setDataflowCode(lustreProgram);
+                    }
+                }
+                // skip None
+            }
+        }
 
-				consume(Type.OPTION);
+        return model;
+    }
 
-				Type type = option();
+    /*
+     * type LustreProgram { type_declarations: ArrayList<TypeDeclaration>;
+     * constant_declarations: ArrayList<ConstantDeclaration>; contract_declarations:
+     * ArrayList<Contract>; node_declarations: ArrayList<Node>; };
+     */
+    public LustreProgram lustreProgram() {
 
-				if (type == Type.SOME) {
-					if (token.type == Type.LUSTRE_PRG) {
-						LustreProgram lustreProgram = lustreProgram();
-						model.setDataflowCode(lustreProgram);
-					}
-				}
-				// skip None
-			}
-		}
+        LustreProgram lustreProgram = new LustreProgram();
+        int array_length = 0;
 
-		return model;
-	}
+        while (token.type == Type.LUSTRE_PRG) {
 
-	/*
-	 * type LustreProgram { type_declarations: ArrayList<TypeDeclaration>;
-	 * constant_declarations: ArrayList<ConstantDeclaration>; contract_declarations:
-	 * ArrayList<Contract>; node_declarations: ArrayList<Node>; };
-	 */
-	public LustreProgram lustreProgram() {
+            consume(Type.LUSTRE_PRG);
 
-		LustreProgram lustreProgram = new LustreProgram();
-		int array_length = 0;
+            if (token.type == Type.ARRAY_LIST) {
 
-		while (token.type == Type.LUSTRE_PRG) {
+                String type_name = this.token.sd.getName();
+                Type type = Type.get(type_name);
 
-			consume(Type.LUSTRE_PRG);
+                if (peek().type == Type.INT) {
 
-			if (token.type == Type.ARRAY_LIST) {
+                    array_length = arrayList_length();
 
-				String type_name = this.token.sd.getName();
-				Type type = Type.get(type_name);
+                } else {
 
-				if (peek().type == Type.INT) {
+                    if (type == Type.TYPE_DECLARATIONS) {
 
-					array_length = arrayList_length();
+                        int typeDeclaration_index = arrayList_element();
 
-				} else {
+                        TypeDeclaration typeDeclaration = typeDeclaration();
+                        lustreProgram
+                                .getTypeDeclaration()
+                                .add(typeDeclaration_index, typeDeclaration);
+                    } else if (type == Type.CONSTANT_DECLARATIONS) {
+                        int constantDeclaration_index = arrayList_element();
 
-					if (type == Type.TYPE_DECLARATIONS) {
+                        ConstantDeclaration constantDeclaration = constantDeclaration();
+                        // LOGGER.info(
+                        // "CONSTANT DECLARATION: ["
+                        // + constantDeclaration_index
+                        // + "] = "
+                        // + constantDeclaration.getName());
+                        // SymbolDefinition symbolDefinition =
+                        // symbolDefinition();
+                        lustreProgram
+                                .getConstantDeclaration()
+                                .add(constantDeclaration_index, constantDeclaration);
+                    } else if (type == Type.CONTRACT_DECLARATIONS) {
 
-						int typeDeclaration_index = arrayList_element();
+                        int contract_index = arrayList_element();
 
-						TypeDeclaration typeDeclaration = typeDeclaration();
-						lustreProgram.getTypeDeclaration().add(typeDeclaration_index, typeDeclaration);
-					} else if (type == Type.CONSTANT_DECLARATIONS) {
-						int constantDeclaration_index = arrayList_element();
+                        Contract contract = contract();
+                        lustreProgram.getContractDeclaration().add(contract_index, contract);
 
-						ConstantDeclaration constantDeclaration = constantDeclaration();
-						// LOGGER.info(
-						// "CONSTANT DECLARATION: ["
-						// + constantDeclaration_index
-						// + "] = "
-						// + constantDeclaration.getName());
-						// SymbolDefinition symbolDefinition =
-						// symbolDefinition();
-						lustreProgram.getConstantDeclaration().add(constantDeclaration_index, constantDeclaration);
-					} else if (type == Type.CONTRACT_DECLARATIONS) {
+                    } else if (type == Type.NODE_DECLARATIONS) {
 
-						int contract_index = arrayList_element();
+                        int node_index = arrayList_element();
 
-						Contract contract = contract();
-						lustreProgram.getContractDeclaration().add(contract_index, contract);
+                        Node node = node();
+                        lustreProgram.getNodeDeclaration().add(node_index, node);
+                    }
+                }
+            }
+        }
 
-					} else if (type == Type.NODE_DECLARATIONS) {
+        return lustreProgram;
+    }
 
-						int node_index = arrayList_element();
+    /*
+     * type Node { name: Identifier; is_function: Bool; is_main: Bool;
+     * input_parameters: ArrayList<InputParameter>; output_parameters:
+     * ArrayList<OutputParameter>; contract: Option<ContractSpec>; body:
+     * Option<NodeBody>; };
+     */
+    public Node node() {
 
-						Node node = node();
-						lustreProgram.getNodeDeclaration().add(node_index, node);
-					}
-				}
-			}
-		}
+        Node node = new Node();
 
-		return lustreProgram;
-	}
+        int array_length = 0;
 
-	/*
-	 * type Node { name: Identifier; is_function: Bool; is_main: Bool;
-	 * input_parameters: ArrayList<InputParameter>; output_parameters:
-	 * ArrayList<OutputParameter>; contract: Option<ContractSpec>; body:
-	 * Option<NodeBody>; };
-	 */
-	public Node node() {
+        while (token.type == Type.NODE_TYPE) {
 
-		Node node = new Node();
+            consume(Type.NODE_TYPE);
 
-		int array_length = 0;
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
+                node.setName(identifier);
+            } else if (token.type == Type.BOOL) {
 
-		while (token.type == Type.NODE_TYPE) {
+                String type_name = this.token.sd.getName();
+                Type type = Type.get(type_name);
 
-			consume(Type.NODE_TYPE);
+                consume(Type.BOOL);
+                boolean value = token.getTruthValue();
+                consume(Type.Boolean);
 
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
-				node.setName(identifier);
-			} else if (token.type == Type.BOOL) {
+                if (type == Type.IS_FUNCTION) {
+                    node.setIsFunction(value);
+                } else if (type == Type.IS_MAIN) {
+                    // TODO node.setIsMain(value);
+                }
+            } else if (token.type == Type.ARRAY_LIST) {
 
-				String type_name = this.token.sd.getName();
-				Type type = Type.get(type_name);
+                String type_name = this.token.sd.getName();
+                Type type = Type.get(type_name);
 
-				consume(Type.BOOL);
-				boolean value = token.getTruthValue();
-				consume(Type.Boolean);
+                if (peek().type == Type.INT) {
 
-				if (type == Type.IS_FUNCTION) {
-					node.setIsFunction(value);
-				} else if (type == Type.IS_MAIN) {
-					// TODO node.setIsMain(value);
-				}
-			} else if (token.type == Type.ARRAY_LIST) {
+                    array_length = arrayList_length();
 
-				String type_name = this.token.sd.getName();
-				Type type = Type.get(type_name);
+                } else {
 
-				if (peek().type == Type.INT) {
+                    if (type == Type.INPUT_NODE_PARAMETER) {
 
-					array_length = arrayList_length();
+                        int parameter_index = arrayList_element();
+                        NodeParameter nodeParametre = inputParameter();
+                        node.getInputParameter().add(parameter_index, nodeParametre);
+                    } else if (type == Type.OUTPUT_NODE_PARAMETER) {
 
-				} else {
+                        int parameter_index = arrayList_element();
+                        NodeParameter nodeParametre = outputParameter();
+                        node.getOutputParameter().add(parameter_index, nodeParametre);
+                    }
+                }
 
-					if (type == Type.INPUT_NODE_PARAMETER) {
+            } else if (token.type == Type.OPTION) {
 
-						int parameter_index = arrayList_element();
-						NodeParameter nodeParametre = inputParameter();
-						node.getInputParameter().add(parameter_index, nodeParametre);
-					} else if (type == Type.OUTPUT_NODE_PARAMETER) {
+                consume(Type.OPTION);
 
-						int parameter_index = arrayList_element();
-						NodeParameter nodeParametre = outputParameter();
-						node.getOutputParameter().add(parameter_index, nodeParametre);
-					}
-				}
+                Type type = option();
 
-			} else if (token.type == Type.OPTION) {
+                if (type == Type.SOME) {
+                    if (token.type == Type.CONTRACT_SPEC) {
+                        ContractSpec contractSpec = contractSpec();
+                        node.setContract(contractSpec);
+                    }
+                    if (token.type == Type.NODE_BODY) {
 
-				consume(Type.OPTION);
+                        NodeBody nodeBody = nodeBody();
+                        node.setBody(nodeBody);
+                    }
+                }
+                // skip None
+            }
+        }
 
-				Type type = option();
+        return node;
+    }
 
-				if (type == Type.SOME) {
-					if (token.type == Type.CONTRACT_SPEC) {
-						ContractSpec contractSpec = contractSpec();
-						node.setContract(contractSpec);
-					}
-					if (token.type == Type.NODE_BODY) {
+    /*
+     * type NodeParameter { name: Identifier; dtype: DataType; }
+     */
 
-						NodeBody nodeBody = nodeBody();
-						node.setBody(nodeBody);
-					}
-				}
-				// skip None
-			}
-		}
+    /*
+     * type InputParameter { name: Identifier; dtype: DataType; is_constant: Bool;
+     * };
+     */
+    public NodeParameter inputParameter() {
 
-		return node;
-	}
+        NodeParameter nodeParameter = new NodeParameter();
+        DataType dataType = null;
 
-	/*
-	 * type NodeParameter { name: Identifier; dtype: DataType; }
-	 */
+        while (token.type == Type.INPUT_PARAMETER) {
+            consume(Type.INPUT_PARAMETER);
 
-	/*
-	 * type InputParameter { name: Identifier; dtype: DataType; is_constant: Bool;
-	 * };
-	 */
-	public NodeParameter inputParameter() {
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
 
-		NodeParameter nodeParameter = new NodeParameter();
-		DataType dataType = null;
+                nodeParameter.setName(identifier);
 
-		while (token.type == Type.INPUT_PARAMETER) {
-			consume(Type.INPUT_PARAMETER);
+            } else if (token.type == Type.DATA_TYPE) {
 
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
+                consume(Type.DATA_TYPE);
 
-				nodeParameter.setName(identifier);
+                if (token.type == Type.DATA_TYPE) {
+                    // consume(Type.DATA_TYPE);
+                    dataType = dataType();
 
-			} else if (token.type == Type.DATA_TYPE) {
+                } else if (token.type == Type.MODEL) {
+                    TypeDeclaration typeDeclaration = getTypeDeclaration();
+                    dataType = new DataType();
+                    dataType.setUserDefinedType(typeDeclaration.getName());
+                }
 
-				consume(Type.DATA_TYPE);
+                // DataType dataType_value = dataType();
+                nodeParameter.setDataType(dataType);
+            } else if (token.type == Type.BOOL) {
+                consume(Type.BOOL);
 
-				if (token.type == Type.DATA_TYPE) {
-					// consume(Type.DATA_TYPE);
-					dataType = dataType();
+                boolean value = token.getTruthValue();
+                consume(Type.Boolean);
+                // DATA this field into VDM Lustre in NodeParameter.
+                nodeParameter.setIsConstant(value);
+            }
+        }
 
-				} else if (token.type == Type.MODEL) {
-					TypeDeclaration typeDeclaration = getTypeDeclaration();
-					dataType = new DataType();
-					dataType.setUserDefinedType(typeDeclaration.getName());
-				}
+        return nodeParameter;
+    }
 
-				// DataType dataType_value = dataType();
-				nodeParameter.setDataType(dataType);
-			} else if (token.type == Type.BOOL) {
-				consume(Type.BOOL);
+    /*
+     * type OutputParameter { name: Identifier; dtype: DataType; };
+     */
 
-				boolean value = token.getTruthValue();
-				consume(Type.Boolean);
-				// DATA this field into VDM Lustre in NodeParameter.
-				nodeParameter.setIsConstant(value);
-			}
-		}
+    public NodeParameter outputParameter() {
 
-		return nodeParameter;
-	}
+        NodeParameter nodeParameter = new NodeParameter();
+        DataType dataType = null;
 
-	/*
-	 * type OutputParameter { name: Identifier; dtype: DataType; };
-	 */
+        while (token.type == Type.OUTPUT_PARAMETER) {
+            consume(Type.OUTPUT_PARAMETER);
 
-	public NodeParameter outputParameter() {
+            if (token.type == Type.IDENTIFIER) {
+                String identifier = Identifier();
 
-		NodeParameter nodeParameter = new NodeParameter();
-		DataType dataType = null;
+                nodeParameter.setName(identifier);
 
-		while (token.type == Type.OUTPUT_PARAMETER) {
-			consume(Type.OUTPUT_PARAMETER);
+            } else if (token.type == Type.DATA_TYPE) {
 
-			if (token.type == Type.IDENTIFIER) {
-				String identifier = Identifier();
+                consume(Type.DATA_TYPE);
 
-				nodeParameter.setName(identifier);
+                if (token.type == Type.DATA_TYPE) {
+                    // consume(Type.DATA_TYPE);
+                    dataType = dataType();
 
-			} else if (token.type == Type.DATA_TYPE) {
+                } else if (token.type == Type.MODEL) {
+                    TypeDeclaration typeDeclaration = getTypeDeclaration();
+                    dataType = new DataType();
+                    dataType.setUserDefinedType(typeDeclaration.getName());
+                }
 
-				consume(Type.DATA_TYPE);
+                // DataType dataType_value = dataType();
+                nodeParameter.setDataType(dataType);
+            }
+        }
 
-				if (token.type == Type.DATA_TYPE) {
-					// consume(Type.DATA_TYPE);
-					dataType = dataType();
-
-				} else if (token.type == Type.MODEL) {
-					TypeDeclaration typeDeclaration = getTypeDeclaration();
-					dataType = new DataType();
-					dataType.setUserDefinedType(typeDeclaration.getName());
-				}
-
-				// DataType dataType_value = dataType();
-				nodeParameter.setDataType(dataType);
-			}
-		}
-
-		return nodeParameter;
-	}
+        return nodeParameter;
+    }
 }

--- a/tools/verdict-back-ends/verdict-bundle-parent/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle-parent/pom.xml
@@ -16,17 +16,18 @@
 
     <modules>
         <module>iml-verdict-translator</module>
-        <module>verdict-data-model</module>
-        <module>verdict-lustre-translator</module>
-        <module>verdict-instrumentor</module>
-        <module>verdict-mbas-translator</module>
-        <module>verdict-test-instrumentor</module>
-        <module>verdict-blame-assignment</module>
-        <module>verdict-crv</module>
-        <module>verdict-stem-runner</module>
-        <module>verdict-bundle</module>
-        <module>verdict-synthesis</module>
         <module>verdict-attack-defense-collector</module>
+        <module>verdict-blame-assignment</module>
+        <module>verdict-bundle</module>
+        <module>verdict-crv</module>
+        <module>verdict-data-model</module>
+        <module>verdict-instrumentor</module>
+        <module>verdict-lustre-translator</module>
+        <module>verdict-mbas-translator</module>
+        <module>verdict-stem-runner</module>
+        <module>verdict-synthesis</module>
+        <module>verdict-test-instrumentor</module>
+        <module>z3-native-libs</module>
     </modules>
 
     <!-- Define dep versions here for consistency between modules -->
@@ -36,6 +37,11 @@
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
                 <version>1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>co.paralleluniverse</groupId>
+                <artifactId>capsule</artifactId>
+                <version>1.0.3</version>
             </dependency>
             <dependency>
                 <groupId>com.ge.research.sadl</groupId>
@@ -66,6 +72,11 @@
             </dependency>
             <dependency>
                 <groupId>com.ge.verdict</groupId>
+                <artifactId>verdict-attack-defense-collector</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ge.verdict</groupId>
                 <artifactId>verdict-data-model</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -91,18 +102,24 @@
             </dependency>
             <dependency>
                 <groupId>com.ge.verdict</groupId>
-                <artifactId>verdict-test-instrumentor</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.ge.verdict</groupId>
                 <artifactId>verdict-synthesis</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.ge.verdict</groupId>
-                <artifactId>verdict-attack-defense-collector</artifactId>
+                <artifactId>verdict-test-instrumentor</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ge.verdict</groupId>
+                <artifactId>z3-native-libs</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ge.verdict</groupId>
+                <artifactId>z3-native-libs</artifactId>
+                <version>${project.version}</version>
+                <classifier>api</classifier>
             </dependency>
             <dependency>
                 <groupId>com.sun.activation</groupId>
@@ -115,11 +132,6 @@
                 <version>1.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>edu.uiowa.clc.verdict.vdm</groupId>
-                <artifactId>iml-verdict-translator</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>edu.uiowa.clc.verdict.blm</groupId>
                 <artifactId>verdict-blame-assignment</artifactId>
                 <version>${project.version}</version>
@@ -127,6 +139,11 @@
             <dependency>
                 <groupId>edu.uiowa.clc.verdict.crv</groupId>
                 <artifactId>verdict-crv</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>edu.uiowa.clc.verdict.vdm</groupId>
+                <artifactId>iml-verdict-translator</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -165,6 +182,11 @@
                 <version>1.10.8</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-math3</artifactId>
+                <version>3.6.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>3.16.1</version>
@@ -191,6 +213,11 @@
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
                 <version>2.3.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.logicng</groupId>
+                <artifactId>logicng</artifactId>
+                <version>1.6.2</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/tools/verdict-back-ends/verdict-bundle-parent/verdict-attack-defense-collector/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle-parent/verdict-attack-defense-collector/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>org.logicng</groupId>
             <artifactId>logicng</artifactId>
-            <version>1.6.2</version>
         </dependency>
         <!-- Dependencies needed only by tests or capsule jar -->
         <dependency>

--- a/tools/verdict-back-ends/verdict-bundle-parent/verdict-bundle/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle-parent/verdict-bundle/pom.xml
@@ -20,6 +20,10 @@
         </dependency>
         <dependency>
             <groupId>com.ge.verdict</groupId>
+            <artifactId>verdict-attack-defense-collector</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.ge.verdict</groupId>
             <artifactId>verdict-data-model</artifactId>
         </dependency>
         <dependency>
@@ -36,11 +40,11 @@
         </dependency>
         <dependency>
             <groupId>com.ge.verdict</groupId>
-            <artifactId>verdict-test-instrumentor</artifactId>
+            <artifactId>verdict-synthesis</artifactId>
         </dependency>
         <dependency>
-            <groupId>edu.uiowa.clc.verdict.vdm</groupId>
-            <artifactId>iml-verdict-translator</artifactId>
+            <groupId>com.ge.verdict</groupId>
+            <artifactId>verdict-test-instrumentor</artifactId>
         </dependency>
         <dependency>
             <groupId>edu.uiowa.clc.verdict.blm</groupId>
@@ -51,12 +55,8 @@
             <artifactId>verdict-crv</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.ge.verdict</groupId>
-            <artifactId>verdict-attack-defense-collector</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.ge.verdict</groupId>
-            <artifactId>verdict-synthesis</artifactId>
+            <groupId>edu.uiowa.clc.verdict.vdm</groupId>
+            <artifactId>iml-verdict-translator</artifactId>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -68,6 +68,11 @@
         </dependency>
         <!-- Dependencies needed only by tests or capsule jar -->
         <dependency>
+            <groupId>com.ge.verdict</groupId>
+            <artifactId>z3-native-libs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
@@ -76,11 +81,41 @@
 
     <build>
         <plugins>
+            <!-- Unpack z3-native-libs -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-native-libs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <excludeClassifiers>api</excludeClassifiers>
+                            <excludes>META-INF/</excludes>
+                            <includeArtifactIds>z3-native-libs</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}/native-libs</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Add native libs to capsule -->
             <plugin>
                 <groupId>com.github.chrisdchristo</groupId>
                 <artifactId>capsule-maven-plugin</artifactId>
                 <configuration>
                     <appClass>com.ge.verdict.bundle.App</appClass>
+                    <caplets>SharedLibraryPathCapsule</caplets>
+                    <fileSets>
+                        <fileSet>
+                            <directory>${project.build.directory}/native-libs</directory>
+                            <includes>
+                                <include>*</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
                     <includeApp>true</includeApp>
                     <includeAppDep>true</includeAppDep>
                     <includePluginDep>false</includePluginDep>

--- a/tools/verdict-back-ends/verdict-bundle-parent/verdict-synthesis/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle-parent/verdict-synthesis/pom.xml
@@ -17,28 +17,30 @@
         <dependency>
             <groupId>com.ge.verdict</groupId>
             <artifactId>verdict-attack-defense-collector</artifactId>
-            <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.microsoft</groupId>
-            <artifactId>z3</artifactId>
-            <version>4.7.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.logicng</groupId>
-            <artifactId>logicng</artifactId>
-            <version>1.6.2</version>
+            <groupId>com.ge.verdict</groupId>
+            <artifactId>z3-native-libs</artifactId>
+            <classifier>api</classifier>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
-            <version>3.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.logicng</groupId>
+            <artifactId>logicng</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <!-- Dependencies needed only by tests or capsule jar -->
+        <dependency>
+            <groupId>com.ge.verdict</groupId>
+            <artifactId>z3-native-libs</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>javax.activation</artifactId>
@@ -63,11 +65,53 @@
 
     <build>
         <plugins>
+            <!-- Unpack z3-native-libs -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-native-libs</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <excludeClassifiers>api</excludeClassifiers>
+                            <excludes>META-INF/</excludes>
+                            <includeArtifactIds>z3-native-libs</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}/native-libs</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Run unit tests with native libs -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <DYLD_LIBRARY_PATH>${project.build.directory}/native-libs</DYLD_LIBRARY_PATH>
+                        <LD_LIBRARY_PATH>${project.build.directory}/native-libs</LD_LIBRARY_PATH>
+                        <PATH>${project.build.directory}/native-libs${path.separator}${env.PATH}</PATH>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+            <!-- Add native libs to capsule -->
             <plugin>
                 <groupId>com.github.chrisdchristo</groupId>
                 <artifactId>capsule-maven-plugin</artifactId>
                 <configuration>
                     <appClass>com.ge.verdict.synthesis.App</appClass>
+                    <caplets>SharedLibraryPathCapsule</caplets>
+                    <fileSets>
+                        <fileSet>
+                            <directory>${project.build.directory}/native-libs</directory>
+                            <includes>
+                                <include>*</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
                     <includeApp>true</includeApp>
                     <includeAppDep>true</includeAppDep>
                     <includePluginDep>false</includePluginDep>

--- a/tools/verdict-back-ends/verdict-bundle-parent/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/App.java
+++ b/tools/verdict-back-ends/verdict-bundle-parent/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/App.java
@@ -15,13 +15,10 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 public class App {
-    /*
-     * Note: currently must set LD_LIBRARY_PATH. For testing purposes
-     * this can be done in Eclipse run configurations, but we will have
-     * to figure this out in a cross-platform way and also set it up
-     * in the Docker image.
-     */
 
+    /*
+     * Note: please specify how to run this app for testing purposes.
+     */
     public static void main(String[] args) {
         if (args.length < 2) {
             throw new RuntimeException("Must specify STEM output directory and cost model XML!");

--- a/tools/verdict-back-ends/verdict-bundle-parent/z3-native-libs/README.md
+++ b/tools/verdict-back-ends/verdict-bundle-parent/z3-native-libs/README.md
@@ -1,0 +1,114 @@
+# Z3 Native Libs
+
+Add and use z3 native libraries in your application capsule in a cross
+platform way without any manual steps needed on your part.  You won't
+have to manually set platform-dependent DYLD\_LIBRARY\_PATH,
+LD\_LIBRARY\_PATH, or PATH environment variables when you run your
+application in a capsule.  The capsule will unpack the z3 native libs
+into its app cache directory and the SharedLibraryPathCapsule caplet
+will set whichever environment variable your platform needs to find
+these native libs.
+
+## How to build z3-native-libs
+
+All you have to do is to say `mvn clean install` and the pom will do
+the rest.  It will tell Maven to:
+
+1. Download the most recently released z3 binaries for osx, ubuntu,
+   and win platforms and unpack them in the target directory
+
+2. Build the SharedLibraryPathCapsule caplet class which sets the
+   appropriate environment variable needed to find the native libs
+
+3. Add the native libs and the SharedLibraryPathCapsule caplet class
+   to the z3-native-libs jar
+
+4. Install both the z3-native-libs jar and the com.microsoft.z3 jar in
+   the local Maven cache so other poms can find them.
+
+## How to use z3-native-libs
+
+Add the following two dependencies to your pom (one to let your app
+call the com.microsoft.z3 Java API, the other to add the native libs
+to your capsule):
+
+```xml
+        <dependency>
+            <groupId>com.ge.verdict</groupId>
+            <artifactId>z3-native-libs</artifactId>
+            <classifier>api</classifier>
+        </dependency>
+        <!-- Dependencies needed only by tests or capsule jar -->
+        <dependency>
+            <groupId>com.ge.verdict</groupId>
+            <artifactId>z3-native-libs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+```
+
+Call maven-dependency-plugin in your pom to unpack the native libs in
+z3-native-libs into your target/native-libs directory:
+
+```xml
+            <!-- Unpack z3-native-libs -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-native-libs</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <excludeClassifiers>api</excludeClassifiers>
+                            <excludes>META-INF/</excludes>
+                            <includeArtifactIds>z3-native-libs</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}/native-libs</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+```
+
+Call maven-surefire-plugin in your pom to run unit tests with these
+native libs:
+
+```xml
+            <!-- Run unit tests with native libs -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <DYLD_LIBRARY_PATH>${project.build.directory}/native-libs</DYLD_LIBRARY_PATH>
+                        <LD_LIBRARY_PATH>${project.build.directory}/native-libs</LD_LIBRARY_PATH>
+                        <PATH>${project.build.directory}/native-libs${path.separator}${env.PATH}</PATH>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+```
+
+Add the native libs to your capsule with these `<caplet>` and
+`<fileSets>` elements in your capsule-maven-plugin configuration:
+
+```xml
+            <!-- Add native libs to capsule -->
+            <plugin>
+                <groupId>com.github.chrisdchristo</groupId>
+                <artifactId>capsule-maven-plugin</artifactId>
+                <configuration>
+                    <caplets>SharedLibraryPathCapsule</caplets>
+                    <fileSets>
+                        <fileSet>
+                            <directory>${project.build.directory}/native-libs</directory>
+                            <includes>
+                                <include>*</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
+```
+
+That's it - now your application will be all set up to use the z3
+native libs.

--- a/tools/verdict-back-ends/verdict-bundle-parent/z3-native-libs/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle-parent/z3-native-libs/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.ge.verdict</groupId>
+        <artifactId>verdict-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>z3-native-libs</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Z3 Native Libs</name>
+
+    <properties>
+        <z3.version>4.8.8</z3.version>
+        <z3-download.uri>https://github.com/Z3Prover/z3/releases/download</z3-download.uri>
+        <z3-osx.sha256>01386e9aeb65a5d5a886f7ff23fff00dd963036afdff26c5a224ef5b63cb22c8</z3-osx.sha256>
+        <z3-osx.version>10.14.6</z3-osx.version>
+        <z3-ubuntu.sha256>6534f26427ee4f02835d17c3472f5ce750f34b4898c35cdd4223459b3589664e</z3-ubuntu.sha256>
+        <z3-ubuntu.version>16.04</z3-ubuntu.version>
+        <z3-win.sha256>3e203aee5fd46afc40211d0cde0a2160ee969012d1c9a62d44324bad6f05d284</z3-win.sha256>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>co.paralleluniverse</groupId>
+            <artifactId>capsule</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <!-- Add native libs to z3-native-libs jar -->
+            <resource>
+                <directory>${project.build.directory}/z3-${z3.version}-x64-osx-${z3-osx.version}/bin</directory>
+                <includes>
+                    <include>*.dylib</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${project.build.directory}/z3-${z3.version}-x64-ubuntu-${z3-ubuntu.version}/bin</directory>
+                <includes>
+                    <include>*.so</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${project.build.directory}/z3-${z3.version}-x64-win/bin</directory>
+                <includes>
+                    <include>*.dll</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <!-- Download native libs -->
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>download-z3-osx</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <sha256>${z3-osx.sha256}</sha256>
+                            <unpack>true</unpack>
+                            <uri>${z3-download.uri}/z3-${z3.version}/z3-${z3.version}-x64-osx-${z3-osx.version}.zip</uri>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-z3-ubuntu</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <sha256>${z3-ubuntu.sha256}</sha256>
+                            <unpack>true</unpack>
+                            <uri>${z3-download.uri}/z3-${z3.version}/z3-${z3.version}-x64-ubuntu-${z3-ubuntu.version}.zip</uri>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-z3-win</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <sha256>${z3-win.sha256}</sha256>
+                            <unpack>true</unpack>
+                            <uri>${z3-download.uri}/z3-${z3.version}/z3-${z3.version}-x64-win.zip</uri>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Don't add native libs to sources jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <excludeResources>true</excludeResources>
+                </configuration>
+            </plugin>
+            <!-- Install com.microsoft.z3 api jar as well as z3-native-libs jar -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-z3-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/z3-${z3.version}-x64-win/bin/com.microsoft.z3.jar</file>
+                                    <type>jar</type>
+                                    <classifier>api</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/verdict-back-ends/verdict-bundle-parent/z3-native-libs/src/main/java/SharedLibraryPathCapsule.java
+++ b/tools/verdict-back-ends/verdict-bundle-parent/z3-native-libs/src/main/java/SharedLibraryPathCapsule.java
@@ -1,0 +1,106 @@
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Prepends this capsule's cache directory to the appropriate dynamic loader library path
+ * environment variable (PATH, LD_LIBRARY_PATH, or DYLD_LIBRARY_PATH) for whichever operating system
+ * we're running on. Works around "can't find dependent library" exception thrown when a native lib
+ * can't find another native lib. Note that adding the cache directory to "java.library.path" isn't
+ * sufficient to let a native lib load another native lib; we must add the cache directory to the
+ * OS's dynamic loader library path too.
+ */
+public final class SharedLibraryPathCapsule extends Capsule {
+
+    /**
+     * Constructs a capsule.
+     *
+     * <p>This constructor is used by a caplet that will be listed in the manifest's {@code
+     * Main-Class} attribute. <b>Caplets are encouraged to "override" the {@link #Capsule(Capsule)
+     * other constructor} so that they may be listed in the {@code Caplets} attribute.</b>
+     *
+     * <p>This constructor or that of a subclass must not make use of any registered capsule
+     * options, as they may not have been properly pre-processed yet.
+     *
+     * @param jarFile the path to the JAR file
+     */
+    protected SharedLibraryPathCapsule(Path jarFile) {
+        super(jarFile);
+    }
+
+    /**
+     * Caplets are required to have this constructor and pass their argument up to the super class
+     * constructor with the same signature as this constructor.
+     *
+     * @param pred The capsule preceding this one in the chain (caplets must not access the passed
+     *     capsule in their constructor)
+     */
+    protected SharedLibraryPathCapsule(Capsule pred) {
+        super(pred);
+    }
+
+    /**
+     * Returns a map of environment variables (property-value pairs) with the appropriate shared
+     * library path environment variable modified by prepending this capsule's cache directory to
+     * any pre-existing path. We want the cache directory to be the first entry in the path since we
+     * don't want to load an already installed library that has a different version than our own
+     * native dependency.
+     *
+     * @param env the current environment
+     */
+    @Override
+    protected Map<String, String> buildEnvironmentVariables(Map<String, String> env) {
+        // On OSX, we must use DYLD_LIBRARY_PATH while on Windows, we must use PATH.
+        final String PROP_OS_NAME = "os.name";
+        String os = getProperty(PROP_OS_NAME).toLowerCase(Locale.ROOT);
+        String sharedLibraryPath = "LD_LIBRARY_PATH";
+        if (os.startsWith("mac")) {
+            sharedLibraryPath = "DYLD_LIBRARY_PATH";
+        } else if (os.startsWith("windows")) {
+            sharedLibraryPath = "PATH";
+        }
+
+        // Prepend the cache directory to the path or simply set the path to the
+        // directory if the path doesn't exist yet.
+        Path appDir = getAppDir();
+        if (appDir != null) {
+            final String PROP_PATH_SEPARATOR = "path.separator";
+            String separator = getProperty(PROP_PATH_SEPARATOR);
+            env.merge(sharedLibraryPath, appDir.toString(), (path, dir) -> dir + separator + path);
+        }
+
+        return env;
+    }
+
+    /**
+     * Returns the value of the given capsule attribute with consideration to the capsule's mode.
+     * This method must not be called directly except as {@code super.attribute(attr)} in the
+     * caplet's implementation of this method.
+     *
+     * <p>This implementation ensures that the Library-Path-P attribute contains this capsule's
+     * cache directory so that it comes first, not last, in "java.library.path" (as we noted with
+     * the shared library path environment variable above, we don't want to load an already
+     * installed library that has a different version than our own native dependency).
+     *
+     * @param attr the attribute
+     * @return the value of the attribute.
+     * @see #getAttribute(Map.Entry)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    protected <T> T attribute(Entry<String, T> attr) {
+        T value = super.attribute(attr);
+        if (attr == ATTR_LIBRARY_PATH_P) {
+            List<Object> oldPath = (List<Object>) value;
+            List<Object> newPath = new ArrayList<>();
+            Path appDir = getAppDir();
+            newPath.add(appDir);
+            newPath.addAll(oldPath);
+            return (T) newPath;
+        }
+        return value;
+    }
+}

--- a/tools/verdict/com.ge.research.osate.verdict.target/com.ge.research.osate.verdict.target.target
+++ b/tools/verdict/com.ge.research.osate.verdict.target/com.ge.research.osate.verdict.target.target
@@ -15,6 +15,10 @@
             <repository location="http://download.eclipse.org/elk/updates/releases/0.5.0"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+            <unit id="javax.xml.bind" version="0.0.0"/>
+            <repository location="http://download.eclipse.org/releases/2019-09/201909181001"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
             <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>

--- a/tools/verdict/com.ge.research.osate.verdict.vdm/META-INF/MANIFEST.MF
+++ b/tools/verdict/com.ge.research.osate.verdict.vdm/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: com.ge.research.osate.verdict.vdm;singleton:=true
 Bundle-Vendor: GE
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: javax.xml.bind
 Export-Package: com.ge.research.verdict.vdm,
  com.kscs.util.jaxb,
  verdict.vdm.vdm_data,

--- a/tools/verdict/com.ge.research.osate.verdict.vdm/pom.xml
+++ b/tools/verdict/com.ge.research.osate.verdict.vdm/pom.xml
@@ -11,11 +11,6 @@
     <artifactId>com.ge.research.osate.verdict.vdm</artifactId>
     <packaging>eclipse-plugin</packaging>
     
-    <dependencies>
-        <!-- JAXB dependencies needed only under Java 9 or later -->
-        <!-- Dependencies needed only by tests -->
-    </dependencies>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Add and use z3 native libraries in a cross-platform way without any
manual steps needed on your part.  You won't have to manually set
platform-dependent DYLD_LIBRARY_PATH, LD_LIBRARY_PATH, or PATH
environment variables in an Eclipse run configuration or the Docker
image when you run your application in a capsule.  The capsule will
unpack the z3 native libs into its app cache directory and the
SharedLibraryPathCapsule caplet will set whichever environment
variable your platform needs to find these native libs.

Note I haven't actually tested either the verdict-synthesis or
verdict-bundle capsule with these changes yet (I'm not clear on how to
run the synthesis functionality), but I wanted to get these changes
into place so the rest of you could test them.  Paul and/or William, please
look over these changes so that you will understand how they work, then
please merge these changes, test, and let me know of any problems.

Add download-maven-plugin and build-helper-maven-plugin versions to
tools/pom.xml so we can use these plugins to build z3-native-libs.

Check in VDMParser.java reformatting changes (Maven reformatted it
automatically).

Add z3-native-libs and sort rest of modules alphabetically in
verdict-bundle-parent/pom.xml.  Maven automatically figures out build
order based on dependencies anyway and since we have so many modules,
it's nice to be able to check if the list of modules matches the list
of subdirectories.  Add co.paralleluniverse:capsule,
com.ge.verdict:z3-native-libs, org.apache.commons:commons-math3, and
org.logicng:logicng versions to dependencyManagement since it's better
to set all dependency versions in one place.

Remove logicng version from verdict-attack-defense-collector/pom.xml.

Add z3-native-libs and reorder dependencies in verdict-bundle/pom.xml.
Unpack z3-native-libs with maven-dependency-plugin and add native libs
and SharedLibraryPathCapsule caplet to the verdict-bundle capsule.

Remove logicng version, old com.microsoft:z3 dependency, and add new
z3-native-libs dependency in verdict-synthesis/pom.xml.  Unpack
z3-native-libs with maven-dependency-plugin, run unit tests with
native libs in LD_LIBRARY_PATH, and add native libs and
SharedLibraryPathCapsule caplet to the verdict-synthesis capsule.

What z3-native-libs/pom.xml will do is:

1) download the most recently released z3 binaries for osx, ubuntu,
and win platforms and unpack them in the target directory

2) build the SharedLibraryPathCapsule caplet class which sets the
appropriate environment variable needed to find the native libs

3) add the native libs and the SharedLibraryPathCapsule caplet class
to the z3-native-libs jar

4) install both the z3-native-libs jar and the com.microsoft.z3 jar in
the local Maven cache so other poms can find them.

Make com.ge.research.osate.verdict.vdm build successfully with Java 11
by adding java.xml.bind (which is not part of the JDK anymore) to
Require-Bundle and getting java.xml.bind from the appropriate Eclipse
update site in com.ge.research.osate.verdict.target.target.