### PR TITLE
Fix Java 11 compilation problem

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [ 8 ]
+        java-version: [ 8, 11 ]
         os: [ ubuntu-20.04 ]
 
     runs-on: ${{ matrix.os }}

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -171,12 +171,12 @@
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-registry-graphite</artifactId>
-                <version>1.5.3</version>
+                <version>1.5.4</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>2.3.2</version>
+                <version>2.3.3</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -244,7 +244,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>2.3.2</version>
+                <version>2.3.3</version>
             </dependency>
             <dependency>
                 <groupId>org.logicng</groupId>

--- a/tools/verdict-back-ends/verdict-bundle-parent/verdict-assurance-case/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle-parent/verdict-assurance-case/pom.xml
@@ -27,7 +27,17 @@
             <groupId>guru.nidi</groupId>
             <artifactId>graphviz-java</artifactId>
         </dependency>
-        <!-- Dependencies needed only by tests -->
+        <!-- JAXB dependencies needed only under Java 9 or later -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Dependencies needed only by tests or capsule jar -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>

--- a/tools/verdict-back-ends/verdict-bundle-parent/verdict-attack-defense-collector/src/main/java/com/ge/verdict/attackdefensecollector/AttackDefenseCollector.java
+++ b/tools/verdict-back-ends/verdict-bundle-parent/verdict-attack-defense-collector/src/main/java/com/ge/verdict/attackdefensecollector/AttackDefenseCollector.java
@@ -1,19 +1,5 @@
 package com.ge.verdict.attackdefensecollector;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.ge.verdict.attackdefensecollector.adtree.ADOr;
 import com.ge.verdict.attackdefensecollector.adtree.ADTree;
 import com.ge.verdict.attackdefensecollector.adtree.Attack;
@@ -30,7 +16,19 @@ import com.ge.verdict.attackdefensecollector.model.PortConcern;
 import com.ge.verdict.attackdefensecollector.model.SystemModel;
 import com.ge.verdict.vdm.DefenseProperties;
 import com.ge.verdict.vdm.VdmTranslator;
-
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import verdict.vdm.vdm_data.GenericAttribute;
 import verdict.vdm.vdm_model.CIAPort;
 import verdict.vdm.vdm_model.ComponentImpl;

--- a/tools/verdict-back-ends/verdict-bundle-parent/verdict-lustre-translator/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle-parent/verdict-lustre-translator/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
         <!-- Dependencies needed only by tests or capsule jar -->
         <dependency>

--- a/tools/verdict/com.ge.research.osate.verdict.vdm/META-INF/MANIFEST.MF
+++ b/tools/verdict/com.ge.research.osate.verdict.vdm/META-INF/MANIFEST.MF
@@ -14,10 +14,9 @@ Export-Package: com.ge.verdict.vdm,
  verdict.vdm.vdm_lustre,
  verdict.vdm.vdm_model
 Bundle-ClassPath: .,
- lib/FastInfoset.jar,
  lib/istack-commons-runtime.jar,
  lib/jakarta.activation-api.jar,
+ lib/jakarta.activation.jar,
  lib/jakarta.xml.bind-api.jar,
  lib/jaxb-runtime.jar,
- lib/stax-ex.jar,
  lib/txw2.jar

--- a/tools/verdict/com.ge.research.osate.verdict.vdm/pom.xml
+++ b/tools/verdict/com.ge.research.osate.verdict.vdm/pom.xml
@@ -18,12 +18,11 @@
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 
@@ -54,7 +53,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeScope>provided</includeScope>
+                            <includeScope>runtime</includeScope>
                             <outputDirectory>${project.basedir}/lib/</outputDirectory>
                             <overWriteReleases>true</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>


### PR DESCRIPTION
Add JAXB dependencies to verdict-assurance-case so that it can be
compiled with Java 11.  Make other poms consistent in specifying
compile/runtime scope of JAXB dependencies.

Update micrometer-registry-graphite, jakarta.xml.bind-api, and
jaxb-runtime dependencies to latest stable versions in tools/pom.xml
as well.  Update com.ge.research.osate.verdict.vdm's MANIFEST.MF for
changes in JAXB transitive dependencies accordingly.

Re-enable compilation checks for Java 11 as well as Java 8 in pull
requests' continous-build CI workflow.