### PR TITLE
Make Stop button stop native binaries too

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -273,6 +273,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.zeroturnaround</groupId>
+                <artifactId>zt-exec</artifactId>
+                <version>1.12</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
+++ b/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
@@ -25,7 +25,7 @@
             <repository location="http://download.eclipse.org/releases/2019-12"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="ch.qos.logback.slf4j" version="0.0.0"/>
+            <unit id="ch.qos.logback.slf4j" version="0.0.0"/>
             <unit id="org.apache.commons.math3" version="0.0.0"/>
             <unit id="org.apache.commons.math3.source" version="0.0.0"/>
             <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository"/>

--- a/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
+++ b/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
@@ -25,6 +25,7 @@
             <repository location="http://download.eclipse.org/releases/2019-12"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="ch.qos.logback.slf4j" version="0.0.0"/>
             <unit id="org.apache.commons.math3" version="0.0.0"/>
             <unit id="org.apache.commons.math3.source" version="0.0.0"/>
             <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository"/>

--- a/tools/verdict/com.ge.research.osate.verdict/.classpath
+++ b/tools/verdict/com.ge.research.osate.verdict/.classpath
@@ -21,5 +21,6 @@
 	<classpathentry exported="true" kind="lib" path="lib/jnr-posix.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jnr-unixsocket.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jnr-x86asm.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/zt-exec.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tools/verdict/com.ge.research.osate.verdict/META-INF/MANIFEST.MF
+++ b/tools/verdict/com.ge.research.osate.verdict/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Bundle-Activator: com.ge.research.osate.verdict.Activator
 Require-Bundle: com.ge.research.osate.verdict.dsl,
  com.ge.research.osate.verdict.dsl.ui,
  com.ge.research.osate.verdict.vdm,
- org.apache.ant,
  org.eclipse.emf.ecore.editor,
  org.eclipse.jface,
  org.eclipse.swt,
@@ -22,7 +21,8 @@ Require-Bundle: com.ge.research.osate.verdict.dsl,
  org.eclipse.core.databinding.observable,
  org.eclipse.jface.databinding,
  org.apache.commons.math3
-Import-Package: org.apache.commons.logging
+Import-Package: org.apache.commons.logging,
+ org.slf4j
 Export-Package: com.ge.research.osate.verdict,
  com.ge.research.osate.verdict.gui,
  com.ge.research.osate.verdict.handlers
@@ -44,4 +44,5 @@ Bundle-ClassPath: .,
  lib/jnr-ffi.jar,
  lib/jnr-posix.jar,
  lib/jnr-unixsocket.jar,
- lib/jnr-x86asm.jar
+ lib/jnr-x86asm.jar,
+ lib/zt-exec.jar

--- a/tools/verdict/com.ge.research.osate.verdict/plugin.xml
+++ b/tools/verdict/com.ge.research.osate.verdict/plugin.xml
@@ -201,7 +201,7 @@
        <command
              categoryId="com.ge.research.osate.verdict.commands"
              id="com.ge.research.osate.verdict.commands.stop"
-             name="Stop MBAS/CRV">
+             name="Stop MBAA/MBAS/CRV">
        </command>
        <command
              categoryId="com.ge.research.osate.verdict.commands"

--- a/tools/verdict/com.ge.research.osate.verdict/pom.xml
+++ b/tools/verdict/com.ge.research.osate.verdict/pom.xml
@@ -24,6 +24,11 @@
             <artifactId>jakarta.json</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>zt-exec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/handlers/StopHandler.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/handlers/StopHandler.java
@@ -6,7 +6,7 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.HandlerEvent;
 
 /**
- * Stops a running MBAS/CRV command. 
+ * Stops a running MBAA/MBAS/CRV command. 
  */
 public class StopHandler extends AbstractHandler {
 
@@ -19,12 +19,12 @@ public class StopHandler extends AbstractHandler {
 			System.err.println("Something unexpected happened - more than one StopHandler instance has been created");
 		}
 		instance = this;
-		setBaseEnabled(false); // disabled until first MBAS/CRV is run
+		instance.setBaseEnabled(false); // disabled until first MBAA/MBAS/CRV is run
 	}
 	
 	/** Enables the StopHandler when we need it. */
-	public static void enable(VerdictBundleCommand command) {
-		StopHandler.command = command;
+	public static void enable(VerdictBundleCommand aCommand) {
+		command = aCommand;
 		if (instance != null) {
 			instance.setBaseEnabled(true);
 			// Refresh the icon's color more quickly in case it was already enabled
@@ -34,7 +34,7 @@ public class StopHandler extends AbstractHandler {
 
 	/** Disables the StopHandler when we don't need it anymore. */
 	public static void disable() {
-		StopHandler.command = null;
+		command = null;
 		if (instance != null) {
 			instance.setBaseEnabled(false);
 			// Refresh the icon's color more quickly in case it was already disabled
@@ -42,6 +42,7 @@ public class StopHandler extends AbstractHandler {
 		}
 	}
 
+	/** Executes the StopHandler when we click the STOP button. */
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		if (command != null) {

--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/handlers/VerdictBundleCommand.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/handlers/VerdictBundleCommand.java
@@ -290,8 +290,8 @@ public class VerdictBundleCommand {
             VerdictLogger.severe("Error running command: " + e);
             return -1;
         } catch (CancellationException e) {
-        	VerdictLogger.info("Command cancelled");
-        	return -1;
+            VerdictLogger.info("Command cancelled");
+            return -1;
         } finally {
             StopHandler.disable();
             setFuture(null);

--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/handlers/VerdictBundleCommand.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/handlers/VerdictBundleCommand.java
@@ -8,12 +8,15 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import javax.json.Json;
 import javax.json.JsonObject;
 
-import org.apache.tools.ant.taskdefs.Execute;
-import org.apache.tools.ant.taskdefs.PumpStreamHandler;
+import org.zeroturnaround.exec.ProcessExecutor;
+import org.zeroturnaround.exec.ProcessResult;
 
 import com.amihaiemil.docker.Container;
 import com.amihaiemil.docker.Docker;
@@ -30,10 +33,11 @@ public class VerdictBundleCommand {
     private String dockerImage;
     private List<String> args = new ArrayList<>();
     private List<String> binds = new ArrayList<>();
-    private List<String> env = new ArrayList<>();
+    private Map<String, String> env = new HashMap<>();
     
-    // Stop docker if necessary
+    // Stop container or cancel future if necessary
     private Container container = null;
+    private Future<ProcessResult> future = null;
 
     /** Tells us whether to run verdict-bundle via java or docker. */
     private boolean isImage() {
@@ -129,7 +133,7 @@ public class VerdictBundleCommand {
      * @return this object to allow calls to be chained
      */
     public VerdictBundleCommand env(String name, String value) {
-        env.add(name + "=" + value);
+        env.put(name, value);
         return this;
     }
 
@@ -148,27 +152,33 @@ public class VerdictBundleCommand {
     }
 
     /**
-     * Stops any currently running verdict-bundle.  Needs synchronization
-     * due to two threads accessing container field.
+     * Stops any currently running execution.  Needs synchronization
+     * due to two threads accessing container and future fields.
      */
-	public synchronized void stop() {
-		VerdictLogger.warning("STOP button pushed");
-		if (container != null) {
-			try {
-				container.stop();
-			} catch (UnexpectedResponseException | IOException e) {
-				VerdictLogger.severe("Unable to stop container: " + e);
-			}
-		}
-		// I've looked and there isn't any way to stop a running
-		// Execute object through its public API.  We'd have to break
-		// through its public API abstraction somehow.  To be done later 
-		// if there's enough need for it.
-	}
+    public synchronized void stop() {
+        VerdictLogger.info("STOP button pushed");
+        if (container != null) {
+            try {
+                container.stop();
+            } catch (UnexpectedResponseException | IOException e) {
+                VerdictLogger.severe("Unable to stop container: " + e);
+            }
+        }
+        if (future != null) {
+            if (!future.cancel(true)) {
+                VerdictLogger.severe("Unable to cancel future");
+            }
+        }
+    }
     
     /** Needs synchronization due to two threads accessing container field. */
     private synchronized void setContainer(Container container) {
-    	this.container = container;
+        this.container = container;
+    }
+
+    /** Needs synchronization due to two threads accessing future field. */
+    private synchronized void setFuture(Future<ProcessResult> future) {
+        this.future = future;
     }
     
     /**
@@ -226,8 +236,8 @@ public class VerdictBundleCommand {
             // Start the container and wait for it to exit
             VerdictLogger.info("Running image: " + dockerImage + " " + String.join(" ", args));
             try {
-            	setContainer(container);
-            	StopHandler.enable(this);
+                setContainer(container);
+                StopHandler.enable(this);
                 container.start();
                 VerdictLogger.info("Started, now waiting for container to finish: " + containerId);
                 int statusCode = container.waitOn(null);
@@ -240,9 +250,9 @@ public class VerdictBundleCommand {
                 return statusCode;
             } finally {
                 // Always remove the container before we return
-            	StopHandler.disable();
-            	setContainer(null);
-            	container.remove();
+                StopHandler.disable();
+                setContainer(null);
+                container.remove();
             }
         } catch (IOException | UnexpectedResponseException e) {
             VerdictLogger.severe("Unable to run command: " + e);
@@ -251,7 +261,7 @@ public class VerdictBundleCommand {
     }
 
     /**
-     * Runs verdict-bundle jar with java using the Ant Execute task API.
+     * Runs verdict-bundle jar with java using the Zeroturnaround Process Executor API.
      *
      * @return Exit code from verdict-bundle
      */
@@ -261,20 +271,30 @@ public class VerdictBundleCommand {
             return 1;
         }
 
-        Execute executor = new Execute(new PumpStreamHandler(System.out, System.err));
-        executor.setCommandline(args.toArray(new String[args.size()]));
-        if (!env.isEmpty()) {
-            executor.setEnvironment(env.toArray(new String[env.size()]));
-        }
+        ProcessExecutor executor = new ProcessExecutor();
+        executor.command(args);
+        executor.destroyOnExit();
+        executor.environment(env);
+        executor.redirectError(System.err);
+        executor.redirectOutput(System.out);
 
+        // Start the command and wait for it to exit
         try {
-            VerdictLogger.info("Running command: " + String.join(" ", args));
             StopHandler.enable(this);
-            return executor.execute();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            setFuture(executor.start().getFuture());
+
+            // Return verdict-bundle's exit code when it finishes
+            int statusCode = future.get().getExitValue();
+            return statusCode;
+        } catch (ExecutionException | InterruptedException | IOException e) {
+            VerdictLogger.severe("Error running command: " + e);
+            return -1;
+        } catch (CancellationException e) {
+        	VerdictLogger.info("Command cancelled");
+        	return -1;
         } finally {
-        	StopHandler.disable();
+            StopHandler.disable();
+            setFuture(null);
         }
     }
 


### PR DESCRIPTION
Make the VERDICT plugin use the Zeroturnaround Process Executor API
instead of the Ant Execute API so that we can use the Stop button to
stop native executables as well as Docker containers.  Sometimes the
Stop button doesn't become active when you run a command; if so,
please click in the Console pane and then the Stop button should
become active so you can use it.

In tools/pom.xml, add zt-exec to our managed dependencies.

In com.ge.research.osate.verdict.targetplatform.target, add
ch.qos.logback.slf4j to our target platform definition file since
zt-exec calls the org.slf4j API.

In com.ge.research.osate.verdict/META-INF/MANIFEST.MF, remove
org.apache.ant from Require-Bundle, add org.slf4j to Import-Package,
and add lib/zt-exec.jar to Bundle-ClassPath.

In com.ge.research.osate.verdict/pom.xml, add zt-exec to dependencies.

In StopHandler.java, make some code and comments easier to read.

In VerdictBundleCommand.java, run the verdict-bundle jar using the
Zeroturnaround Process Executor API instead of the Ant Execute API.
Make ProcessExecutor start verdict-bundle and return a
Future<ProcessResult> so we can call future.cancel(true) if the Stop
button gets pressed before verdict-bundle finishes running.  Calling
future.cancel(true) seems to work well enough that we shouldn't need
to use the Zeroturnaround Process Killer API (zt-process-killer).