### PR TITLE
Update dependencies and plugins

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -132,7 +132,7 @@
             <dependency>
                 <groupId>com.github.davidmoten</groupId>
                 <artifactId>word-wrap</artifactId>
-                <version>0.1.6</version>
+                <version>0.1.8</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.activation</groupId>
@@ -172,7 +172,7 @@
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-registry-graphite</artifactId>
-                <version>1.5.4</version>
+                <version>1.5.5</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
@@ -192,7 +192,7 @@
             <dependency>
                 <groupId>net.sf.saxon</groupId>
                 <artifactId>Saxon-HE</artifactId>
-                <version>10.1</version>
+                <version>10.2</version>
             </dependency>
             <dependency>
                 <groupId>org.antlr</groupId>
@@ -202,7 +202,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.10.8</version>
+                <version>1.10.9</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -217,7 +217,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.16.1</version>
+                <version>3.17.2</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.xtext</groupId>
@@ -250,7 +250,7 @@
             <dependency>
                 <groupId>org.logicng</groupId>
                 <artifactId>logicng</artifactId>
-                <version>2.0.0</version>
+                <version>2.0.2</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -288,7 +288,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>1.31.0</version>
+                    <version>2.4.2</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.chrisdchristo</groupId>
@@ -337,14 +337,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.0.0-M4</version>
-                    <configuration>
-                        <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>3.0.0-M1</version>
                 </plugin>
@@ -356,12 +348,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.9.0</version>
+                    <version>3.9.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -371,7 +363,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M4</version>
+                    <version>3.0.0-M5</version>
                     <configuration>
                         <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
                     </configuration>
@@ -384,7 +376,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>1.6.0</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -394,7 +386,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
@@ -478,8 +470,8 @@
                 </executions>
                 <configuration>
                     <java>
+                        <!-- Uncomment to format verdict plugin <includes><include>src/**/*.java</include></includes> -->
                         <googleJavaFormat>
-                            <version>1.7</version>
                             <style>AOSP</style>
                         </googleJavaFormat>
                     </java>
@@ -494,12 +486,12 @@
                             <eclipseWtp>
                                 <type>XML</type>
                             </eclipseWtp>
+                            <trimTrailingWhitespace />
                             <endWithNewline />
                             <indent>
                                 <spaces>true</spaces>
                                 <spacesPerTab>4</spacesPerTab>
                             </indent>
-                            <trimTrailingWhitespace />
                         </format>
                     </formats>
                     <lineEndings>UNIX</lineEndings>
@@ -531,7 +523,7 @@
                 <configuration>
                     <rules>
                         <requireMavenVersion>
-                            <version>[3.5.0,)</version>
+                            <version>[3.6.3,)</version>
                         </requireMavenVersion>
                     </rules>
                 </configuration>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-lustre-translator/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-lustre-translator/pom.xml
@@ -112,6 +112,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                        <configuration>
+                            <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                        </configuration>
                         <executions>
                             <execution>
                                 <goals>

--- a/tools/verdict/pom.xml
+++ b/tools/verdict/pom.xml
@@ -25,8 +25,9 @@
         <module>com.ge.research.osate.verdict.vdm</module>
     </modules>
 
-    <build><!-- Use Tycho to build our Eclipse plugin code -->
+    <build>
         <plugins>
+            <!-- Use Tycho to build our Eclipse plugin code -->
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-maven-plugin</artifactId>


### PR DESCRIPTION
Check for new versions and update:

  com.github.davidmoten:word-wrap ....................... 0.1.6 -> 0.1.8
  io.micrometer:micrometer-registry-graphite ............ 1.5.4 -> 1.5.5
  net.sf.saxon:Saxon-HE ................................... 10.1 -> 10.2
  org.apache.ant:ant .................................. 1.10.8 -> 1.10.9
  org.assertj:assertj-core ............................ 3.16.1 -> 3.17.2
  org.logicng:logicng ................................... 2.0.0 -> 2.0.2

     com.diffplug.spotless:spotless-maven-plugin ....... 1.31.0 -> 2.4.2
     maven-failsafe-plugin ........................ 3.0.0-M4 -> 3.0.0-M5
     maven-resources-plugin ............................. 3.1.0 -> 3.2.0
     maven-site-plugin .................................. 3.9.0 -> 3.9.1
     maven-surefire-plugin ........................ 3.0.0-M4 -> 3.0.0-M5
     org.codehaus.mojo:exec-maven-plugin ................ 1.6.0 -> 3.0.0
     org.codehaus.mojo:versions-maven-plugin .............. 2.7 -> 2.8.1

Hold off updating Tycho because new version 2.0.0 requires Java 11 or
higher (all developers would have to switch from Java 8 to 11 in order
to build the VERDICT plugin, although the plugin probably would still
install in OSATE and run fine with Java 8):

     org.eclipse.tycho:target-platform-configuration .... 1.7.0 -> 2.0.0
     org.eclipse.tycho:tycho-compiler-plugin ............ 1.7.0 -> 2.0.0
     org.eclipse.tycho:tycho-maven-plugin ............... 1.7.0 -> 2.0.0
     org.eclipse.tycho:tycho-p2-plugin .................. 1.7.0 -> 2.0.0
     org.eclipse.tycho:tycho-p2-publisher-plugin ........ 1.7.0 -> 2.0.0
     org.eclipse.tycho:tycho-p2-repository-plugin ....... 1.7.0 -> 2.0.0
     org.eclipse.tycho:tycho-packaging-plugin ........... 1.7.0 -> 2.0.0

Define maven-failsafe-plugin version in
verdict-lustre-translator/pom.xml to avoid a "mvn
versions:display-plugin-updates" warning message.