### PR TITLE
Add --add-opens when running bundle jar

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -14,7 +14,7 @@
     <module>verdict-data-model</module>
   </modules>
 
-  <!-- Set properties used by all modules -->
+  <!-- Set properties for all modules -->
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
@@ -27,14 +27,22 @@
     <version.jaxb2-namespace-prefix>1.3</version.jaxb2-namespace-prefix>
     <version.jaxb2-rich-contract-plugin>2.1.0</version.jaxb2-rich-contract-plugin>
     <version.sadl>3.4.1-SNAPSHOT</version.sadl>
-    <version.tycho>2.2.0</version.tycho>
+    <version.tycho>2.3.0</version.tycho>
     <version.xml.bind-api>2.3.3</version.xml.bind-api>
     <version.xtext>2.20.0</version.xtext>
   </properties>
 
-  <!-- Lock down dependencies for consistent builds -->
+  <!-- Set dependencies for all modules -->
   <dependencyManagement>
     <dependencies>
+      <!-- Import Xtext dependencies from Xtext BOM -->
+      <dependency>
+        <groupId>org.eclipse.xtext</groupId>
+        <artifactId>xtext-dev-bom</artifactId>
+        <version>${version.xtext}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>co.paralleluniverse</groupId>
         <artifactId>capsule</artifactId>
@@ -175,7 +183,7 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-graphite</artifactId>
-        <version>1.6.5</version>
+        <version>1.6.6</version>
       </dependency>
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
@@ -195,7 +203,7 @@
       <dependency>
         <groupId>net.sf.saxon</groupId>
         <artifactId>Saxon-HE</artifactId>
-        <version>10.3</version>
+        <version>10.5</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -205,7 +213,7 @@
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.10.9</version>
+        <version>1.10.10</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -274,14 +282,6 @@
         <artifactId>zt-exec</artifactId>
         <version>1.12</version>
       </dependency>
-      <!-- Import most Xtext dependencies from Xtext BOM -->
-      <dependency>
-        <groupId>org.eclipse.xtext</groupId>
-        <artifactId>xtext-dev-bom</artifactId>
-        <version>${version.xtext}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -292,7 +292,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.9.0</version>
+          <version>2.11.0</version>
           <configuration>
             <java>
               <!-- Uncomment to format verdict plugin <includes><include>src/**/*.java</include></includes> -->
@@ -359,10 +359,9 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>2.15.0</version>
+          <version>3.0.0</version>
           <configuration>
             <createBackupFile>false</createBackupFile>
-            <keepBlankLines>true</keepBlankLines>
             <indentSchemaLocation>true</indentSchemaLocation>
             <lineSeparator>\n</lineSeparator>
             <predefinedSortOrder>custom_1</predefinedSortOrder>
@@ -384,7 +383,7 @@
         <plugin>
           <groupId>com.googlecode.maven-download-plugin</groupId>
           <artifactId>download-maven-plugin</artifactId>
-          <version>1.6.2</version>
+          <version>1.6.3</version>
         </plugin>
         <plugin>
           <groupId>org.antlr</groupId>
@@ -576,6 +575,27 @@
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-packaging-plugin</artifactId>
           <version>${version.tycho}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-source-plugin</artifactId>
+          <version>${version.tycho}</version>
+          <executions>
+            <execution>
+              <id>default-plugin-source</id>
+              <goals>
+                <goal>plugin-source</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-surefire-plugin</artifactId>
+          <version>${version.tycho}</version>
+          <configuration>
+            <failIfNoTests>false</failIfNoTests>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.eclipse.xtend</groupId>

--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/handlers/VerdictBundleCommand.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/handlers/VerdictBundleCommand.java
@@ -57,6 +57,10 @@ public class VerdictBundleCommand {
         if (!isImage()) {
             if (bundleJar != null && !bundleJar.isEmpty()) {
                 args.add("java");
+                args.add("--add-opens");
+                args.add("java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED");
+                args.add("--add-opens");
+                args.add("java.base/java.lang=ALL-UNNAMED");
                 args.add("-jar");
                 args.add(bundleJar);
             } else {


### PR DESCRIPTION
Prevent Java 11's illegal access warnings by adding two --add-opens
options when the VERDICT plugin runs the bundle jar, like our
Dockerfile already does when running the jar.

Also update parent pom as well.  Improve 2 comments.  Update 3 deps to
newer versions (micrometer, saxon, ant).  Update 4 plugins to newer
version (spotless, sortpom, download, tycho).