### PR TITLE
Bring over some changes from SADL's poms

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -3,18 +3,20 @@
      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <!-- Define ourselves -->
   <groupId>com.ge.verdict</groupId>
   <artifactId>tools</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <!-- Build ourselves -->
   <modules>
     <module>verdict</module>
     <module>verdict-back-ends</module>
     <module>verdict-data-model</module>
   </modules>
 
-  <!-- Set properties for all modules -->
+  <!-- Set all properties in one place -->
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
@@ -27,12 +29,14 @@
     <version.jaxb2-namespace-prefix>1.3</version.jaxb2-namespace-prefix>
     <version.jaxb2-rich-contract-plugin>2.1.0</version.jaxb2-rich-contract-plugin>
     <version.sadl>3.4.1-SNAPSHOT</version.sadl>
-    <version.tycho>2.3.0</version.tycho>
+    <version.slf4j>1.7.32</version.slf4j>
+    <version.surefire>3.0.0-M5</version.surefire>
+    <version.tycho>2.4.0</version.tycho>
     <version.xml.bind-api>2.3.3</version.xml.bind-api>
     <version.xtext>2.20.0</version.xtext>
   </properties>
 
-  <!-- Set dependencies for all modules -->
+  <!-- Set all dependency versions in one place -->
   <dependencyManagement>
     <dependencies>
       <!-- Import Xtext dependencies from Xtext BOM -->
@@ -140,6 +144,7 @@
         <artifactId>word-wrap</artifactId>
         <version>0.1.9</version>
       </dependency>
+      <!-- Version needed by SADL's reasoner/sadlserver -->
       <dependency>
         <groupId>com.sun.activation</groupId>
         <artifactId>javax.activation</artifactId>
@@ -233,7 +238,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.19.0</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.xtext</groupId>
@@ -263,12 +268,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.30</version>
+        <version>${version.slf4j}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
-        <version>1.7.30</version>
+        <version>${version.slf4j}</version>
       </dependency>
       <dependency>
         <groupId>org.xmlunit</groupId>
@@ -291,7 +296,7 @@
   </dependencyManagement>
 
   <build>
-    <!-- Lock down plugins for consistent builds -->
+    <!-- Set all plugin versions in one place -->
     <pluginManagement>
       <plugins>
         <plugin>
@@ -407,6 +412,35 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
+          <!-- Clean extra files created by build -->
+          <configuration>
+            <filesets>
+              <fileset>
+                <directory>${project.basedir}</directory>
+                <includes>
+                  <include>plugin.xml_gen</include>
+                </includes>
+              </fileset>
+              <fileset>
+                <directory>${project.basedir}/lib</directory>
+              </fileset>
+              <fileset>
+                <directory>${project.basedir}/model</directory>
+              </fileset>
+              <fileset>
+                <directory>${project.basedir}/src-gen</directory>
+                <excludes>
+                  <exclude>README.md</exclude>
+                </excludes>
+              </fileset>
+              <fileset>
+                <directory>${project.basedir}/xtend-gen</directory>
+                <excludes>
+                  <exclude>README.rst</exclude>
+                </excludes>
+              </fileset>
+            </filesets>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -421,7 +455,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -431,7 +465,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.0.0</version>
           <configuration>
             <rules>
               <requireMavenVersion>
@@ -451,7 +485,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>${version.surefire}</version>
           <configuration>
             <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
           </configuration>
@@ -492,27 +526,34 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>${version.surefire}</version>
           <configuration>
             <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.2.0</version>
-        </plugin>
-        <plugin>
+          <?m2e ignore?>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>3.0.0</version>
+          <executions>
+            <execution>
+              <id>default-exec</id>
+              <goals>
+                <goal>exec</goal>
+              </goals>
+              <phase>generate-sources</phase>
+            </execution>
+          </executions>
         </plugin>
+        <!-- Goals: mvn -N versions:display-{dependency,plugin,property}-updates -->
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
           <version>2.8.1</version>
         </plugin>
         <plugin>
+          <?m2e ignore?>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>target-platform-configuration</artifactId>
           <version>${version.tycho}</version>
@@ -555,11 +596,26 @@
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-maven-plugin</artifactId>
           <version>${version.tycho}</version>
+          <extensions>true</extensions>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-p2-director-plugin</artifactId>
           <version>${version.tycho}</version>
+          <executions>
+            <execution>
+              <id>default-materialize-products</id>
+              <goals>
+                <goal>materialize-products</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-archive-products</id>
+              <goals>
+                <goal>archive-products</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
@@ -575,6 +631,9 @@
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-p2-repository-plugin</artifactId>
           <version>${version.tycho}</version>
+          <configuration>
+            <includeAllDependencies>true</includeAllDependencies>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
@@ -594,6 +653,9 @@
             </execution>
           </executions>
         </plugin>
+        <!-- To skip running (and compiling) tests, use: -Dmaven.test.skip
+             To skip tests, but still compile them, use: -DskipTests
+             To run all tests but only fail at end, use: -fae -->
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-surefire-plugin</artifactId>
@@ -606,6 +668,24 @@
           <groupId>org.eclipse.xtend</groupId>
           <artifactId>xtend-maven-plugin</artifactId>
           <version>${version.xtext}</version>
+          <configuration>
+            <outputDirectory>${project.basedir}/xtend-gen</outputDirectory>
+            <xtendAsPrimaryDebugSource>true</xtendAsPrimaryDebugSource>
+          </configuration>
+          <executions>
+            <execution>
+              <id>default-compile</id>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-xtend-install-debug-info</id>
+              <goals>
+                <goal>xtend-install-debug-info</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.jvnet.jaxb2.maven2</groupId>
@@ -672,4 +752,5 @@
     <name>GE Global Research</name>
     <url>www.geglobalresearch.com</url>
   </organization>
+
 </project>

--- a/tools/verdict-back-ends/pom.xml
+++ b/tools/verdict-back-ends/pom.xml
@@ -15,4 +15,5 @@
   <modules>
     <module>verdict-bundle</module>
   </modules>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/iml-verdict-translator/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/iml-verdict-translator/pom.xml
@@ -58,6 +58,7 @@
 
   <build>
     <plugins>
+      <!-- Build capsule jar -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -81,4 +82,5 @@
       <url>https://raw.github.com/ge-high-assurance/sadl-snapshot-repository/master/repository</url>
     </repository>
   </repositories>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/pom.xml
@@ -28,4 +28,5 @@
     <module>verdict-test-instrumentor</module>
     <module>z3-native-libs</module>
   </modules>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-assurance-case/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-assurance-case/pom.xml
@@ -47,6 +47,7 @@
 
   <build>
     <plugins>
+      <!-- Build capsule jar -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -56,4 +57,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-attack-defense-collector/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-attack-defense-collector/pom.xml
@@ -47,6 +47,7 @@
 
   <build>
     <plugins>
+      <!-- Build capsule jar -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -56,4 +57,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-blame-assignment/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-blame-assignment/pom.xml
@@ -33,4 +33,5 @@
       <scope>runtime</scope>
     </dependency>
   </dependencies>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-bundle-app/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-bundle-app/pom.xml
@@ -89,7 +89,7 @@
 
   <build>
     <plugins>
-      <!-- Add native libs to capsule -->
+      <!-- Build capsule jar and include native libs -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -106,7 +106,7 @@
           </fileSets>
         </configuration>
       </plugin>
-      <!-- Unpack z3-native-libs -->
+      <!-- Unpack native libs -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -123,9 +123,11 @@
             <goals>
               <goal>unpack-dependencies</goal>
             </goals>
+            <phase>generate-resources</phase>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-crv/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-crv/pom.xml
@@ -39,6 +39,7 @@
 
   <build>
     <plugins>
+      <!-- Build capsule jar -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -48,4 +49,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-instrumentor/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-instrumentor/pom.xml
@@ -36,6 +36,7 @@
 
   <build>
     <plugins>
+      <!-- Build capsule jar -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -45,4 +46,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-lustre-translator/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-lustre-translator/pom.xml
@@ -68,6 +68,7 @@
 
   <build>
     <plugins>
+      <!-- Build capsule jar -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -75,6 +76,7 @@
           <appClass>com.ge.verdict.lustre.App</appClass>
         </configuration>
       </plugin>
+      <!-- Generate and build antlr parser code -->
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
@@ -91,7 +93,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.0.0-M5</version>
+            <version>${version.surefire}</version>
             <configuration>
               <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
             </configuration>
@@ -108,4 +110,5 @@
       </build>
     </profile>
   </profiles>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-mbas-translator/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-mbas-translator/pom.xml
@@ -32,6 +32,7 @@
 
   <build>
     <plugins>
+      <!-- Build capsule jar -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -41,4 +42,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-merit-assignment/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-merit-assignment/pom.xml
@@ -24,4 +24,5 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-stem-runner/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-stem-runner/pom.xml
@@ -58,8 +58,7 @@
   </dependencies>
 
   <build>
-    <!-- Let's use the STEM project above us rather than copying it into
-            src/test/resources -->
+    <!-- Use STEM project directly, no need to copy it to src/test/resources -->
     <testResources>
       <testResource>
         <directory>${basedir}/../..</directory>
@@ -69,6 +68,7 @@
       </testResource>
     </testResources>
     <plugins>
+      <!-- Build capsule jar -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -92,4 +92,5 @@
       <url>https://raw.github.com/ge-high-assurance/sadl-snapshot-repository/master/repository</url>
     </repository>
   </repositories>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/pom.xml
@@ -68,7 +68,7 @@
 
   <build>
     <plugins>
-      <!-- Add native libs to capsule -->
+      <!-- Build capsule jar and include native libs -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -85,7 +85,7 @@
           </fileSets>
         </configuration>
       </plugin>
-      <!-- Unpack z3-native-libs -->
+      <!-- Unpack native libs -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -102,7 +102,7 @@
             <goals>
               <goal>unpack-dependencies</goal>
             </goals>
-            <phase>process-test-resources</phase>
+            <phase>generate-resources</phase>
           </execution>
         </executions>
       </plugin>
@@ -121,4 +121,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-test-instrumentor/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-test-instrumentor/pom.xml
@@ -32,6 +32,7 @@
 
   <build>
     <plugins>
+      <!-- Build capsule jar -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>
@@ -41,4 +42,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict-back-ends/verdict-bundle/z3-native-libs/README.md
+++ b/tools/verdict-back-ends/verdict-bundle/z3-native-libs/README.md
@@ -49,7 +49,7 @@ Call maven-dependency-plugin in your pom to unpack the native libs in
 z3-native-libs into your target/native-libs directory:
 
 ```xml
-      <!-- Unpack z3-native-libs -->
+      <!-- Unpack native libs -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -66,6 +66,7 @@ z3-native-libs into your target/native-libs directory:
             <goals>
               <goal>unpack-dependencies</goal>
             </goals>
+            <phase>generate-resources</phase>
           </execution>
         </executions>
       </plugin>
@@ -95,7 +96,7 @@ Add the native libs to your capsule with these `<caplet>` and
 `<fileSets>` elements in your capsule-maven-plugin configuration:
 
 ```xml
-      <!-- Add native libs to capsule -->
+      <!-- Build capsule jar and include native libs -->
       <plugin>
         <groupId>com.github.chrisdchristo</groupId>
         <artifactId>capsule-maven-plugin</artifactId>

--- a/tools/verdict-back-ends/verdict-bundle/z3-native-libs/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/z3-native-libs/pom.xml
@@ -103,6 +103,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <file>${project.build.directory}/z3-${z3.version}-x64-win/bin/com.microsoft.z3.jar</file>
+          <artifactId>com.microsoft.z3</artifactId>
+          <generatePom>true</generatePom>
+          <groupId>com.ge.verdict</groupId>
+          <packaging>jar</packaging>
+          <version>${project.version}</version>
+        </configuration>
         <executions>
           <execution>
             <id>default-install-file</id>
@@ -110,14 +118,6 @@
               <goal>install-file</goal>
             </goals>
             <phase>install</phase>
-            <configuration>
-              <file>${project.build.directory}/z3-${z3.version}-x64-win/bin/com.microsoft.z3.jar</file>
-              <artifactId>com.microsoft.z3</artifactId>
-              <generatePom>true</generatePom>
-              <groupId>com.ge.verdict</groupId>
-              <packaging>jar</packaging>
-              <version>${project.version}</version>
-            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -131,4 +131,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict-data-model/pom.xml
+++ b/tools/verdict-data-model/pom.xml
@@ -55,4 +55,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict/com.ge.research.osate.verdict.dsl.ide/pom.xml
+++ b/tools/verdict/com.ge.research.osate.verdict.dsl.ide/pom.xml
@@ -11,4 +11,5 @@
 
   <artifactId>com.ge.research.osate.verdict.dsl.ide</artifactId>
   <packaging>eclipse-plugin</packaging>
+
 </project>

--- a/tools/verdict/com.ge.research.osate.verdict.dsl.ui/pom.xml
+++ b/tools/verdict/com.ge.research.osate.verdict.dsl.ui/pom.xml
@@ -11,4 +11,5 @@
 
   <artifactId>com.ge.research.osate.verdict.dsl.ui</artifactId>
   <packaging>eclipse-plugin</packaging>
+
 </project>

--- a/tools/verdict/com.ge.research.osate.verdict.dsl/pom.xml
+++ b/tools/verdict/com.ge.research.osate.verdict.dsl/pom.xml
@@ -15,47 +15,7 @@
   <build>
     <sourceDirectory>${project.basedir}/src</sourceDirectory>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets combine.children="append">
-            <fileset>
-              <directory>${project.basedir}</directory>
-              <includes>
-                <include>plugin.xml_gen</include>
-              </includes>
-            </fileset>
-            <fileset>
-              <directory>${project.basedir}/model</directory>
-            </fileset>
-            <fileset>
-              <directory>${project.basedir}/src-gen</directory>
-              <excludes>
-                <exclude>README.md</exclude>
-              </excludes>
-            </fileset>
-            <fileset>
-              <directory>${project.basedir}/xtend-gen</directory>
-              <excludes>
-                <exclude>README.rst</exclude>
-              </excludes>
-            </fileset>
-            <fileset>
-              <directory>${project.basedir}/../com.ge.research.osate.verdict.dsl.ui</directory>
-              <includes>
-                <include>plugin.xml_gen</include>
-              </includes>
-            </fileset>
-            <fileset>
-              <directory>${project.basedir}/../com.ge.research.osate.verdict.dsl.ui/src-gen</directory>
-              <excludes>
-                <exclude>README.md</exclude>
-              </excludes>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
+      <!-- Copy xtend files to classes first -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
@@ -80,6 +40,7 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Generate additional files -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -94,39 +55,13 @@
           <classpathScope>compile</classpathScope>
           <workingDirectory>${project.basedir}</workingDirectory>
         </configuration>
-        <executions>
-          <execution>
-            <?m2e ignore?>
-            <id>default-exec</id>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <phase>generate-sources</phase>
-          </execution>
-        </executions>
       </plugin>
+      <!-- Compile Xtend sources -->
       <plugin>
         <groupId>org.eclipse.xtend</groupId>
         <artifactId>xtend-maven-plugin</artifactId>
-        <configuration>
-          <outputDirectory>${project.basedir}/xtend-gen</outputDirectory>
-          <xtendAsPrimaryDebugSource>true</xtendAsPrimaryDebugSource>
-        </configuration>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-xtend-install-debug-info</id>
-            <goals>
-              <goal>xtend-install-debug-info</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict/com.ge.research.osate.verdict.feature/pom.xml
+++ b/tools/verdict/com.ge.research.osate.verdict.feature/pom.xml
@@ -11,4 +11,5 @@
 
   <artifactId>com.ge.research.osate.verdict.feature</artifactId>
   <packaging>eclipse-feature</packaging>
+
 </project>

--- a/tools/verdict/com.ge.research.osate.verdict.targetplatform/pom.xml
+++ b/tools/verdict/com.ge.research.osate.verdict.targetplatform/pom.xml
@@ -11,4 +11,5 @@
 
   <artifactId>com.ge.research.osate.verdict.targetplatform</artifactId>
   <packaging>eclipse-target-definition</packaging>
+
 </project>

--- a/tools/verdict/com.ge.research.osate.verdict.updatesite/pom.xml
+++ b/tools/verdict/com.ge.research.osate.verdict.updatesite/pom.xml
@@ -11,4 +11,5 @@
 
   <artifactId>com.ge.research.osate.verdict.updatesite</artifactId>
   <packaging>eclipse-repository</packaging>
+
 </project>

--- a/tools/verdict/com.ge.research.osate.verdict/pom.xml
+++ b/tools/verdict/com.ge.research.osate.verdict/pom.xml
@@ -12,6 +12,7 @@
   <artifactId>com.ge.research.osate.verdict</artifactId>
   <packaging>eclipse-plugin</packaging>
 
+  <!-- Needed by maven-dependency-plugin -->
   <dependencies>
     <dependency>
       <groupId>com.amihaiemil.web</groupId>
@@ -44,19 +45,7 @@
 
   <build>
     <plugins>
-      <!-- Remove lib directory when cleaning -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>${project.basedir}/lib</directory>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
-      <!-- Copy dependencies into lib directory -->
+      <!-- Copy dependencies to lib directory -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -75,9 +64,11 @@
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
+            <phase>generate-resources</phase>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tools/verdict/pom.xml
+++ b/tools/verdict/pom.xml
@@ -25,16 +25,17 @@
 
   <build>
     <plugins>
+      <!-- Define our Eclipse target platform -->
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
       </plugin>
-      <!-- Use Tycho to build our Eclipse plugin code -->
+      <!-- Build Eclipse bundles with Tycho -->
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-maven-plugin</artifactId>
-        <extensions>true</extensions>
       </plugin>
     </plugins>
   </build>
+
 </project>


### PR DESCRIPTION
Include all plugins in VERDICT's update site as requested.

Also bring some other changes over from SADL's poms to make VERDICT's
poms better.  First change is to bump some versions:

- SLF4J from 1.7.30 to 1.7.32
- Tycho from 2.3.0 to 2.4.0
- assertj-core from 3.19.0 to 3.20.2
- maven-dependency-plugin from 3.1.2 to 3.2.0
- maven-enforcer-plugin from 3.0.0-M3 to 3.0.0

Couldn't bump some other versions (tried activation, didn't try xtext)
because we use an older SADL version (3.4.1-SNAPSHOT), not the latest
version.

Second change is to setup some plugins in tools/pom.xml and eliminate
unnecessary plugin setup from child modules' poms (maven-clean-plugin,
exec-maven-plugin, tycho-maven-plugin, xtend-maven-plugin).