### PR TITLE
Update VERDICT workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  # Maintain dependencies for Docker
+  - package-ecosystem: "docker"
+    # Location of Dockerfile
+    directory: "/tools/verdict-back-ends/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Location of .github/workflows
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for Maven
+  - package-ecosystem: "maven"
+    # Location of poms
+    directory: "/tools/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -1,41 +1,47 @@
-# Builds Verdict jars on each pull request as a CI check
+name: VERDICT Continuous Integration Workflow
 
-name: Verdict continuous build
+# Runs whenever a pull request is created, reopened, or has a change
+# made to it
 
 on:
   pull_request:
-    branches: [ master ]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
+
+# Runs a build job as a check:
+# - Builds VERDICT source & runs unit tests
 
 jobs:
   build:
     strategy:
       matrix:
+        distribution: [ temurin ]
         java-version: [ 11 ]
         os: [ ubuntu-20.04 ]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Check out VERDICT source
-      uses: actions/checkout@v2
-
     - name: Set up GraphViz
-      uses: ts-graphviz/setup-graphviz@v1
+      uses: ts-graphviz/setup-graphviz@v1.0.0
 
     - name: Set up Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2.2.0
       with:
+        distribution: ${{ matrix.distribution }}
         java-version: ${{ matrix.java-version }}
 
-    - name: Cache Maven repository
-      uses: actions/cache@v2
+    - name: Set up Maven cache
+      uses: actions/cache@v2.1.6
       with:
         path: ~/.m2/repository
-        key: ${{ matrix.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ matrix.os }}-m2
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
 
-    - name: Run Maven build
+    - name: Check out VERDICT source
+      uses: actions/checkout@v2.3.4
+
+    - name: Build VERDICT source
       run: |
         mvn -B install --file tools/verdict-back-ends/verdict-bundle/z3-native-libs/pom.xml
         mvn -B package -Dtycho.localArtifacts=ignore --file tools/pom.xml

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Set up GraphViz
-      uses: ts-graphviz/setup-graphviz@v1.0.0
+      uses: ts-graphviz/setup-graphviz@v1
 
     - name: Set up Java
       uses: actions/setup-java@v2.2.0

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -1,9 +1,7 @@
-# Builds Verdict developer artifacts on each push to master:
-# - Uploads native binaries as build artifacts (kind2 omitted to save time)
-# - Pushes verdict-dev Docker image to Docker Hub
-# - Updates verdict-dev update site
+name: VERDICT Main Workflow
 
-name: Verdict main build
+# Runs whenever the main branch has a change made to it (except for
+# tag-only pushes)
 
 on:
   push:
@@ -11,34 +9,57 @@ on:
     tags-ignore: [ '*' ]
   workflow_dispatch:
 
+# Runs a build job and uploads VERDICT build artifacts:
+# - Builds VERDICT source & runs unit tests
+# - Builds aadl2iml and soteria_pp native binaries
+# - Pushes verdict-dev image to Docker Hub
+# - Updates verdict-dev update site
+
 jobs:
   build:
     strategy:
-      matrix:
-        java-version: [ 11 ]
-        ocaml-version: [ 4.07.1 ]
-        os: [ macos-10.15, ubuntu-20.04 ]
-      # Still worth uploading one build even if the other build fails
       fail-fast: false
+      matrix:
+        distribution: [ temurin ]
+        java-version: [ 11 ]
+        ocaml-compiler: [ 4.07.1 ]
+        os: [ macos-10.15, ubuntu-20.04 ]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Check out VERDICT source
-      uses: actions/checkout@v2
+    - name: Set up GraphViz
+      uses: ts-graphviz/setup-graphviz@v1.0.0
 
-    - name: Cache opam repository
-      uses: actions/cache@v2
+    - name: Set up Java
+      uses: actions/setup-java@v2.2.0
       with:
-        path: ~/.opam
-        key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}
+        distribution: ${{ matrix.distribution }}
+        java-version: ${{ matrix.java-version }}
+
+    - name: Set up Maven cache
+      uses: actions/cache@v2.1.6
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
+
+    - name: Check out VERDICT source
+      uses: actions/checkout@v2.3.4
+
+    - name: Build VERDICT source
+      run: |
+        mvn -B install --file tools/verdict-back-ends/verdict-bundle/z3-native-libs/pom.xml
+        mvn -B package -Dtycho.localArtifacts=ignore --file tools/pom.xml
+      env:
+        GraphVizPath: /usr/bin
 
     - name: Set up OCaml
-      uses: avsm/setup-ocaml@v1
+      uses: avsm/setup-ocaml@v2.0.0-beta3
       with:
-        ocaml-version: ${{ matrix.ocaml-version }}
+        ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-    - name: Install opam packages
+    - name: Install OCaml packages
       run: |
         opam install --yes \
           async \
@@ -62,61 +83,39 @@ jobs:
         opam exec make
 
     - name: Upload aadl2iml
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.2.4
       with:
         name: ${{ matrix.os }}-binaries
         path: tools/verdict-back-ends/aadl2iml/bin/aadl2iml
 
     - name: Upload soteria_pp
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.2.4
       with:
         name: ${{ matrix.os }}-binaries
         path: tools/verdict-back-ends/soteria_pp/bin/soteria_pp
 
-    - name: Set up GraphViz
-      uses: ts-graphviz/setup-graphviz@v1
-
-    - name: Set up Java
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java-version }}
-
-    - name: Cache Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ matrix.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ matrix.os }}-m2
-
-    - name: Run Maven build
-      run: |
-        mvn -B install --file tools/verdict-back-ends/verdict-bundle/z3-native-libs/pom.xml
-        mvn -B package -Dtycho.localArtifacts=ignore --file tools/pom.xml
-      env:
-        GraphVizPath: /usr/bin
-
     - name: Upload verdict-bundle-app
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.2.4
       with:
         name: ${{ matrix.os }}-binaries
         path: tools/verdict-back-ends/verdict-bundle/verdict-bundle-app/target/verdict-bundle-app-1.0.0-SNAPSHOT-capsule.jar
 
-    # Rest of steps can run on only Linux, other OS isn't needed
+    # Run rest of steps only on Linux - macOS isn't needed
 
     - name: Set up Docker Buildx
       if: runner.os == 'Linux'
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v1.5.1
 
     - name: Login to Docker Hub
       if: runner.os == 'Linux'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v1.10.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Build and push verdict-dev image
       if: runner.os == 'Linux'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v2.6.1
       with:
         context: tools/verdict-back-ends
         file: tools/verdict-back-ends/Dockerfile
@@ -127,7 +126,7 @@ jobs:
 
     - name: Check out VERDICT-update-sites
       if: runner.os == 'Linux'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: ge-high-assurance/VERDICT-update-sites
         token: ${{ secrets.CI_PAT }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Set up GraphViz
-      uses: ts-graphviz/setup-graphviz@v1.0.0
+      uses: ts-graphviz/setup-graphviz@v1
 
     - name: Set up Java
       uses: actions/setup-java@v2.2.0

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,20 +1,23 @@
-# Builds Verdict release artifacts on each published release:
-# - Uploads native binaries as build artifacts
-# - Uploads extern.zip and README.md as GitHub release assets
-# - Pushes verdict Docker image to Docker Hub
-# - Updates verdict-latest & verdict-$RELEASE update sites
+name: VERDICT Release Workflow
 
-name: Verdict release build
+# Runs whenever a release is published on GitHub
 
 on:
   release:
     types: [ published ]
 
+# Runs a build job and uploads VERDICT build artifacts:
+# - Builds aadl2iml, kind2, and soteria_pp native binaries
+# - Builds VERDICT source & runs unit tests
+# - Uploads extern.zip and README.md to release assets
+# - Pushes verdict image to Docker Hub
+# - Updates verdict-latest update site
+
 jobs:
   native-binaries:
     strategy:
       matrix:
-        ocaml-version: [ 4.07.1 ]
+        ocaml-compiler: [ 4.07.1 ]
         os: [ macos-10.15, ubuntu-20.04 ]
         include:
           - os: macos-10.15
@@ -25,30 +28,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Check out VERDICT source
-      uses: actions/checkout@v2
-
-    - name: Check out kind2 source
-      uses: actions/checkout@v2
-      with:
-        repository: kind2-mc/kind2
-        path: tools/verdict-back-ends/kind2
-
-    - name: Cache opam repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.opam
-        key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}
-
-    - name: Set up OCaml
-      uses: avsm/setup-ocaml@v1
-      with:
-        ocaml-version: ${{ matrix.ocaml-version }}
-
     - name: Set up zmq library
       run: ${{ matrix.zmq_install }}
 
-    - name: Install opam packages
+    - name: Set up OCaml
+      uses: avsm/setup-ocaml@v2.0.0-beta3
+      with:
+        ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+    - name: Install OCaml packages
       run: |
         opam install --yes \
           async \
@@ -63,6 +51,15 @@ jobs:
           xml-light \
           yojson \
           zmq
+
+    - name: Check out VERDICT source
+      uses: actions/checkout@v2.3.4
+
+    - name: Check out kind2 source
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: kind2-mc/kind2
+        path: tools/verdict-back-ends/kind2
 
     - name: Build aadl2iml
       run: |
@@ -80,19 +77,19 @@ jobs:
         opam exec make
 
     - name: Upload aadl2iml
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.2.4
       with:
         name: ${{ matrix.os }}-binaries
         path: tools/verdict-back-ends/aadl2iml/bin/aadl2iml
 
     - name: Upload kind2
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.2.4
       with:
         name: ${{ matrix.os }}-binaries
         path: tools/verdict-back-ends/kind2/bin/kind2
 
     - name: Upload soteria_pp
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.2.4
       with:
         name: ${{ matrix.os }}-binaries
         path: tools/verdict-back-ends/soteria_pp/bin/soteria_pp
@@ -100,6 +97,7 @@ jobs:
   release:
     strategy:
       matrix:
+        distribution: [ temurin ]
         java-version: [ 11 ]
         os: [ ubuntu-20.04 ]
 
@@ -107,39 +105,40 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Check out VERDICT source
-      uses: actions/checkout@v2
-
     - name: Set up GraphViz
-      uses: ts-graphviz/setup-graphviz@v1
+      uses: ts-graphviz/setup-graphviz@v1.0.0
 
     - name: Set up Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2.2.0
       with:
+        distribution: ${{ matrix.distribution }}
         java-version: ${{ matrix.java-version }}
 
-    - name: Cache Maven repository
-      uses: actions/cache@v2
+    - name: Set up Maven cache
+      uses: actions/cache@v2.1.6
       with:
         path: ~/.m2/repository
-        key: ${{ matrix.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ matrix.os }}-m2
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
 
-    - name: Run Maven build
+    - name: Check out VERDICT source
+      uses: actions/checkout@v2.3.4
+
+    - name: Build VERDICT source
       run: |
         mvn -B install --file tools/verdict-back-ends/verdict-bundle/z3-native-libs/pom.xml
         mvn -B package -Dtycho.localArtifacts=ignore --file tools/pom.xml
       env:
         GraphVizPath: /usr/bin
 
-    - name: Download mac binaries
-      uses: actions/download-artifact@v2
+    - name: Download macOS binaries
+      uses: actions/download-artifact@v2.0.10
       with:
         name: macos-10.15-binaries
         path: extern/mac
 
-    - name: Download nix binaries
-      uses: actions/download-artifact@v2
+    - name: Download Linux binaries
+      uses: actions/download-artifact@v2.0.10
       with:
         name: ubuntu-20.04-binaries
         path: extern/nix
@@ -157,37 +156,24 @@ jobs:
         cp -a extern/nix/aadl2iml tools/verdict-back-ends/aadl2iml/bin
         cp -a extern/nix/soteria_pp tools/verdict-back-ends/soteria_pp/bin
 
-    - name: Upload extern.zip to GitHub release assets
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload extern.zip and README.md to GitHub release assets
+      uses: softprops/action-gh-release@v0.1.12
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: extern.zip
-        asset_name: extern.zip
-        asset_content_type: application/zip
-
-    - name: Upload README.md to GitHub release assets
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: docs/README.md
-        asset_name: README.md
-        asset_content_type: text/markdown; charset=UTF-8
+        files: |
+          extern.zip
+          docs/README.md
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v1.5.1
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v1.10.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Build and push verdict image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v2.6.1
       with:
         context: tools/verdict-back-ends
         file: tools/verdict-back-ends/Dockerfile
@@ -199,7 +185,7 @@ jobs:
           gehighassurance/verdict:${{ github.event.release.tag_name }}
 
     - name: Check out VERDICT-update-sites
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: ge-high-assurance/VERDICT-update-sites
         token: ${{ secrets.CI_PAT }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -106,7 +106,7 @@ jobs:
 
     steps:
     - name: Set up GraphViz
-      uses: ts-graphviz/setup-graphviz@v1.0.0
+      uses: ts-graphviz/setup-graphviz@v1
 
     - name: Set up Java
       uses: actions/setup-java@v2.2.0


### PR DESCRIPTION
Bring over the latest updates from other repositories' workflows. Ensure every action has an explicit version number and configure Dependabot to keep both the actions and Maven dependencies up to date.