### PR TITLE
Fix soteria_pp build error

### DIFF
--- a/tools/verdict-back-ends/soteria_pp/dune-project
+++ b/tools/verdict-back-ends/soteria_pp/dune-project
@@ -10,7 +10,7 @@
  (depends
    async
    (core_extended (and (>= v0.12) (< v0.13)))
-   printbox
+   (printbox (and (>= 0.5) (< 0.6)))
    xml-light
  )
 )


### PR DESCRIPTION
A new printbox version just broke soteria_pp's build.  Make dune use
only printbox 0.5 until we decide whether the incompatible changes are
OK or not (box corners also have changed to Unicode characters).