### PR TITLE
Attempt to support latest versions of OSATE and AGREE

### DIFF
--- a/tools/verdict/com.ge.research.osate.verdict.dsl.ui/src/com/ge/research/osate/verdict/dsl/ui/annex/VerdictAnnexHighlighter.java
+++ b/tools/verdict/com.ge.research.osate.verdict.dsl.ui/src/com/ge/research/osate/verdict/dsl/ui/annex/VerdictAnnexHighlighter.java
@@ -8,12 +8,13 @@ import org.eclipse.xtext.EnumLiteralDeclaration;
 import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.parser.IParseResult;
 import org.osate.aadl2.AnnexLibrary;
 import org.osate.aadl2.AnnexSubclause;
 import org.osate.annexsupport.AnnexHighlighter;
 import org.osate.annexsupport.AnnexHighlighterPositionAcceptor;
-import org.osate.annexsupport.AnnexParseUtil;
 import org.osate.annexsupport.AnnexUtil;
+import org.osate.annexsupport.ParseResultHolder;
 
 /**
  * Perform syntax highlighting/coloring; Osate extension point.
@@ -154,8 +155,9 @@ public class VerdictAnnexHighlighter implements AnnexHighlighter {
 		EObject saved = AnnexUtil.getParsedAnnex(annex);
 		if (annex != null && saved != null) {
 			int offset = AnnexUtil.getAnnexOffset(annex);
-			if (AnnexParseUtil.getParseResult(saved) != null) {
-				highlight(AnnexParseUtil.getParseResult(saved).getRootNode(), acceptor, offset, styles);
+			IParseResult parseResult = ParseResultHolder.Factory.INSTANCE.adapt(saved).getParseResult();
+			if (parseResult != null) {
+				highlight(parseResult.getRootNode(), acceptor, offset, styles);
 			}
 		}
 	}

--- a/tools/verdict/com.ge.research.osate.verdict.dsl.ui/src/com/ge/research/osate/verdict/dsl/ui/annex/VerdictAnnexParser.java
+++ b/tools/verdict/com.ge.research.osate.verdict.dsl.ui/src/com/ge/research/osate/verdict/dsl/ui/annex/VerdictAnnexParser.java
@@ -12,6 +12,7 @@ import com.ge.research.osate.verdict.dsl.ui.VerdictUiModule;
 import com.ge.research.osate.verdict.dsl.ui.internal.VerdictActivator;
 import com.ge.research.osate.verdict.dsl.verdict.VerdictContractLibrary;
 import com.ge.research.osate.verdict.dsl.verdict.VerdictContractSubclause;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 
 /**
@@ -22,33 +23,31 @@ import com.google.inject.Injector;
  * An annex subclause is inside of a system and contains cyber properties.
  */
 public class VerdictAnnexParser implements AnnexParser {
-	final private Injector injector = VerdictActivator.getInstance()
-			.getInjector(VerdictUiModule.INJECTOR_NAME);
 
+	@Inject
 	private VerdictParser parser;
 
-	protected VerdictParser getParser() {
-		if (parser == null) {
-			parser = injector.getInstance(VerdictParser.class);
-		}
-		return parser;
+	public VerdictAnnexParser() {
+		Injector injector = VerdictActivator.getInstance()
+			.getInjector(VerdictUiModule.INJECTOR_NAME);
+		injector.injectMembers(this);
 	}
 
 	protected VerdictGrammarAccess getGrammarAccess() {
-		return getParser().getGrammarAccess();
+		return parser.getGrammarAccess();
 	}
 
 	@Override
-	public AnnexLibrary parseAnnexLibrary(String name, String source, String filename, int line, int column,
+	public AnnexLibrary parseAnnexLibrary(String annexName, String source, String filename, int line, int column,
 			ParseErrorReporter errReporter) {
-		return (VerdictContractLibrary) AnnexParseUtil.parse(getParser(), source,
+		return (VerdictContractLibrary) AnnexParseUtil.parse(parser, source,
 				getGrammarAccess().getAnnexLibraryRule(), filename, line, column, errReporter);
 	}
 
 	@Override
-	public AnnexSubclause parseAnnexSubclause(String name, String source, String filename, int line, int column,
+	public AnnexSubclause parseAnnexSubclause(String annexName, String source, String filename, int line, int column,
 			ParseErrorReporter errReporter) {
-		return (VerdictContractSubclause) AnnexParseUtil.parse(getParser(), source,
+		return (VerdictContractSubclause) AnnexParseUtil.parse(parser, source,
 				getGrammarAccess().getAnnexSubclauseRule(), filename, line, column, errReporter);
 	}
 }

--- a/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
+++ b/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
@@ -1,50 +1,44 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target includeMode="feature" name="com.ge.research.osate.verdict.targetplatform" sequenceNumber="1">
+<target includeMode="feature" name="com.ge.research.osate.verdict.targetplatform" sequenceNumber="2">
     <locations>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
             <unit id="org.eclipse.ease.feature.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.ease.feature.source.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/ease/release/0.6.0"/>
+            <repository location="https://download.eclipse.org/ease/release/0.7.0"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
             <unit id="org.eclipse.elk.feature.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.elk.feature.source.feature.group" version="0.0.0"/>
-            <repository location="http://download.eclipse.org/elk/updates/releases/0.5.0"/>
+            <repository location="http://download.eclipse.org/elk/updates/releases/0.7.1"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-            <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.20.0"/>
+            <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
             <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.emf.mwe2.launcher.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.platform.sdk" version="0.0.0"/>
-            <repository location="http://download.eclipse.org/releases/2019-12"/>
+            <repository location="http://download.eclipse.org/releases/2021-03"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
             <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="0.0.0"/>
             <repository location="http://download.itemis.com/updates/releases/2.1.1"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
             <unit id="org.osate.core.feature.feature.group" version="0.0.0"/>
-            <unit id="org.osate.core.feature.source.feature.group" version="0.0.0"/>
             <unit id="org.osate.ge.feature.feature.group" version="0.0.0"/>
-            <unit id="org.osate.ge.feature.source.feature.group" version="0.0.0"/>
             <unit id="org.osate.plugins.feature.feature.group" version="0.0.0"/>
-            <unit id="org.osate.plugins.feature.source.feature.group" version="0.0.0"/>
-            <repository location="http://osate-build.sei.cmu.edu/download/osate/stable/2.7.1/updates"/>
+            <repository location="http://osate-build.sei.cmu.edu/download/osate/stable/2.10.2/updates"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
             <unit id="com.rockwellcollins.atc.agree.feature.feature.group" version="0.0.0"/>
             <unit id="com.rockwellcollins.atc.tcg.feature.feature.group" version="0.0.0"/>
             <unit id="edu.uah.rsesc.aadlsimulator.agree.feature.feature.group" version="0.0.0"/>
             <unit id="edu.uah.rsesc.aadlsimulator.feature.feature.group" version="0.0.0"/>
-            <repository location="https://raw.githubusercontent.com/loonwerks/AGREE-Updates/master/agree_2.5.2"/>
+            <repository location="https://raw.githubusercontent.com/loonwerks/AGREE-Updates/master/agree_2.8.0"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
             <unit id="org.yakindu.base.xtext.utils.jface" version="0.0.0"/>
             <repository location="http://updates.yakindu.com/statecharts/releases/3.5.9"/>
         </location>

--- a/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
+++ b/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
@@ -36,7 +36,7 @@
             <unit id="com.rockwellcollins.atc.tcg.feature.feature.group" version="0.0.0"/>
             <unit id="edu.uah.rsesc.aadlsimulator.agree.feature.feature.group" version="0.0.0"/>
             <unit id="edu.uah.rsesc.aadlsimulator.feature.feature.group" version="0.0.0"/>
-            <repository location="https://raw.githubusercontent.com/loonwerks/AGREE-Updates/master/agree_2.8.0"/>
+            <repository location="https://raw.githubusercontent.com/loonwerks/AGREE-Updates/master/agree_2.9.1"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
             <unit id="org.yakindu.base.xtext.utils.jface" version="0.0.0"/>

--- a/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/aadl2vdm/Agree2Vdm.java
+++ b/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/aadl2vdm/Agree2Vdm.java
@@ -149,6 +149,14 @@ public class Agree2Vdm {
 		final Injector injector = new Aadl2StandaloneSetup().createInjectorAndDoEMFRegistration();
 		final XtextResourceSet rs = injector.getInstance(XtextResourceSet.class);
 		rs.addLoadOption(XtextResource.OPTION_RESOLVE_ALL, Boolean.TRUE);
+		
+		EcorePlugin.ExtensionProcessor.process(null);
+		//getting aadl imported files
+		final List<URI> contributed = PluginSupportUtil.getContributedAadl();
+		for (final URI uri : contributed) {
+			rs.getResource(uri, true);
+		}		
+		
 		List<String> aadlFileNames = new ArrayList<>();
 		// Obtain all AADL files contents in the project
 		List<EObject> objects = new ArrayList<>();
@@ -164,12 +172,7 @@ public class Agree2Vdm {
 		for (int i = 0; i < aadlFileNames.size(); i++) {
 			rs.getResource(URI.createFileURI(aadlFileNames.get(i)), true);
 		}
-		EcorePlugin.ExtensionProcessor.process(null);
-		//getting aadl imported files
-		final List<URI> contributed = PluginSupportUtil.getContributedAadl();
-		for (final URI uri : contributed) {
-			rs.getResource(uri, true);
-		}
+		
 		// Load the resources
 		Map<String,Boolean> options = new HashMap<String,Boolean>();
 	    options.put(XtextResource.OPTION_RESOLVE_ALL, Boolean.TRUE);
@@ -178,7 +181,7 @@ public class Agree2Vdm {
 				resource.load(options);
 				IResourceValidator validator = ((XtextResource) resource).getResourceServiceProvider()
 				        .getResourceValidator();
-				List<Issue> issues = validator.validate(resource, CheckMode.ALL, CancelIndicator.NullImpl);
+				List<Issue> issues = validator.validate(resource, CheckMode.FAST_ONLY, CancelIndicator.NullImpl);
 				for (Issue issue : issues) {
 				    System.out.println(issue.getMessage());
 				}


### PR DESCRIPTION
Bump VERDICT's target platform to same versions as OSATE 2.10.2's
target platform.  Fix compilation problems.  Still need to fix runtime
problems that show up when running VERDICT's CRV tool in OSATE 2.10.2
and AGREE 2.8.0 (combination of OSATE 2.7.1 and AGREE 2.5.2 still
works fine).  Probably need to change AADL2VDM translator and/or
AGREE annex in DeliveryDrone as well.  Sharing this branch for easier
collaboration, not ready for merging yet.

VerdictAnnexHighlighter.java: Fix compilation problem (needed to
replace call of AnnexParseUtil.getParseResult(saved) with call of
ParseResultHolder.Factory.INSTANCE.adapt(saved).getParseResult()).

VerdictAnnexParser.java: No compilation problem, but compare with
EMV2AnnexParser.java in OSATE and make VerdictAnnexParser more similar
to EMV2AnnexParser.java since it's how the parser gets called.

com.ge.research.osate.verdict.targetplatform.target: Bump nearly every
update site's version to the same versions used by OSATE 2.10.2.
Remove source features to save compilation time.