### PR TITLE
MSHU11: Updated VERDICT Installation Guidelines in ReadMe(s) 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,8 +104,14 @@ plugin to communicate with Docker:
 - Go into Settings in Docker Desktop and enable the checkbox next to
   "Expose daemon on tcp://localhost:2375 without TLS".
 
+- Click the "Apply & Restart" button at the bottom to restart Docker
+  after these changes.
+
+If you are running Docker on macOS, you will also have to 
+configure the following:
+
 - Click on Resources under Settings, click on FILE SHARING under
-  Resources, and add your drive letter to the list of directories
+  Resources, and add your workspace directory to the list of directories 
   which Docker can bind mount into containers.
 
 - Click the "Apply & Restart" button at the bottom to restart Docker
@@ -127,7 +133,7 @@ of whether you use Docker or native binaries.  After unpacking
 extern.zip (make sure you remember the location of the unpacked extern
 folder), then configure some VERDICT settings in OSATE:
 
-- Launch OSATE, go to Window > Preferences > Verdict > Verdict
+- Launch OSATE, go to Window (OSATE for macOS) > Preferences > Verdict > Verdict
   Settings, and fill out the following fields.
 
 - Click the Browse... button next to the "STEM Project PATH:" field,
@@ -166,7 +172,7 @@ of whether you use Docker or native binaries.  After unpacking
 extern.zip (make sure you remember the location of the unpacked extern
 folder), then configure some VERDICT settings in OSATE:
 
-- Launch OSATE, go to Window > Preferences > Verdict > Verdict
+- Launch OSATE, go to Window (OSATE for macOS) > Preferences > Verdict > Verdict
   Settings, and fill out the following fields.
 
 - Click the Browse... button next to the "STEM Project PATH:" field,
@@ -208,11 +214,13 @@ import that model into your OSATE workspace.  You can open the model's
 AADL files to see how that model uses AGREE annexes, VERDICT annexes,
 and VERDICT properties.
 
-You can invoke VERDICT's functionality from the Verdict pulldown menu.
-First click on a project's name in the AADL Navigator pane to make it
-the currently selected project, then pull down the Verdict menu and
-run the appropriate back-end tools (MBAA, MBAS, CRV, etc.).  Our
-plugin will use Docker Java API calls to pull the appropriate Docker
+You can invoke VERDICT's functionality from the Verdict pulldown menu 
+(in the OSATE application toolbar). First click on a project's name in 
+the AADL Navigator pane to make it the currently selected project, then 
+pull down the Verdict menu and run the appropriate back-end tools 
+(MBAA, MBAS, CRV, etc.). 
+
+Our plugin will use Docker Java API calls to pull the appropriate Docker
 image from Docker Hub (only if the image isn't already in your
 Docker's local cache), start a temporary Docker container to run the
 MBAA or CRV command, and then display any output from that command.

--- a/tools/README.md
+++ b/tools/README.md
@@ -63,20 +63,21 @@ OSATE asks you whether to convert the project to an Xtext project
 after you open an AADL file, answer yes since the project must have a
 Xtext nature to enable our VERDICT plugin's functionality.
 
-You can invoke our VERDICT plugin's functionality from the Verdict
-pulldown menu.  First click on a project's name in the AADL Navigator
-pane to make it the currently selected project, then pull down the
-Verdict menu and run the appropriate back-end tools (MBAA, MBAS, CRV,
-etc.).  Our plugin will use Docker Java API calls to pull down the
-appropriate Docker image from Docker Hub (only if the image isn't
-already in your Docker's local cache), start a temporary Docker
-container to run the MBAA or CRV command, and then display any output
-from that command.  If you use the executable jar instead of the
-Docker image, the plugin will run the executable jar in a subprocess
-directly on your system.  Both the temporary container and the
-executable jar will run several VERDICT back-end tool chain programs
-in additional subprocesses inside the temporary container or directly
-on your system as well.
+You can invoke VERDICT's functionality from the Verdict pulldown menu
+(in the OSATE application toolbar). First click on a project's name in
+the AADL Navigator pane to make it the currently selected project, then
+pull down the Verdict menu and run the appropriate back-end tools
+(MBAA, MBAS, CRV, etc.).
+
+Our plugin will use Docker Java API calls to pull the appropriate Docker
+image from Docker Hub (only if the image isn't already in your
+Docker's local cache), start a temporary Docker container to run the
+MBAA or CRV command, and then display any output from that command.
+If you use the executable jar instead of the Docker image, the plugin
+will run the executable jar in a subprocess directly on your system.
+Both the temporary container and the executable jar will run several
+VERDICT back-end tool chain programs in additional subprocesses inside
+the temporary container or directly on your system as well.
 
 For further information how to analyze a model's system architecture
 using our VERDICT tools, please read our VERDICT wiki's

--- a/tools/verdict-back-ends/README.md
+++ b/tools/verdict-back-ends/README.md
@@ -157,13 +157,19 @@ following things to allow our plugin to communicate with Docker:
    socket.
 
 2. Go into Settings in Docker Desktop and enable the checkbox
-   next to "Expose daemon on tcp://localhost:2375 without TLS".
+   next to "Expose daemon on tcp://localhost:2375 without TLS". 
 
-3. Click on Resources under Settings, click on FILE SHARING under
-   Resources, and add your drive letter to the list of directories
+3. Click the "Apply & Restart" button at the bottom to restart Docker
+   after these changes.
+
+If you are running Docker on macOS, you will also have to 
+configure the following:
+
+1. Click on Resources under Settings, click on FILE SHARING under 
+   Resources, and add your workspace directory to the list of directories
    which Docker can bind mount into containers.
 
-4. Click the "Apply & Restart" button at the bottom to restart Docker
+2. Click the "Apply & Restart" button at the bottom to restart Docker
    after these changes.
 
 If you want to check that Docker is installed and running correctly,


### PR DESCRIPTION
Added a few points of clarification after following the ReadMe installation guidelines available in release [1.6.4](https://github.com/ge-high-assurance/VERDICT/releases/tag/1.6.4)

- Docker Desktop on Windows: the FILE_SHARING setting is not available for non-HyperV configurations. More information on this can be found in the [docker windows documentation](https://docs.docker.com/desktop/windows/):

> Note: The File sharing tab is only available in Hyper-V mode because the files are automatically shared in WSL 2 mode and Windows container mode.

- MacOS verdict settings can be found from the OSATE application toolbar > OSATE > Verdict > Verdict Settings... etc.), different from windows

- Specified that the Verdict menu is available in the application toolbar (for all OS's)