### PR TITLE
VERDICT-194: Including DAL0 Defense Profiles in Likelihood Calculation

### DIFF
--- a/tools/verdict-back-ends/README.md
+++ b/tools/verdict-back-ends/README.md
@@ -186,7 +186,7 @@ more quickly.  Our back-end programs tend to be CPU-bound, not
 memory-bound, so increasing the number of CPUs probably will be more
 effective than increasing the memory.
 
-## Build the native back-end programs (optional)
+## Build the soteria++ native back-end programs (optional)
 
 The native program sources are written in
 [OCaml](https://ocaml.org/learn/description.html).  If you want to

--- a/tools/verdict-back-ends/soteria_pp/README.md
+++ b/tools/verdict-back-ends/soteria_pp/README.md
@@ -1,94 +1,83 @@
-# Instructions to build the SOTERIA++ tool
+# SOTERIA++ build and run instructions
 
--------------------
-** Prerequisites **
--------------------
+## Installation
 
-OCaml version 4.07.0 is required, installed using opam version
-2.0.0. The following OCaml packages are required: async, core,
-core_extended, ocamlbuild, ocamlfind, printbox, and xml-light. These
-can be installed using the following command:
+Follow the [Build the native back-end programs](../README.md) installation instructions to install the soteria++ 
+application and dependencies. 
 
+## Debug Prerequisites
 
-```
-$ opam install async core core_extended ocamlbuild ocamlfind printbox xml-light
-```
-
-Edit your ~/.ocamlinit file by adding the following lines:
+The oCaml core package is required to bundle soteria++:
 
 ```
-#use "topfind" ;;
-#thread ;;
-#load "stdlib.cma" ;;
-#require "async" ;;
-#require "core_extended" ;;
-open Core ;;
+$ opam install core && eval $(opam config env)
 ```
 
-
-Graphviz is also required, which can be installed using MacPorts with the following command: 
-
-
-```
-$ port install graphviz
-```
-
--------------------
-**     Build     **
--------------------
+## Build
 
 The tool is built using the following command:
-
 
 ```
 $ corebuild -pkg printbox -pkg xml-light soteria_pp.byte 
 ```
 
-or
+or for the native executable:
 
 ```
 $ corebuild -pkg printbox -pkg xml-light soteria_pp.native 
 ```
 
-Note that you can clean a build with the following command. (If you do, you have
+You can clean a build with the following command. (If you do, you have
 to rebuild the tool with the command above)
 
 ```
 $ corebuild -clean
 ```
 
--------------------
-**      Run      **
--------------------
+## Run
 
-Run the tool by executing the following command. The following files are expected in the input_path: CAPEC.csv, CompDep.csv, ScnArch.csv, Mission.csv, and Defenses.csv.
-
+Soteria++ builds can be configured to [run in OSATE](../README.md) or run form the CLI. The input_path should include 
+STEM files: CAPEC.csv, CompDep.csv, ScnArch.csv, Mission.csv, and Defenses.csv. Run the VERDICT OSATE once to 
+initialize these files (in ~/workspace/extern/STEM/Output/).
 
 ```
 $ ./soteria_pp.byte -o output_path input_path 
 ```
-
-Alternatively, the output path can be left out.
-
+The output path may be omitted with:
 ```
 $ ./soteria_pp.byte input_path 
 ```
 
+## OCaml Debugger
 
+The [oCaml debugger](https://ocaml.org/manual/debugger.html) provides a CLI to set breakpoints and easily inspect 
+variable values. Refer to oCaml debugger manual's [Running the Program](https://ocaml.org/manual/debugger.html#s%3Adebugger-commands) for debug 
+commands. After building the soteria++ .byte bundle run the debugger with: 
 
--------------------
-**   OCaml Top   **
--------------------
+```
+cd ./soteria_pp/_build/
+ocamldebug soteria_pp.byte input_path
+```
 
-If you want to run using OCaml top-level, cd to /examples, then call ocaml. From OCaml top, load top.ml,
-then load your example file. For instance:
+The input_path should include STEM files: CAPEC.csv, CompDep.csv, ScnArch.csv, Mission.csv, and Defenses.csv. Run VERDICT 
+in OSATE once to initialize these files (in ~/workspace/extern/STEM/Output/). After the debugger initializes set a breakpoint, 
+run the application and inspect a variable. For example:
 
+```
+(ocd) set print_length 10000
+(ocd) break @ translator 1309
+(ocd) run
+(ocd) print l_librariesThreats
+```
 
+## OCaml Top (and Running Tests)
 
-$ cd examples
+If you want to run using OCaml top-level, build the project then call ocaml. From the OCaml top CLI load top.ml and 
+then your example or test file. For instance:
 
-$ ocaml
-
-\# \#use "top.ml";;
-
-\# \#use "your_file_name.ml";;
+```
+$ ocaml -I ./_build
+# #use "examples/top.ml";;
+# #use "examples/your_example_file.ml";;
+# #use "qualitative-test.ml";;
+```

--- a/tools/verdict-back-ends/soteria_pp/attackDefenseTree.ml
+++ b/tools/verdict-back-ends/soteria_pp/attackDefenseTree.ml
@@ -36,7 +36,7 @@ type 'a adtree =
 type 'a adexp = 
   | ATRUE
   | AFALSE
-  | AVar of 'a (* attackStr, defenseStr, dal *)
+  | AVar of 'a (* attack_component,attack_event,probability -or- def_component,def_event,DAL tuples *)
   | ANot of 'a adexp
   | ASum of 'a adexp list
   | APro of 'a adexp list

--- a/tools/verdict-back-ends/soteria_pp/attackDefenseTree.ml
+++ b/tools/verdict-back-ends/soteria_pp/attackDefenseTree.ml
@@ -36,7 +36,7 @@ type 'a adtree =
 type 'a adexp = 
   | ATRUE
   | AFALSE
-  | AVar of 'a 
+  | AVar of 'a (* attackStr, defenseStr, dal *)
   | ANot of 'a adexp
   | ASum of 'a adexp list
   | APro of 'a adexp list

--- a/tools/verdict-back-ends/soteria_pp/dune
+++ b/tools/verdict-back-ends/soteria_pp/dune
@@ -3,7 +3,7 @@
  (libraries core printbox xml-light)
  (preprocess (pps ppx_let))
  (modules :standard \
-   qualitative-test quantitative-test treeSynthesis-test validation-tests
+            qualitative-test quantitative-test treeSynthesis-test validation-tests
  )
 )
 

--- a/tools/verdict-back-ends/soteria_pp/qualitative-test.ml
+++ b/tools/verdict-back-ends/soteria_pp/qualitative-test.ml
@@ -46,17 +46,17 @@ test_sumofprod_ad ();;
 
 (* testing with some AD trees *)
 let test_cutsets_ad () =
-	let a = ALeaf(("a_atk","a_def"), 1.)
-	and b = DLeaf(("b_atk","b_def"), 5)
-	and c = ALeaf(("c_atk","c_def"), 1.) in
+	let a = ALeaf(("defCompA","defEventA"), 1.)
+	and b = DLeaf(("defCompB","defEventB"), 5)
+	and c = ALeaf(("defCompC","defEventC"), 1.) in
 	let t1 = C(a, b) in
     let t2 = ASUM [ c; t1 ]
     and t3 = APRO [ c; t1 ]
     and t4 = ASUM [ a; t1 ] in
-    assert( cutsets_ad t1 = APro [ AVar ("a_atk","a_def",""); ANot (AVar ("b_atk","b_def","5")) ] );
-    assert( cutsets_ad t2 = ASum [ AVar ("c_atk","c_def",""); APro [AVar ("a_atk","a_def",""); ANot (AVar ("b_atk","b_def","5"))]] );
-    assert( cutsets_ad t3 = APro [ AVar ("a_atk","a_def",""); AVar ("c_atk","c_def",""); ANot (AVar ("b_atk","b_def","5")) ] );
-    assert( cutsets_ad t4 = AVar ("a_atk","a_def","") );
+    assert( cutsets_ad t1 = APro [ AVar ("defCompA","defEventA",""); ANot (AVar ("defCompB","defEventB","5")) ] );
+    assert( cutsets_ad t2 = ASum [ AVar ("defCompC","defEventC",""); APro [AVar ("defCompA","defEventA",""); ANot (AVar ("defCompB","defEventB","5"))]] );
+    assert( cutsets_ad t3 = APro [ AVar ("defCompA","defEventA",""); AVar ("defCompC","defEventC",""); ANot (AVar ("defCompB","defEventB","5")) ] );
+    assert( cutsets_ad t4 = AVar ("defCompA","defEventA","") );
     true;;
     
 test_cutsets_ad ();;
@@ -64,11 +64,11 @@ test_cutsets_ad ();;
 (* test cutsets_ad algo again with different combinations of PoS's and SoP's *)
 let test_cutsets_ad () =
 
-    let i_leaf = ("i_atk","i_def")
-    and a_leaf = ("a_atk","a_def")
-    and b_leaf = ("b_atk","b_def")
-    and c_leaf = ("c_atk","c_def")
-    and d_leaf = ("d_atk","d_def")
+    let i_leaf = ("atkComp","atkEvent")
+    and a_leaf = ("defCompA","defEventA")
+    and b_leaf = ("defCompB","defEventB")
+    and c_leaf = ("defCompC","defEventC")
+    and d_leaf = ("defCompD","defEventD")
     in
 
     let sss = C( ALeaf(i_leaf, 1.0), DSUM[ DSUM[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
@@ -83,11 +83,11 @@ let test_cutsets_ad () =
      
     in
 
-    let i_cut = ("i_atk","i_def","")
-    and a_cut = ("a_atk","a_def","5")
-    and b_cut = ("b_atk","b_def","5")
-    and c_cut = ("c_atk","c_def","5")
-    and d_cut = ("d_atk","d_def","5")
+    let i_cut = ("atkComp","atkEvent","")
+    and a_cut = ("defCompA","defEventA","5")
+    and b_cut = ("defCompB","defEventB","5")
+    and c_cut = ("defCompC","defEventC","5")
+    and d_cut = ("defCompD","defEventD","5")
     in
 
     assert( cutsets_ad sss = APro[ AVar i_cut; DPro [ANot (AVar a_cut); ANot (AVar b_cut); ANot (AVar c_cut); ANot (AVar d_cut)] ] );

--- a/tools/verdict-back-ends/soteria_pp/qualitative-test.ml
+++ b/tools/verdict-back-ends/soteria_pp/qualitative-test.ml
@@ -46,44 +46,59 @@ test_sumofprod_ad ();;
 
 (* testing with some AD trees *)
 let test_cutsets_ad () =
-	let a = ALeaf("a", 1.) 
-	and b = DLeaf("b", 5)
-	and c = ALeaf("c", 1.) in
+	let a = ALeaf(("a_atk","a_def"), 1.)
+	and b = DLeaf(("b_atk","b_def"), 5)
+	and c = ALeaf(("c_atk","c_def"), 1.) in
 	let t1 = C(a, b) in
     let t2 = ASUM [ c; t1 ]
     and t3 = APRO [ c; t1 ]
     and t4 = ASUM [ a; t1 ] in
-    assert( cutsets_ad t1 = APro [ AVar "a"; ANot (AVar "b") ] );
-    assert( cutsets_ad t2 = ASum [ AVar "c"; APro [AVar "a"; ANot (AVar "b")]] );
-    assert( cutsets_ad t3 = APro [ AVar "a"; AVar "c"; ANot (AVar "b") ] );
-    assert( cutsets_ad t4 = AVar "a" );
+    assert( cutsets_ad t1 = APro [ AVar ("a_atk","a_def",""); ANot (AVar ("b_atk","b_def","5")) ] );
+    assert( cutsets_ad t2 = ASum [ AVar ("c_atk","c_def",""); APro [AVar ("a_atk","a_def",""); ANot (AVar ("b_atk","b_def","5"))]] );
+    assert( cutsets_ad t3 = APro [ AVar ("a_atk","a_def",""); AVar ("c_atk","c_def",""); ANot (AVar ("b_atk","b_def","5")) ] );
+    assert( cutsets_ad t4 = AVar ("a_atk","a_def","") );
     true;;
     
 test_cutsets_ad ();;
 
 (* test cutsets_ad algo again with different combinations of PoS's and SoP's *)
 let test_cutsets_ad () =
-    let sss = C( ALeaf("i", 1.0), DSUM[ DSUM[ DLeaf("a", 5); DLeaf("b", 5) ]; DSUM[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)
-    and spp = C( ALeaf("i", 1.0), DSUM[ DPRO[ DLeaf("a", 5); DLeaf("b", 5) ]; DPRO[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)
-    and ssp = C( ALeaf("i", 1.0), DSUM[ DSUM[ DLeaf("a", 5); DLeaf("b", 5) ]; DPRO[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)
-    and sps = C( ALeaf("i", 1.0), DSUM[ DPRO[ DLeaf("a", 5); DLeaf("b", 5) ]; DSUM[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)
-    and ppp = C( ALeaf("i", 1.0), DPRO[ DPRO[ DLeaf("a", 5); DLeaf("b", 5) ]; DPRO[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)
-    and p   = C( ALeaf("i", 1.0), DPRO[ DSUM[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *) 
-    and pss = C( ALeaf("i", 1.0), DPRO[ DSUM[ DLeaf("a", 5); DLeaf("b", 5) ]; DSUM[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)        
-    and psp = C( ALeaf("i", 1.0), DPRO[ DSUM[ DLeaf("a", 5); DLeaf("b", 5) ]; DPRO[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* was ANot working, now working *) 
-    and pps = C( ALeaf("i", 1.0), DPRO[ DPRO[ DLeaf("a", 5); DLeaf("b", 5) ]; DSUM[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* was ANot working, now working *)
+
+    let i_leaf = ("i_atk","i_def")
+    and a_leaf = ("a_atk","a_def")
+    and b_leaf = ("b_atk","b_def")
+    and c_leaf = ("c_atk","c_def")
+    and d_leaf = ("d_atk","d_def")
+    in
+
+    let sss = C( ALeaf(i_leaf, 1.0), DSUM[ DSUM[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
+    and spp = C( ALeaf(i_leaf, 1.0), DSUM[ DPRO[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DPRO[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
+    and ssp = C( ALeaf(i_leaf, 1.0), DSUM[ DSUM[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DPRO[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
+    and sps = C( ALeaf(i_leaf, 1.0), DSUM[ DPRO[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
+    and ppp = C( ALeaf(i_leaf, 1.0), DPRO[ DPRO[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DPRO[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
+    and p   = C( ALeaf(i_leaf, 1.0), DPRO[ DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *) 
+    and pss = C( ALeaf(i_leaf, 1.0), DPRO[ DSUM[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)        
+    and psp = C( ALeaf(i_leaf, 1.0), DPRO[ DSUM[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DPRO[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* was ANot working, now working *) 
+    and pps = C( ALeaf(i_leaf, 1.0), DPRO[ DPRO[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* was ANot working, now working *)
      
     in
-    
-    assert( cutsets_ad sss = APro[ AVar "i"; DPro [ANot (AVar "a"); ANot (AVar "b"); ANot (AVar "c"); ANot (AVar "d")] ] );
-    assert( cutsets_ad spp = APro[ AVar "i"; DPro [DSum [ANot (AVar "a"); ANot (AVar "b")]; DSum [ANot (AVar "c"); ANot (AVar "d")]] ]);
-    assert( cutsets_ad ssp = APro[ AVar "i"; DPro [ANot (AVar "a"); ANot (AVar "b"); DSum [ANot (AVar "c"); ANot (AVar "d")]] ]);
-    assert( cutsets_ad sps = APro[ AVar "i"; DPro [ANot (AVar "c"); ANot (AVar "d"); DSum [ANot (AVar "a"); ANot (AVar "b")]] ]);
-    assert( cutsets_ad ppp = APro[ AVar "i"; DSum [ANot (AVar "a"); ANot (AVar "b"); ANot (AVar "c"); ANot (AVar "d")] ]);
-    assert( cutsets_ad p   = APro[ AVar "i"; DPro [ANot (AVar "c"); ANot (AVar "d")] ]);
-    assert( cutsets_ad pss = APro[ AVar "i"; DSum [DPro [ANot (AVar "a"); ANot (AVar "b")]; DPro [ANot (AVar "c"); ANot (AVar "d")];] ]);
-    assert( cutsets_ad psp = APro[ AVar "i"; DSum [ANot (AVar "c"); ANot (AVar "d"); DPro [ANot (AVar "a"); ANot (AVar "b");] ] ]);
-    assert( cutsets_ad pps = APro[ AVar "i"; DSum [ANot (AVar "a"); ANot (AVar "b"); DPro [ANot (AVar "c"); ANot (AVar "d") ] ] ]);
+
+    let i_cut = ("i_atk","i_def","")
+    and a_cut = ("a_atk","a_def","5")
+    and b_cut = ("b_atk","b_def","5")
+    and c_cut = ("c_atk","c_def","5")
+    and d_cut = ("d_atk","d_def","5")
+    in
+
+    assert( cutsets_ad sss = APro[ AVar i_cut; DPro [ANot (AVar a_cut); ANot (AVar b_cut); ANot (AVar c_cut); ANot (AVar d_cut)] ] );
+    assert( cutsets_ad spp = APro[ AVar i_cut; DPro [DSum [ANot (AVar a_cut); ANot (AVar b_cut)]; DSum [ANot (AVar c_cut); ANot (AVar d_cut)]] ]);
+    assert( cutsets_ad ssp = APro[ AVar i_cut; DPro [ANot (AVar a_cut); ANot (AVar b_cut); DSum [ANot (AVar c_cut); ANot (AVar d_cut)]] ]);
+    assert( cutsets_ad sps = APro[ AVar i_cut; DPro [ANot (AVar c_cut); ANot (AVar d_cut); DSum [ANot (AVar a_cut); ANot (AVar b_cut)]] ]);
+    assert( cutsets_ad ppp = APro[ AVar i_cut; DSum [ANot (AVar a_cut); ANot (AVar b_cut); ANot (AVar c_cut); ANot (AVar d_cut)] ]);
+    assert( cutsets_ad p   = APro[ AVar i_cut; DPro [ANot (AVar c_cut); ANot (AVar d_cut)] ]);
+    assert( cutsets_ad pss = APro[ AVar i_cut; DSum [DPro [ANot (AVar a_cut); ANot (AVar b_cut)]; DPro [ANot (AVar c_cut); ANot (AVar d_cut)];] ]);
+    assert( cutsets_ad psp = APro[ AVar i_cut; DSum [ANot (AVar c_cut); ANot (AVar d_cut); DPro [ANot (AVar a_cut); ANot (AVar b_cut);] ] ]);
+    assert( cutsets_ad pps = APro[ AVar i_cut; DSum [ANot (AVar a_cut); ANot (AVar b_cut); DPro [ANot (AVar c_cut); ANot (AVar d_cut) ] ] ]);
     
     true;;
     

--- a/tools/verdict-back-ends/soteria_pp/qualitative.ml
+++ b/tools/verdict-back-ends/soteria_pp/qualitative.ml
@@ -60,14 +60,14 @@ let rec formulaOfTree t =
 (** Code for translating an attack-defense tree into a formula *)
 let rec formulaOfDTree dt =
   match dt with
-    | DLeaf (var, dal) -> let (attackStr, defenseStr) = var in AVar ((attackStr, defenseStr, string_of_int dal))
+    | DLeaf (var, dal) -> let (component, event) = var in AVar ((component, event, string_of_int dal))
     | DSUM (tree) -> DSum(List.map tree ~f:formulaOfDTree)
     | DPRO (tree) -> DPro(List.map tree ~f:formulaOfDTree) 
 ;;
 
 let rec formulaOfADTree adt =
   match adt with
-    | ALeaf (var, _) -> let (attackStr, defenseStr) = var in AVar ((attackStr, defenseStr, ""))
+    | ALeaf (var, probability) -> let (component, event) = var in AVar ((component, event, ""))
     | ASUM (tree) -> ASum(List.map tree ~f:formulaOfADTree)
     | APRO (tree) -> APro(List.map tree ~f:formulaOfADTree)
     | C (at, dt) -> APro([formulaOfADTree at; ANot(formulaOfDTree dt)])

--- a/tools/verdict-back-ends/soteria_pp/qualitative.ml
+++ b/tools/verdict-back-ends/soteria_pp/qualitative.ml
@@ -9,6 +9,8 @@ Date: 2017-12-15
 Updates: 5/9/2018, Kit Siu, added formulaOfADTree
          7/23/2018, Kit Siu, added cutsets_ad
          1/9/2019, Kit Siu, added capability for DSum and DPro, which are operators for defenses
+         5/23/2022, Chris Alexander, Multi-Rule cutset likelihoods to include unimplemented defenses
+
          
 *)
 
@@ -58,14 +60,14 @@ let rec formulaOfTree t =
 (** Code for translating an attack-defense tree into a formula *)
 let rec formulaOfDTree dt =
   match dt with
-    | DLeaf (var, _) -> AVar (var)
+    | DLeaf (var, dal) -> let (attackStr, defenseStr) = var in AVar ((attackStr, defenseStr, string_of_int dal))
     | DSUM (tree) -> DSum(List.map tree ~f:formulaOfDTree)
     | DPRO (tree) -> DPro(List.map tree ~f:formulaOfDTree) 
 ;;
 
 let rec formulaOfADTree adt =
   match adt with
-    | ALeaf (var, _) -> AVar (var) 
+    | ALeaf (var, _) -> let (attackStr, defenseStr) = var in AVar ((attackStr, defenseStr, ""))
     | ASUM (tree) -> ASum(List.map tree ~f:formulaOfADTree)
     | APRO (tree) -> APro(List.map tree ~f:formulaOfADTree)
     | C (at, dt) -> APro([formulaOfADTree at; ANot(formulaOfDTree dt)])

--- a/tools/verdict-back-ends/soteria_pp/quantitative-test.ml
+++ b/tools/verdict-back-ends/soteria_pp/quantitative-test.ml
@@ -9,10 +9,10 @@ Updates:
 
 *)
 
-let myDtree_and = DPRO [ DLeaf (("a1","d1"), 7); DLeaf (("a2","d2"), 9); DLeaf (("a3","d3"), 7) ];;
-let myDtree_or = DSUM [ DLeaf (("a1","d1"), 7); DLeaf (("a2","d2"), 9); DLeaf (("a3","d3"), 7) ];;
-let myADtree_wDtree_and = C ( ALeaf (("a1","d1"), 1.0), myDtree_and );;
-let myADtree_wDtree_or = C ( ALeaf (("a1","d1"), 1.0), myDtree_or );;
+let myDtree_and = DPRO [ DLeaf (("defCompA","defEventA"), 7); DLeaf (("defCompB","defEventB"), 9); DLeaf (("defCompC","defEventC"), 7) ];;
+let myDtree_or = DSUM [ DLeaf (("defCompA","defEventA"), 7); DLeaf (("defCompB","defEventB"), 9); DLeaf (("defCompC","defEventC"), 7) ];;
+let myADtree_wDtree_and = C ( ALeaf (("atkComp","atkEvent"), 1.0), myDtree_and );;
+let myADtree_wDtree_or = C ( ALeaf (("atkComp","atkEvent"), 1.0), myDtree_or );;
 
 
 (* assuranceCalcApprox *)
@@ -40,8 +40,8 @@ test_likelihoodCalcApprox ();;
 (* eventLikelihoodsAuxDt *)
 
 let test_eventLikelihoodsAuxDt () =
-  assert( eventLikelihoodsAuxDt myDtree_and = [(("a1","d1"), 1e-07); (("a2","d2"), 1e-09); (("a3","d3"), 1e-07)] );
-  assert( eventLikelihoodsAuxDt myDtree_or = [(("a1","d1"), 1e-07); (("a2","d2"), 1e-09); (("a3","d3"), 1e-07)] );
+  assert( eventLikelihoodsAuxDt myDtree_and = [(("defCompA","defEventA"), 1e-07); (("defCompB","defEventB"), 1e-09); (("defCompC","defEventC"), 1e-07)] );
+  assert( eventLikelihoodsAuxDt myDtree_or = [(("defCompA","defEventA"), 1e-07); (("defCompB","defEventB"), 1e-09); (("defCompC","defEventC"), 1e-07)] );
   true
 ;;
 
@@ -51,8 +51,8 @@ test_eventLikelihoodsAuxDt ();;
 (* eventLikelihoodsAux *)
 
 let test_eventLikelihoodsAux () =
-  assert( eventLikelihoodsAux myADtree_wDtree_and = [(("a1","d1"), 1.); (("a1","d1"), 1e-07); (("a2","d2"), 1e-09); (("a3","d3"), 1e-07)] );
-  assert( eventLikelihoodsAux myADtree_wDtree_or = [(("a1","d1"), 1.); (("a1","d1"), 1e-07); (("a2","d2"), 1e-09); (("a3","d3"), 1e-07)] );
+  assert( eventLikelihoodsAux myADtree_wDtree_and = [(("atkComp","atkEvent"), 1.); (("defCompA","defEventA"), 1e-07); (("defCompB","defEventB"), 1e-09); (("defCompC","defEventC"), 1e-07)] );
+  assert( eventLikelihoodsAux myADtree_wDtree_or = [(("atkComp","atkEvent"), 1.); (("defCompA","defEventA"), 1e-07); (("defCompB","defEventB"), 1e-09); (("defCompC","defEventC"), 1e-07)] );
   true
 ;;
 
@@ -68,7 +68,7 @@ let test_likelihoodCutSOP () =
 
    (* test the Dtree with ANDed defenses -- expect higher likelihood of success 
       because if you need all the defenses, then pick out the weakest link *)
-   assert( likelihoodCutSOP [(sop_ad (formulaOfADTree myADtree_wDtree_and))] (eventLikelihoodsAux myADtree_wDtree_and) = [1.] );
+   assert( likelihoodCutSOP [(sop_ad (formulaOfADTree myADtree_wDtree_and))] (eventLikelihoodsAux myADtree_wDtree_and) = [1e-07] );
    true
 ;;
 

--- a/tools/verdict-back-ends/soteria_pp/quantitative-test.ml
+++ b/tools/verdict-back-ends/soteria_pp/quantitative-test.ml
@@ -9,10 +9,10 @@ Updates:
 
 *)
 
-let myDtree_and = DPRO [ DLeaf ("d1", 7); DLeaf ("d2", 9); DLeaf ("d3", 7) ];;
-let myDtree_or = DSUM [ DLeaf ("d1", 7); DLeaf ("d2", 9); DLeaf ("d3", 7) ];;
-let myADtree_wDtree_and = C ( ALeaf ("a1", 1.0), myDtree_and );;
-let myADtree_wDtree_or = C ( ALeaf ("a1", 1.0), myDtree_or );;
+let myDtree_and = DPRO [ DLeaf (("a1","d1"), 7); DLeaf (("a2","d2"), 9); DLeaf (("a3","d3"), 7) ];;
+let myDtree_or = DSUM [ DLeaf (("a1","d1"), 7); DLeaf (("a2","d2"), 9); DLeaf (("a3","d3"), 7) ];;
+let myADtree_wDtree_and = C ( ALeaf (("a1","d1"), 1.0), myDtree_and );;
+let myADtree_wDtree_or = C ( ALeaf (("a1","d1"), 1.0), myDtree_or );;
 
 
 (* assuranceCalcApprox *)
@@ -40,8 +40,8 @@ test_likelihoodCalcApprox ();;
 (* eventLikelihoodsAuxDt *)
 
 let test_eventLikelihoodsAuxDt () =
-  assert( eventLikelihoodsAuxDt myDtree_and = [("d1", 1e-07); ("d2", 1e-09); ("d3", 1e-07)] );
-  assert( eventLikelihoodsAuxDt myDtree_or = [("d1", 1e-07); ("d2", 1e-09); ("d3", 1e-07)] );
+  assert( eventLikelihoodsAuxDt myDtree_and = [(("a1","d1"), 1e-07); (("a2","d2"), 1e-09); (("a3","d3"), 1e-07)] );
+  assert( eventLikelihoodsAuxDt myDtree_or = [(("a1","d1"), 1e-07); (("a2","d2"), 1e-09); (("a3","d3"), 1e-07)] );
   true
 ;;
 
@@ -51,8 +51,8 @@ test_eventLikelihoodsAuxDt ();;
 (* eventLikelihoodsAux *)
 
 let test_eventLikelihoodsAux () =
-  assert( eventLikelihoodsAux myADtree_wDtree_and = [("a1", 1.); ("d1", 1e-07); ("d2", 1e-09); ("d3", 1e-07)] );
-  assert( eventLikelihoodsAux myADtree_wDtree_or = [("a1", 1.); ("d1", 1e-07); ("d2", 1e-09); ("d3", 1e-07)] );
+  assert( eventLikelihoodsAux myADtree_wDtree_and = [(("a1","d1"), 1.); (("a1","d1"), 1e-07); (("a2","d2"), 1e-09); (("a3","d3"), 1e-07)] );
+  assert( eventLikelihoodsAux myADtree_wDtree_or = [(("a1","d1"), 1.); (("a1","d1"), 1e-07); (("a2","d2"), 1e-09); (("a3","d3"), 1e-07)] );
   true
 ;;
 
@@ -68,7 +68,7 @@ let test_likelihoodCutSOP () =
 
    (* test the Dtree with ANDed defenses -- expect higher likelihood of success 
       because if you need all the defenses, then pick out the weakest link *)
-   assert( likelihoodCutSOP [(sop_ad (formulaOfADTree myADtree_wDtree_and))] (eventLikelihoodsAux myADtree_wDtree_and) = [1e-07] );
+   assert( likelihoodCutSOP [(sop_ad (formulaOfADTree myADtree_wDtree_and))] (eventLikelihoodsAux myADtree_wDtree_and) = [1.] );
    true
 ;;
 

--- a/tools/verdict-back-ends/soteria_pp/treeSynthesis-test.ml
+++ b/tools/verdict-back-ends/soteria_pp/treeSynthesis-test.ml
@@ -124,7 +124,7 @@ let cycle_cutset = cutsets_ad cycle_adtree        (* <-- AVar ("a", "a_atck") *)
 in
 
 assert( cycle_adtree = ASUM [ALeaf (("a", "a_atck"), 1.); ASUM [ALeaf (("a", "a_atck"), 1.)]] );
-assert( cycle_cutset = AVar ("a", "a_atck") );
+assert( cycle_cutset = AVar ("a", "a_atck", "") );
 
 true
 ;;
@@ -186,7 +186,7 @@ let cycle_cutset = cutsets_ad cycle_adtree       (* <-- AVar ("b", "b_atck") *)
 in
 
 assert( cycle_adtree = ASUM [ALeaf (("b", "b_atck"), 1.)]);
-assert( cycle_cutset = AVar ("b", "b_atck"););
+assert( cycle_cutset = AVar ("b", "b_atck", ""););
 
 true
 ;;
@@ -268,7 +268,7 @@ let cycle_cutset = cutsets_ad cycle_adtree (* <-- AVar ("b2", "b_atck") *)
 in
 
 assert( cycle_adtree = ASUM [ASUM [ALeaf (("b2", "b_atck"), 1.)]] );
-assert( cycle_cutset = AVar ("b2", "b_atck")  );
+assert( cycle_cutset = AVar ("b2", "b_atck", "")  );
 
 true
 
@@ -357,7 +357,7 @@ assert( cycle_adtree =
    [ALeaf (("c", "c_atck"), 1.);
     ASUM [ALeaf (("c", "c_atck"), 1.); ASUM [ALeaf (("c", "c_atck"), 1.)]];
     ASUM [ALeaf (("c", "c_atck"), 1.); ASUM [ALeaf (("c", "c_atck"), 1.)]]] );
-assert( cycle_cutset = AVar ("c", "c_atck") );
+assert( cycle_cutset = AVar ("c", "c_atck", "") );
 
 true 
 ;;
@@ -443,7 +443,7 @@ let cycle_cutset = cutsets_ad cycle_adtree       (* <-- AVar ("c", "c_atck") *)
 in
 
 assert( cycle_adtree = ASUM [ALeaf (("c", "c_atck"), 1.)] );
-assert( cycle_cutset = AVar ("c", "c_atck") );
+assert( cycle_cutset = AVar ("c", "c_atck", "") );
 
 true
 ;;

--- a/tools/verdict-back-ends/soteria_pp/validation-tests.ml
+++ b/tools/verdict-back-ends/soteria_pp/validation-tests.ml
@@ -354,7 +354,7 @@ let test_checkLibrary_listsAreConsistentLengths () =
   assert( checkLibrary_listsAreConsistentLengths library_bad2 = Error "Faults and fault formulas lists are of inconsistent lengths in component Sensor");
   assert( checkLibrary_listsAreConsistentLengths library_bad3 = Error "Attack events and attack info are of inconsistent lengths in component Sensor");
   assert( checkLibrary_listsAreConsistentLengths library_bad4 = Error "Attacks and attack formulas lists are of inconsistent lengths in component Sensor");
-  assert( checkLibrary_listsAreConsistentLengths library_bad5 = Error "Defense events and defense info are of inconsistent lengths in component Sensor");
+  assert( checkLibrary_listsAreConsistentLengths library_bad5 = Error "Defense events and defense rigors are of inconsistent lengths in component Sensor");
   true;;
 
 test_checkLibrary_listsAreConsistentLengths ();;

--- a/tools/verdict-back-ends/soteria_pp/visualization.ml
+++ b/tools/verdict-back-ends/soteria_pp/visualization.ml
@@ -8,7 +8,7 @@ Date: 2017-12-15
 
 Updates: 7/24/2018, Kit Siu, added dot_gen_show_direct_adtree_file and dot_gen_show_adtree_file
          10/22/2018, Kit Siu, added functions to print out cutset reports
-
+         5/23/2022, Chris Alexander, Multi-Rule cutset likelihoods to include unimplemented defenses
 *)
 
 (**
@@ -168,7 +168,7 @@ let rec adtree_dot ?(acc = (0, [], [])) f =
       (cnt+1, (cnt, "TRUE")::nodes, edges)
     | AFALSE ->
       (cnt+1, (cnt, "FALSE")::nodes, edges)
-    | AVar (x, y) ->
+    | AVar (x, y, d) ->
       (cnt+1, (cnt, (String.concat ~sep:": " [x; y]))::nodes, edges)
     | ASum x ->
       let (l,(cnt2, nodes2, edges2)) = adtree_dot_l ~acc x in
@@ -942,7 +942,7 @@ let dot_gen_show_fault_file
    using Out_channel.output_string and Out_channel. output_char *)
 let rec print_each_cs adexp ch  =
    match adexp with
-   | AVar( comp, event) -> Out_channel.output_string ch (comp ^ ":" ^ event); 
+   | AVar( comp, event, _) -> Out_channel.output_string ch (comp ^ ":" ^ event);
    | ASum l -> 
       (match l with
       | hd::tl -> print_each_cs hd ch; Out_channel.output_char ch '\n'; print_each_cs (ASum tl) ch ;
@@ -974,61 +974,62 @@ let rec print_each_csImp l ch =
 
 
 (* This function generates a string representation of the defense profiles *)
-let rec sprint_defenseProfile adexp =
+let rec sprint_defenseProfile adexp add_dal_suffix=
    let andStr = " ^ \n" 
    and orStr = " v " in
    match adexp with
-   | AVar(comp, event) -> comp ^ ":" ^ event
+   | AVar(comp, event, dal) -> let suffix = if add_dal_suffix then ":" ^ dal else "" in comp ^ ":" ^ event ^ suffix
    | DPro l -> 
      (match l with 
      | hd::tl -> 
-       if List.length tl = 0 then sprint_defenseProfile hd
-       else sprint_defenseProfile hd ^ andStr ^ sprint_defenseProfile (DPro tl)
+       if List.length tl = 0 then sprint_defenseProfile hd add_dal_suffix
+       else sprint_defenseProfile hd add_dal_suffix ^ andStr ^ sprint_defenseProfile (DPro tl) add_dal_suffix
      | []  -> "")
    | DSum l -> 
      (match l with 
      | hd::tl -> 
-       if List.length tl = 0 then sprint_defenseProfile hd
-       else sprint_defenseProfile hd ^ orStr ^ sprint_defenseProfile (DSum tl)
+       if List.length tl = 0 then sprint_defenseProfile hd add_dal_suffix
+       else sprint_defenseProfile hd add_dal_suffix ^ orStr ^ sprint_defenseProfile (DSum tl) add_dal_suffix
      | []  -> "")
-   | ANot form -> "Not(" ^ sprint_defenseProfile form ^ ")"
+   | ANot form -> "Not(" ^ sprint_defenseProfile form add_dal_suffix ^ ")"
    | _ -> "" ;; 
 
 
 (* This function generates 2 strings: attackStr, defenseStr *)
-let rec sprint_AProAVar2 adexp str =
+let rec sprint_AProAVar2 adexp str add_dal_suffix =
    let andStr = " ^ \n" 
    and orStr = " v " 
    and (attackStr, defenseStr) = str in
    match adexp with
-   | AVar (comp, event) -> (comp ^ ":" ^ event, defenseStr)
-   | APro l -> 
+   | AVar (comp, event, _) -> (comp ^ ":" ^ event, defenseStr)
+   | APro l ->
      (match l with
         | hd::tl -> 
            (match hd with
-              | AVar(comp, event) -> 
-              		let aStr = (if attackStr = "" then (comp ^ ":" ^ event) else (attackStr ^ andStr ^ comp ^ ":" ^ event)) in
-              		sprint_AProAVar2 (APro tl) (aStr, defenseStr )
+              | AVar(comp, event, dal) ->
+                    let dal_suffix = if add_dal_suffix then ":" ^ dal else "" in
+              		let aStr = (if attackStr = "" then (comp ^ ":" ^ event ^ dal_suffix) else (attackStr ^ andStr ^ comp ^ ":" ^ event ^ dal_suffix)) in
+              		sprint_AProAVar2 (APro tl) (aStr, defenseStr ) add_dal_suffix
               | DSum l -> 
-                    let dStr = (if defenseStr = "" then (sprint_defenseProfile (DSum l)) else (defenseStr ^ andStr ^ (sprint_defenseProfile (DSum l)))) in
-                    sprint_AProAVar2 (APro tl) (attackStr, dStr )
+                    let dStr = (if defenseStr = "" then (sprint_defenseProfile (DSum l) add_dal_suffix) else (defenseStr ^ andStr ^ (sprint_defenseProfile (DSum l) add_dal_suffix))) in
+                    sprint_AProAVar2 (APro tl) (attackStr, dStr ) add_dal_suffix
               | DPro l -> 
-                    let dStr = (if defenseStr = "" then (sprint_defenseProfile (DPro l)) else (defenseStr ^ andStr ^ (sprint_defenseProfile (DPro l)))) in
-                    sprint_AProAVar2 (APro tl) (attackStr, dStr )
+                    let dStr = (if defenseStr = "" then (sprint_defenseProfile (DPro l) add_dal_suffix) else (defenseStr ^ andStr ^ (sprint_defenseProfile (DPro l) add_dal_suffix))) in
+                    sprint_AProAVar2 (APro tl) (attackStr, dStr ) add_dal_suffix
               | ANot x -> 
-                    let dStr = (if defenseStr = "" then (sprint_defenseProfile (ANot x)) else (defenseStr ^ andStr ^ (sprint_defenseProfile (ANot x)))) in
-                    sprint_AProAVar2 (APro tl) (attackStr, dStr )
+                    let dStr = (if defenseStr = "" then (sprint_defenseProfile (ANot x) add_dal_suffix) else (defenseStr ^ andStr ^ (sprint_defenseProfile (ANot x) add_dal_suffix))) in
+                    sprint_AProAVar2 (APro tl) (attackStr, dStr ) add_dal_suffix
               | _ -> str)
         | [] -> (attackStr, defenseStr))
    | _ -> str;;
 
 (* Given the list of cutset from likelihoodCutImp, generates an output to use with PrintBox *)
-let rec sprint_each_csImp l_csImp csArray =
+let rec sprint_each_csImp l_csImp csArray add_dal_suffix =
    match l_csImp with
    | hd::tl -> 
       (let (adexp_APro, likelihood, _) = hd in 
-      let (attackStr, defenseStr) = sprint_AProAVar2 adexp_APro ("","") in
-      sprint_each_csImp tl (Array.append csArray [| [| (string_of_float likelihood); attackStr; defenseStr |] |] ) )
+      let (attackStr, defenseStr) = sprint_AProAVar2 adexp_APro ("","") add_dal_suffix in
+      sprint_each_csImp tl (Array.append csArray [| [| (string_of_float likelihood); attackStr; defenseStr |] |] ) add_dal_suffix)
    | [] -> csArray ;; 
 
 (* This function generates a string of failure events *)
@@ -1066,7 +1067,7 @@ let rec sprint_each_safety_csImp l_csImp csArray =
 
 (** This function generates a report with the top-level likelihood, the likelihood of 
     each cutset, and the cutset list. The cutset list is printed in a frame. *)
-let saveADCutSetsToFile ?cyberReqID:(cid="") ?risk:(r="") ?header:(h="") file adtree =
+let saveADCutSetsToFile ?cyberReqID:(cid="") ?risk:(r="") ?header:(h="") file adtree add_dal_suffix =
    if (Sys.file_exists file = `Yes) then Sys.command_exn("rm " ^ file);
    (* if header file is specified, then copy it as the cutset file *)
    if (not(String.is_empty h) && (Sys.file_exists h = `Yes )) then Sys.command_exn("cp " ^ h ^ " " ^ file);
@@ -1075,7 +1076,7 @@ let saveADCutSetsToFile ?cyberReqID:(cid="") ?risk:(r="") ?header:(h="") file ad
    and likelihood = likelihoodCut adtree 
    and targetString = (if (String.is_empty r) then "\n" else ("Acceptable level of risk must be less than or equal to " ^ r))
    in
-   let myArray = sprint_each_csImp csImp [| [|"Cutset\nlikelihood: "; "CAPEC: "; "Defense Profile: "|] |] in
+   let myArray = sprint_each_csImp csImp [| [|"Cutset\nlikelihood: "; "CAPEC: "; "Defense Profile: "|] |] add_dal_suffix in
    let box = PrintBox.(hlist [ text ("Cyber\nReqID: \n" ^ cid); grid_text myArray ]) |> PrintBox.frame
    in
    (Out_channel.output_string ch ("\n");


### PR DESCRIPTION
**GSN assurance case graph nodes are improperly colored (green) for success when a mission is failed**. The underlying issue is that assurance case fragments have incorrect likelihoods for CAPEC cutsets are only partially implemented. AD Tree Synthesis (used in calculating risk) drops DAL 0 rules of the cutset (from the tree). Risk is later calculated from the remaining nodes. In cases where only the parent (risk 1 ALeaf) node is left risk is calculated correctly but incorrectly in cases where there are remaining (DLeaf) leaves because removed rule risk is ignored. Steps to reproduce are captured in https://github.com/ge-high-assurance/VERDICT/issues/228 

1. Set secureBoot=1. Run Verdict > Create GSN Assurance Case Fragments. GSN is correctly colored red.
2. Set secureBoot=0. Run Verdict > Create GSN Assurance Case Fragments. GSN is incorrectly colored green.
3. Right click on the circle "SOLUTION_1". This will bring up the file Additive_Machine_V3-CyberReq01-ImplProperties.txt. Observe that the Calculated likelihood of successful attack (line 2) is 1e-09.

To solve the issue without editing STEM data generation (including Defenses.csv) the soteria++ logic can reference the ApplicableDefenseProperties (instead of ImplProperties in Defenses.csv) to infer DAL-0 cutset and include them in likelihood calculation. The assumptions of Defenses.csv for this fix to work are:
- ApplicableDefenseProperties, ImplProperties and DAL will always be listed in the same order
- ImplProperties defense profiles will always be formatted as the uncapitalized ApplicableDefenseProperties elements

**soteria++ installation and debug instructions enhancements**. Merged the soteria++ installation instructions between the tools README and the soteria++ README. Enhanced the debuging instructions to include ocamldebug setup

Solves: https://github.com/ge-high-assurance/VERDICT/issues/228, https://github.com/ge-high-assurance/VERDICT/issues/194