### PR TITLE
VERDICT-194: Factor Unimplemented Defenses in Implemented Cutset Likelihoods

### DIFF
--- a/tools/verdict-back-ends/README.md
+++ b/tools/verdict-back-ends/README.md
@@ -186,7 +186,7 @@ more quickly.  Our back-end programs tend to be CPU-bound, not
 memory-bound, so increasing the number of CPUs probably will be more
 effective than increasing the memory.
 
-## Build the native back-end programs (optional)
+## Build the soteria++ back-end programs (optional)
 
 The native program sources are written in
 [OCaml](https://ocaml.org/learn/description.html).  If you want to

--- a/tools/verdict-back-ends/soteria_pp/README.md
+++ b/tools/verdict-back-ends/soteria_pp/README.md
@@ -1,94 +1,83 @@
-# Instructions to build the SOTERIA++ tool
+# SOTERIA++ build and run instructions
 
--------------------
-** Prerequisites **
--------------------
+## Installation
 
-OCaml version 4.07.0 is required, installed using opam version
-2.0.0. The following OCaml packages are required: async, core,
-core_extended, ocamlbuild, ocamlfind, printbox, and xml-light. These
-can be installed using the following command:
+Follow the [Build the native back-end programs](../README.md) installation instructions to install the soteria++
+application and dependencies.
 
+## Debug Prerequisites
 
-```
-$ opam install async core core_extended ocamlbuild ocamlfind printbox xml-light
-```
-
-Edit your ~/.ocamlinit file by adding the following lines:
+The oCaml core package is required to bundle soteria++:
 
 ```
-#use "topfind" ;;
-#thread ;;
-#load "stdlib.cma" ;;
-#require "async" ;;
-#require "core_extended" ;;
-open Core ;;
+$ opam install core && eval $(opam config env)
 ```
 
-
-Graphviz is also required, which can be installed using MacPorts with the following command: 
-
-
-```
-$ port install graphviz
-```
-
--------------------
-**     Build     **
--------------------
+## Build
 
 The tool is built using the following command:
-
 
 ```
 $ corebuild -pkg printbox -pkg xml-light soteria_pp.byte 
 ```
 
-or
+or for the native executable:
 
 ```
 $ corebuild -pkg printbox -pkg xml-light soteria_pp.native 
 ```
 
-Note that you can clean a build with the following command. (If you do, you have
+You can clean a build with the following command. (If you do, you have
 to rebuild the tool with the command above)
 
 ```
 $ corebuild -clean
 ```
 
--------------------
-**      Run      **
--------------------
+## Run
 
-Run the tool by executing the following command. The following files are expected in the input_path: CAPEC.csv, CompDep.csv, ScnArch.csv, Mission.csv, and Defenses.csv.
-
+Soteria++ builds can be configured to [run in OSATE](../README.md) or run form the CLI. The input_path should include
+STEM files: CAPEC.csv, CompDep.csv, ScnArch.csv, Mission.csv, and Defenses.csv. Run the VERDICT OSATE once to
+initialize these files (in ~/workspace/extern/STEM/Output/).
 
 ```
 $ ./soteria_pp.byte -o output_path input_path 
 ```
-
-Alternatively, the output path can be left out.
-
+The output path may be omitted with:
 ```
 $ ./soteria_pp.byte input_path 
 ```
 
+## OCaml Debugger
 
+The [oCaml debugger](https://ocaml.org/manual/debugger.html) provides a CLI to set breakpoints and easily inspect
+variable values. Refer to oCaml debugger manual's [Running the Program](https://ocaml.org/manual/debugger.html#s%3Adebugger-commands) for debug
+commands. After building the soteria++ .byte bundle run the debugger with:
 
--------------------
-**   OCaml Top   **
--------------------
+```
+cd ./soteria_pp/_build/
+ocamldebug soteria_pp.byte input_path
+```
 
-If you want to run using OCaml top-level, cd to /examples, then call ocaml. From OCaml top, load top.ml,
-then load your example file. For instance:
+The input_path should include STEM files: CAPEC.csv, CompDep.csv, ScnArch.csv, Mission.csv, and Defenses.csv. Run VERDICT
+in OSATE once to initialize these files (in ~/workspace/extern/STEM/Output/). After the debugger initializes set a breakpoint,
+run the application and inspect a variable. For example:
 
+```
+(ocd) set print_length 10000
+(ocd) break @ translator 1309
+(ocd) run
+(ocd) print l_librariesThreats
+```
 
+## OCaml Top (and Running Tests)
 
-$ cd examples
+If you want to run using OCaml top-level, build the project then call ocaml. From the OCaml top CLI load top.ml and
+then your example or test file. For instance:
 
-$ ocaml
-
-\# \#use "top.ml";;
-
-\# \#use "your_file_name.ml";;
+```
+$ ocaml -I ./_build
+# #use "examples/top.ml";;
+# #use "examples/your_example_file.ml";;
+# #use "qualitative-test.ml";;
+```

--- a/tools/verdict-back-ends/soteria_pp/qualitative-test.ml
+++ b/tools/verdict-back-ends/soteria_pp/qualitative-test.ml
@@ -46,44 +46,58 @@ test_sumofprod_ad ();;
 
 (* testing with some AD trees *)
 let test_cutsets_ad () =
-	let a = ALeaf("a", 1.) 
-	and b = DLeaf("b", 5)
-	and c = ALeaf("c", 1.) in
+	let a = ALeaf(("defCompA","defEventA"), 1.)
+	and b = DLeaf(("defCompB","defEventB"), 5)
+	and c = ALeaf(("defCompC","defEventC"), 1.) in
 	let t1 = C(a, b) in
     let t2 = ASUM [ c; t1 ]
     and t3 = APRO [ c; t1 ]
     and t4 = ASUM [ a; t1 ] in
-    assert( cutsets_ad t1 = APro [ AVar "a"; ANot (AVar "b") ] );
-    assert( cutsets_ad t2 = ASum [ AVar "c"; APro [AVar "a"; ANot (AVar "b")]] );
-    assert( cutsets_ad t3 = APro [ AVar "a"; AVar "c"; ANot (AVar "b") ] );
-    assert( cutsets_ad t4 = AVar "a" );
+    assert( cutsets_ad t1 = APro [ AVar ("defCompA","defEventA",""); ANot (AVar ("defCompB","defEventB","5")) ] );
+    assert( cutsets_ad t2 = ASum [ AVar ("defCompC","defEventC",""); APro [AVar ("defCompA","defEventA",""); ANot (AVar ("defCompB","defEventB","5"))]] );
+    assert( cutsets_ad t3 = APro [ AVar ("defCompA","defEventA",""); AVar ("defCompC","defEventC",""); ANot (AVar ("defCompB","defEventB","5")) ] );
+    assert( cutsets_ad t4 = AVar ("defCompA","defEventA","") );
     true;;
     
 test_cutsets_ad ();;
 
 (* test cutsets_ad algo again with different combinations of PoS's and SoP's *)
 let test_cutsets_ad () =
-    let sss = C( ALeaf("i", 1.0), DSUM[ DSUM[ DLeaf("a", 5); DLeaf("b", 5) ]; DSUM[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)
-    and spp = C( ALeaf("i", 1.0), DSUM[ DPRO[ DLeaf("a", 5); DLeaf("b", 5) ]; DPRO[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)
-    and ssp = C( ALeaf("i", 1.0), DSUM[ DSUM[ DLeaf("a", 5); DLeaf("b", 5) ]; DPRO[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)
-    and sps = C( ALeaf("i", 1.0), DSUM[ DPRO[ DLeaf("a", 5); DLeaf("b", 5) ]; DSUM[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)
-    and ppp = C( ALeaf("i", 1.0), DPRO[ DPRO[ DLeaf("a", 5); DLeaf("b", 5) ]; DPRO[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)
-    and p   = C( ALeaf("i", 1.0), DPRO[ DSUM[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *) 
-    and pss = C( ALeaf("i", 1.0), DPRO[ DSUM[ DLeaf("a", 5); DLeaf("b", 5) ]; DSUM[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* working *)        
-    and psp = C( ALeaf("i", 1.0), DPRO[ DSUM[ DLeaf("a", 5); DLeaf("b", 5) ]; DPRO[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* was ANot working, now working *) 
-    and pps = C( ALeaf("i", 1.0), DPRO[ DPRO[ DLeaf("a", 5); DLeaf("b", 5) ]; DSUM[ DLeaf("c", 5); DLeaf("d", 5) ]; ] )(* was ANot working, now working *)
-     
+
+    let i_leaf = ("atkComp","atkEvent")
+    and a_leaf = ("defCompA","defEventA")
+    and b_leaf = ("defCompB","defEventB")
+    and c_leaf = ("defCompC","defEventC")
+    and d_leaf = ("defCompD","defEventD")
     in
     
-    assert( cutsets_ad sss = APro[ AVar "i"; DPro [ANot (AVar "a"); ANot (AVar "b"); ANot (AVar "c"); ANot (AVar "d")] ] );
-    assert( cutsets_ad spp = APro[ AVar "i"; DPro [DSum [ANot (AVar "a"); ANot (AVar "b")]; DSum [ANot (AVar "c"); ANot (AVar "d")]] ]);
-    assert( cutsets_ad ssp = APro[ AVar "i"; DPro [ANot (AVar "a"); ANot (AVar "b"); DSum [ANot (AVar "c"); ANot (AVar "d")]] ]);
-    assert( cutsets_ad sps = APro[ AVar "i"; DPro [ANot (AVar "c"); ANot (AVar "d"); DSum [ANot (AVar "a"); ANot (AVar "b")]] ]);
-    assert( cutsets_ad ppp = APro[ AVar "i"; DSum [ANot (AVar "a"); ANot (AVar "b"); ANot (AVar "c"); ANot (AVar "d")] ]);
-    assert( cutsets_ad p   = APro[ AVar "i"; DPro [ANot (AVar "c"); ANot (AVar "d")] ]);
-    assert( cutsets_ad pss = APro[ AVar "i"; DSum [DPro [ANot (AVar "a"); ANot (AVar "b")]; DPro [ANot (AVar "c"); ANot (AVar "d")];] ]);
-    assert( cutsets_ad psp = APro[ AVar "i"; DSum [ANot (AVar "c"); ANot (AVar "d"); DPro [ANot (AVar "a"); ANot (AVar "b");] ] ]);
-    assert( cutsets_ad pps = APro[ AVar "i"; DSum [ANot (AVar "a"); ANot (AVar "b"); DPro [ANot (AVar "c"); ANot (AVar "d") ] ] ]);
+    let sss = C( ALeaf(i_leaf, 1.0), DSUM[ DSUM[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
+    and spp = C( ALeaf(i_leaf, 1.0), DSUM[ DPRO[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DPRO[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
+    and ssp = C( ALeaf(i_leaf, 1.0), DSUM[ DSUM[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DPRO[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
+    and sps = C( ALeaf(i_leaf, 1.0), DSUM[ DPRO[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
+    and ppp = C( ALeaf(i_leaf, 1.0), DPRO[ DPRO[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DPRO[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)
+    and p   = C( ALeaf(i_leaf, 1.0), DPRO[ DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *) 
+    and pss = C( ALeaf(i_leaf, 1.0), DPRO[ DSUM[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* working *)        
+    and psp = C( ALeaf(i_leaf, 1.0), DPRO[ DSUM[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DPRO[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* was ANot working, now working *) 
+    and pps = C( ALeaf(i_leaf, 1.0), DPRO[ DPRO[ DLeaf(a_leaf, 5); DLeaf(b_leaf, 5) ]; DSUM[ DLeaf(c_leaf, 5); DLeaf(d_leaf, 5) ]; ] )(* was ANot working, now working *)
+    in
+    
+    let i_cut = ("atkComp","atkEvent","")
+    and a_cut = ("defCompA","defEventA","5")
+    and b_cut = ("defCompB","defEventB","5")
+    and c_cut = ("defCompC","defEventC","5")
+    and d_cut = ("defCompD","defEventD","5")
+    in
+    
+    assert( cutsets_ad sss = APro[ AVar i_cut; DPro [ANot (AVar a_cut); ANot (AVar b_cut); ANot (AVar c_cut); ANot (AVar d_cut)] ] );
+    assert( cutsets_ad spp = APro[ AVar i_cut; DPro [DSum [ANot (AVar a_cut); ANot (AVar b_cut)]; DSum [ANot (AVar c_cut); ANot (AVar d_cut)]] ]);
+    assert( cutsets_ad ssp = APro[ AVar i_cut; DPro [ANot (AVar a_cut); ANot (AVar b_cut); DSum [ANot (AVar c_cut); ANot (AVar d_cut)]] ]);
+    assert( cutsets_ad sps = APro[ AVar i_cut; DPro [ANot (AVar c_cut); ANot (AVar d_cut); DSum [ANot (AVar a_cut); ANot (AVar b_cut)]] ]);
+    assert( cutsets_ad ppp = APro[ AVar i_cut; DSum [ANot (AVar a_cut); ANot (AVar b_cut); ANot (AVar c_cut); ANot (AVar d_cut)] ]);
+    assert( cutsets_ad p   = APro[ AVar i_cut; DPro [ANot (AVar c_cut); ANot (AVar d_cut)] ]);
+    assert( cutsets_ad pss = APro[ AVar i_cut; DSum [DPro [ANot (AVar a_cut); ANot (AVar b_cut)]; DPro [ANot (AVar c_cut); ANot (AVar d_cut)];] ]);
+    assert( cutsets_ad psp = APro[ AVar i_cut; DSum [ANot (AVar c_cut); ANot (AVar d_cut); DPro [ANot (AVar a_cut); ANot (AVar b_cut);] ] ]);
+    assert( cutsets_ad pps = APro[ AVar i_cut; DSum [ANot (AVar a_cut); ANot (AVar b_cut); DPro [ANot (AVar c_cut); ANot (AVar d_cut) ] ] ]);
     
     true;;
     

--- a/tools/verdict-back-ends/soteria_pp/qualitative.ml
+++ b/tools/verdict-back-ends/soteria_pp/qualitative.ml
@@ -9,7 +9,8 @@ Date: 2017-12-15
 Updates: 5/9/2018, Kit Siu, added formulaOfADTree
          7/23/2018, Kit Siu, added cutsets_ad
          1/9/2019, Kit Siu, added capability for DSum and DPro, which are operators for defenses
-         
+         6/5/2022, Christopher Alexander, extended ADT defense leaf model with DAL
+
 *)
 
 (**
@@ -58,14 +59,14 @@ let rec formulaOfTree t =
 (** Code for translating an attack-defense tree into a formula *)
 let rec formulaOfDTree dt =
   match dt with
-    | DLeaf (var, _) -> AVar (var)
+    | DLeaf (var, dal) -> let (component, event) = var in AVar ((component, event, string_of_int dal)) (* defense-leaf *)
     | DSUM (tree) -> DSum(List.map tree ~f:formulaOfDTree)
     | DPRO (tree) -> DPro(List.map tree ~f:formulaOfDTree) 
 ;;
 
 let rec formulaOfADTree adt =
   match adt with
-    | ALeaf (var, _) -> AVar (var) 
+    | ALeaf (var, probability) -> let (component, event) = var in AVar ((component, event, "")) (* attack-leaf *)
     | ASUM (tree) -> ASum(List.map tree ~f:formulaOfADTree)
     | APRO (tree) -> APro(List.map tree ~f:formulaOfADTree)
     | C (at, dt) -> APro([formulaOfADTree at; ANot(formulaOfDTree dt)])

--- a/tools/verdict-back-ends/soteria_pp/quantitative-test.ml
+++ b/tools/verdict-back-ends/soteria_pp/quantitative-test.ml
@@ -9,10 +9,10 @@ Updates:
 
 *)
 
-let myDtree_and = DPRO [ DLeaf ("d1", 7); DLeaf ("d2", 9); DLeaf ("d3", 7) ];;
-let myDtree_or = DSUM [ DLeaf ("d1", 7); DLeaf ("d2", 9); DLeaf ("d3", 7) ];;
-let myADtree_wDtree_and = C ( ALeaf ("a1", 1.0), myDtree_and );;
-let myADtree_wDtree_or = C ( ALeaf ("a1", 1.0), myDtree_or );;
+let myDtree_and = DPRO [ DLeaf (("defCompA","defEventA"), 7); DLeaf (("defCompB","defEventB"), 9); DLeaf (("defCompC","defEventC"), 7) ];;
+let myDtree_or = DSUM [ DLeaf (("defCompA","defEventA"), 7); DLeaf (("defCompB","defEventB"), 9); DLeaf (("defCompC","defEventC"), 7) ];;
+let myADtree_wDtree_and = C ( ALeaf (("atkComp","atkEvent"), 1.0), myDtree_and );;
+let myADtree_wDtree_or = C ( ALeaf (("atkComp","atkEvent"), 1.0), myDtree_or );;
 
 
 (* assuranceCalcApprox *)
@@ -40,8 +40,8 @@ test_likelihoodCalcApprox ();;
 (* eventLikelihoodsAuxDt *)
 
 let test_eventLikelihoodsAuxDt () =
-  assert( eventLikelihoodsAuxDt myDtree_and = [("d1", 1e-07); ("d2", 1e-09); ("d3", 1e-07)] );
-  assert( eventLikelihoodsAuxDt myDtree_or = [("d1", 1e-07); ("d2", 1e-09); ("d3", 1e-07)] );
+  assert( eventLikelihoodsAuxDt myDtree_and = [(("defCompA","defEventA"), 1e-07); (("defCompB","defEventB"), 1e-09); (("defCompC","defEventC"), 1e-07)] );
+  assert( eventLikelihoodsAuxDt myDtree_or = [(("defCompA","defEventA"), 1e-07); (("defCompB","defEventB"), 1e-09); (("defCompC","defEventC"), 1e-07)] );
   true
 ;;
 
@@ -51,8 +51,8 @@ test_eventLikelihoodsAuxDt ();;
 (* eventLikelihoodsAux *)
 
 let test_eventLikelihoodsAux () =
-  assert( eventLikelihoodsAux myADtree_wDtree_and = [("a1", 1.); ("d1", 1e-07); ("d2", 1e-09); ("d3", 1e-07)] );
-  assert( eventLikelihoodsAux myADtree_wDtree_or = [("a1", 1.); ("d1", 1e-07); ("d2", 1e-09); ("d3", 1e-07)] );
+  assert( eventLikelihoodsAux myADtree_wDtree_and = [(("atkComp","atkEvent"), 1.); (("defCompA","defEventA"), 1e-07); (("defCompB","defEventB"), 1e-09); (("defCompC","defEventC"), 1e-07)] );
+  assert( eventLikelihoodsAux myADtree_wDtree_or = [(("atkComp","atkEvent"), 1.); (("defCompA","defEventA"), 1e-07); (("defCompB","defEventB"), 1e-09); (("defCompC","defEventC"), 1e-07)] );
   true
 ;;
 

--- a/tools/verdict-back-ends/soteria_pp/quantitative.ml
+++ b/tools/verdict-back-ends/soteria_pp/quantitative.ml
@@ -8,7 +8,7 @@ Date: 2017-12-15
 
 Updates: 5/10/2018, Kit Siu, added severityCalc and supporting measures for ADT
          7/23/2018, Kit Siu, added likelihood calculations (formerly severityCalc)
-
+         6/5/2022, Chris Alexander, updated likelihood calculator to reflect AVar model changes 
 *)
 
 (**
@@ -311,8 +311,8 @@ let rec likelihoodCutSOP sop la =
   match sop with
     | [] -> []
     | hd::tl -> let prod = match hd with
-                             | AVar e       -> List.Assoc.find_exn la e ~equal:(=)
-                             | ANot (AVar e)-> List.Assoc.find_exn la e ~equal:(=)
+                             | AVar (a,d,_)        -> List.Assoc.find_exn la (a,d) ~equal:(=)
+                             | ANot (AVar (a,d,_)) -> List.Assoc.find_exn la (a,d) ~equal:(=)
                              | APro le      -> gMin (likelihoodCutSOP le la)
                              | DPro le      -> gMin (likelihoodCutSOP le la) (* min on d-AND gate b/c assoc list is in terms of likelihood *)
                              | DSum le      -> gMax (likelihoodCutSOP le la) (* allow SOP to include defense Sum gates *)
@@ -325,8 +325,8 @@ let rec likelihoodCutSOP sop la =
 *)
 let likelihoodCutCalc cs la =
   match cs with
-    | AVar v         -> let a = (List.Assoc.find_exn la v ~equal:(=)) in a
-    | ANot ( AVar v )-> let a = (List.Assoc.find_exn la v ~equal:(=)) in a
+    | AVar (a,d,_)          -> let a = (List.Assoc.find_exn la (a,d) ~equal:(=)) in a
+    | ANot (AVar (a,d,_))  -> let a = (List.Assoc.find_exn la (a,d) ~equal:(=)) in a
     | ASum s         -> let l = (likelihoodCutSOP s la) in (gMax l)
     | APro p         -> gMin (likelihoodCutSOP p la) 
     | DSum s         -> let l = (likelihoodCutSOP s la) in (gMax l)  (* max on d-OR gate b/c assoc list is in terms of likelihood *)

--- a/tools/verdict-back-ends/soteria_pp/translator.ml
+++ b/tools/verdict-back-ends/soteria_pp/translator.ml
@@ -15,7 +15,9 @@ Updates: 4/18/2019, Kit Siu, added function to generate cutset report using Prin
          5/26/2020, Heber Herencia-Zapana,  safety/cyber Availability dependes on availability only
          8/4/2020, Kit Siu, defense properties on connections generates new components to 
                             represent the connection, with relevant CAPECs and defenses 
-                            moved from the vulnerable component to the new connection component          
+                            moved from the vulnerable component to the new connection component 
+         6/5/2022, Chris Alexander, unimplemented defenses are factored into implemented cutset likelihoods
+
 *)
 
 (**
@@ -973,19 +975,19 @@ let all_not l =
  
 let get_defense l = 
    match l with 
-   ANot(AVar (_,b))->b
+   ANot(AVar (_,b,_))->b
    |_->"";;
      
 let takeAvar aVar = 
    match aVar with
-       AVar (a,b) -> [("comp",a);("attack",b)]
+       AVar (a,b,_) -> [("comp",a);("attack",b)]
      | _          -> [("comp","");("attack","")];;
 
 let takeDefenseAnd l = 
   let concat_And_Or op l =List.fold (List.tl_exn l) ~init:(List.hd_exn l) ~f:(fun x y -> x^" "^ op^" " ^y) in
   let clean x =  List.dedup_and_sort ~compare:compare x in 
    match l with 
-   |ANot (AVar (_,b))->[b]
+   |ANot (AVar (_,b,_))->[b]
    |DSum l -> clean( List.map l ~f:(fun x->"("^(concat_And_Or "and" (List.map l ~f:(fun x->get_defense x)))^")" ))
    |_->["No support"] ;;  
 
@@ -993,7 +995,7 @@ let takeDefenseAndOr l =
   let concat_And_Or op l =List.fold (List.tl_exn l) ~init:(List.hd_exn l) ~f:(fun x y -> x^" "^ op^" " ^y) in
   let clean x =  List.dedup_and_sort ~compare:compare x in 
    match l with 
-   |ANot (AVar (_,b))->[[b]]
+   |ANot (AVar (_,b,_))->[[b]]
    |DPro l ->  List.map l ~f:(fun x-> takeDefenseAnd x)
    |DSum l -> clean( List.map l ~f:(fun x->["("^(concat_And_Or "and" (List.map l ~f:(fun x->get_defense x)))^")" ]))
    |_->[["No support"]] ;;  
@@ -1021,12 +1023,12 @@ let concat_And_Or op l =List.fold (List.tl_exn l) ~init:(List.hd_exn l) ~f:(fun 
 let rec attacksToView cOpe = 
       match cOpe with 
       | APro (h::tl) -> List.append (attacksToView h) (attacksToView (APro tl))
-      | AVar (c,a) -> [[("comp",c);("capec",a)]]
+      | AVar (c,a,_) -> [[("comp",c);("capec",a)]]
       | _ -> [] ;;
 
 let rec defenseCompToView cOpe = 
       match cOpe with 
-      | ANot( AVar (c,_) ) -> c
+      | ANot( AVar (c,_,_) ) -> c
       | DSum l -> defenseCompToView (List.hd_exn l)
       | DPro l -> defenseCompToView (List.hd_exn l)
       | _ -> "" ;;
@@ -1040,15 +1042,15 @@ let convertProp2Profile_single dp l_defense2nist =
 
 let propCut2nistCut cOpe defense2nist = 
       match cOpe with 
-      | ANot( AVar (c,d) ) -> 
+      | ANot( AVar (c,d,_) ) -> 
          let dNISTlist = String.split_on_chars (convertProp2Profile_single d defense2nist) ~on:[';']
-         in List.map dNISTlist ~f:(fun x -> ANot( AVar (c, x) ))       
+         in List.map dNISTlist ~f:(fun x -> ANot( AVar (c, x, "") )) (* empty dal to enable de-duping empty nists *)    
       | _ -> [] ;;
 
 let rec defenseToView cOpe = 
       match cOpe with 
       | APro (h::tl) -> List.append (defenseToView h) (defenseToView (APro tl))
-      | ANot( AVar (c,d) ) -> 
+      | ANot( AVar (c,d,_) ) -> 
             [[("comp",c);
               ("suggested",d);]]
       | DSum l -> 
@@ -1061,7 +1063,7 @@ let rec defenseToView cOpe =
 
 let rec defenseProfileTranslator cOpe l_defense2nist =
       match cOpe with
-      | ANot( AVar (c,d) ) -> DSum (propCut2nistCut (ANot( AVar (c,d) )) l_defense2nist ) (* <-- same as DSum because it's the DeMorgan of the a product of NISTs *)
+      | ANot( AVar (c,d,dal) ) -> DSum (propCut2nistCut (ANot( AVar (c,d,dal) )) l_defense2nist ) (* <-- same as DSum because it's the DeMorgan of the a product of NISTs *)
       | DSum l -> DSum (List.map l ~f:(fun x -> defenseProfileTranslator x l_defense2nist) ) 
       | DPro l -> DPro (List.map l ~f:(fun x -> defenseProfileTranslator x l_defense2nist) ) 
       | _ -> AFALSE ;;
@@ -1069,10 +1071,10 @@ let rec defenseProfileTranslator cOpe l_defense2nist =
 let rec defenseToView2 cOpe l_defense2nist = 
       match cOpe with 
       | APro (h::tl) -> List.append (defenseToView2 h l_defense2nist) (defenseToView2 (APro tl) l_defense2nist)
-      | ANot( AVar (c,d) ) -> 
+      | ANot( AVar (c,d,dal) ) -> 
             [[("comp",c);
               ("suggested",d);
-              ("profile", takeDefense2 (ssfc_ad (defenseProfileTranslator (ANot(AVar(c,d))) l_defense2nist))) ]]
+              ("profile", takeDefense2 (ssfc_ad (defenseProfileTranslator (ANot(AVar(c,d,dal))) l_defense2nist))) ]]
       | DSum l -> 
             [[("comp",(defenseCompToView (DSum l))); 
               ("suggested", takeDefense2 (DSum l));
@@ -1263,96 +1265,195 @@ let renameConnectionName l_arch =
       let newConnName = connName ^ impl ^ comp in
       (connName_Arc, newConnName)::(List.filter aL ~f:(fun (tag, _) -> tag<>connName_Arc)) );;
        
+(* translate mission threats to attack-defense tree, generate cutsets, and save visualizations to file *)
+let save_ad_mission_cutsets mission missionList filePath saveDotML ?(wDalSuffix=false) defType =
+    let ((reqIDStr, _), (lib, mdl)) = mission in
+    (* attack-defense tree calculates min/max likelihood using NOT gates *)
+    let attackDefenseTree = model_to_adtree lib mdl
+    and (modelVersion, _, risk) = get_CyberReqText_Risk missionList reqIDStr in
+    let fileName = filePath ^ modelVersion ^ "-" ^ reqIDStr ^ "-" ^ defType in
+    (* -- save .ml file of the lib and mdl, for debugging purposes -- *)
+    if saveDotML then saveLibraryAndModelToFile (fileName ^ ".ml") lib mdl;
+    (* -- cutset metric file, in printbox format -- *)
+    saveADCutSetsToFile ~cyberReqID:(reqIDStr) ~risk:(risk) ~header:("header.txt") (fileName ^ ".txt") attackDefenseTree wDalSuffix;
+    (* -- save .svg tree visualizations -- *)
+    dot_gen_show_adtree_file fileName attackDefenseTree ;;
+
+(* translate mission threats to fault tree, generate cutsets, and save visualizations to file *)
+let save_f_mission_cutsets mission missionList filePath saveDotML defType =
+    let ((reqIDStr, _), (lib, mdl)) = mission in
+    (* fault tree - calculates probability using + * operators *)
+    let faultTree = model_to_ftree lib mdl
+    and (modelVersion, _, risk) = get_CyberReqText_Risk missionList reqIDStr in
+    let fileName = filePath ^ modelVersion ^ "-" ^ reqIDStr ^ "-" ^ defType in
+    (* -- save .ml file of the lib and mdl, for debugging purposes -- *)
+    if saveDotML then saveLibraryAndModelToFile (fileName ^ "-safety.ml") lib mdl;
+    (* -- cutset metric file, in printbox format -- *)
+    saveCutSetsToFile ~reqID:(reqIDStr) ~risk:(risk) ~header:("header.txt") (fileName ^ "-safety.txt") faultTree ;
+    (* -- save .svg tree visualizations -- *)
+    dot_gen_show_tree_file fileName faultTree ;;
+
+(* returns a hash (component & capec) for an xml cyber cutset *)
+let rec get_cutset_hash xmlNode =
+    match Xml.tag xmlNode with
+         | "Cutset" | "Attack" ->
+                 List.find_exn (List.map (Xml.children xmlNode) get_cutset_hash) ~f:(fun n -> n <> "")
+         | "Component" ->
+                 List.fold (Xml.attribs xmlNode) ~init:"" ~f:(fun acc (c,d) -> acc ^ ";" ^ c ^ ":" ^ d)
+         | _ -> "" ;;
+
+(* flattens an xml mission list to [(hash, probability attributes)] for each mission & cutset (probability) element *)
+let rec flatten_probability_xml_node ?(hashAcc="") xmlNode =
+    match Xml.tag xmlNode with
+         | "Results" ->
+                 List.fold (Xml.children xmlNode) ~init:[] ~f:(fun acc mission -> 
+                        List.append acc (flatten_probability_xml_node mission ~hashAcc:hashAcc))
+         | "Mission" ->
+                 let newHash = hashAcc^(Xml.attrib xmlNode "label") in
+                 List.fold (Xml.children xmlNode) ~init:[] ~f:(fun acc cutset -> 
+                                         List.append acc (flatten_probability_xml_node cutset ~hashAcc:newHash))
+         | "Requirement" ->
+                 let probAttrbs = List.filter (Xml.attribs xmlNode) ~f:(fun (k,_) -> k <> "defenseType")
+                 and newHash = hashAcc^(Xml.attrib xmlNode "label") in
+                 List.fold (Xml.children xmlNode) ~init:[] ~f:(fun acc req ->  
+                                         List.append 
+                                                 (List.append acc [(newHash,probAttrbs)]) 
+                                                 (flatten_probability_xml_node req ~hashAcc:newHash))
+         | "Cutset" ->
+                 let probAttrbs = Xml.attribs xmlNode
+                 and cutsetHash = hashAcc^(get_cutset_hash xmlNode) in
+                 [(cutsetHash, probAttrbs)]
+         | _ -> [] ;;
+
+(* overwrites values of k,v tuples from listA with listB's, matches only on existing k(s) *)
+let merge_attribute_lists attrListA attrListB = 
+    List.map attrListA ~f:(fun (k,v) -> 
+            match List.findi attrListB ~f:(fun _ (kb, _) -> k = kb) 
+                    with | Some (_,n) -> n | None -> (k,v) );;
+
+(* return the first xml mission list with a probabilities from a [(hash, probability attributes)] *)
+let rec merge_cutset_probabilities cyberXmlNode ?(hashAcc="") probList =
+    
+    let (tag, comp, children) = ((Xml.tag cyberXmlNode),(Xml.attribs cyberXmlNode),(Xml.children cyberXmlNode)) in
+    
+    match Xml.tag cyberXmlNode with
+        | "Results" ->
+                Xml.Element(tag, comp, 
+                        List.map children ~f:(fun c -> merge_cutset_probabilities c probList ~hashAcc:hashAcc))
+        | "Mission" ->
+                let hash = hashAcc^(Xml.attrib cyberXmlNode "label") in
+                Xml.Element(tag, comp, 
+                        List.map children ~f:(fun c -> merge_cutset_probabilities c probList ~hashAcc:hash))
+        | "Requirement" ->                
+                let hash = hashAcc^(Xml.attrib cyberXmlNode "label") in
+                let (_, probAttribs) = List.find_exn probList ~f:(fun (h,_) -> h = hash) in
+                Xml.Element(tag, (merge_attribute_lists comp probAttribs), 
+                        List.map children ~f:(fun c -> merge_cutset_probabilities c probList ~hashAcc:hash))
+        | "Cutset" ->
+                let hash = hashAcc^(get_cutset_hash cyberXmlNode) in
+                let (_, probAttribs) = List.find_exn probList ~f:(fun (h,_) -> h = hash) in
+                Xml.Element(tag, probAttribs, children)
+        | _ -> cyberXmlNode ;;
+
+(* assigns acceptable_p to computed_p on all requirement nodes and to all cutset sub-element likelihoods 
+    in an applicable mission list xml *)    
+let rec post_process_applicable_mission ?(acceptProb = None) applXmlNode = 
+
+    let (tag, comp, children) = ((Xml.tag applXmlNode),(Xml.attribs applXmlNode),(Xml.children applXmlNode)) in
+
+    match Xml.tag applXmlNode with
+        | "Results" | "Mission" ->
+                Xml.Element(tag, comp, List.map children post_process_applicable_mission)
+        | "Requirement" ->                
+                let acceptable = Xml.attrib applXmlNode "acceptable_p" in
+                Xml.Element(tag, (merge_attribute_lists comp [("computed_p", acceptable)]), 
+                        List.map children ~f:(fun c -> 
+                                post_process_applicable_mission ~acceptProb:(Option.some acceptable) c))
+        | "Cutset" ->
+                let probability = match acceptProb with 
+                        Some p -> (merge_attribute_lists comp [("likelihood", p)]) 
+                        | None -> comp in
+                        
+                Xml.Element(tag, probability, children)
+        | _ -> applXmlNode ;;
 
 (* Analyze function - Calls model_to_adtree and model_to_ftree. Generates the artifacts *)
 let do_arch_analysis ?(save_dot_ml=false) comp_dep_ch comp_saf_ch attack_ch events_ch arch_ch mission_ch defense_ch defense2nist_ch fpath infeCyber infeSafe =
-   let compDepen    = mainListtag comp_dep_ch  
-   and compSafe     = mainListtag comp_saf_ch
-   and attack       = mainListtag attack_ch    
-   and events       = mainListtag events_ch 
-   and arch         = renameConnectionName (mainListtag arch_ch) (* <-- rename the "ConnectionName" so that it is a concatenation of <ConnectionName><Impl><Comp> *)
-   and mission      = mainListtag mission_ch 
-   and defense      = mainListtag defense_ch 
-   and defense2nist = mainListtag defense2nist_ch in
-   
-   (* iterate through the following: ApplicableDefenseProperties and ImplProperties*)
-   List.iter [applProps_D; implProps_D] ~f:(fun deftype ->
-   
-     (* check if there's anything to analyze *)
-     if List.is_empty mission 
-     then Format.printf 
-          "Info: mission.csv is empty. No requirements to analyze@." ;   
-     let l_librariesThreats = libraries_threatConditions deftype compDepen compSafe attack events arch mission defense defense2nist infeCyber infeSafe
   
-     in
-     
-     (* separate into lists based on Cyber reqs and Safety reqs, because they will be handled differently *)
-     let l_librariesThreats_Cyber = 
-        removeMissionsWithNoReq (
-        List.map l_librariesThreats ~f:(fun mID -> let (missionReqIdStr, l_libmdl) = mID in
-              (missionReqIdStr, extractCyberReq l_libmdl mission) ) )
-     and l_librariesThreats_Safety = 
-        removeMissionsWithNoReq (
-        List.map l_librariesThreats ~f:(fun mID -> let (missionReqIdStr, l_libmdl) = mID in
-              (missionReqIdStr, extractSafetyReq l_libmdl mission) ) )
+    let compDepen    = mainListtag comp_dep_ch  (* List of components to input/output ports *)
+    and compSafe     = mainListtag comp_saf_ch (* List of event to components *)
+    and attack       = mainListtag attack_ch (* List of components to capec attack likelihood *)
+    and events       = mainListtag events_ch (* List of events to event probabilities *)
+    and arch         = renameConnectionName (mainListtag arch_ch) (* List of architecture configurations between components *)
+    and missionList  = mainListtag mission_ch (* List of missions including model, severity and request type *)
+    and defense      = mainListtag defense_ch (* List of component capec defense development assurance level *)
+    and defense2nist = mainListtag defense2nist_ch in (* List of defense to National Institute of Standards and Technology (NIST) profile *)
 
-     in
-  
-     (* [CYBER] iterate through the list of Cyber reqs *)
-     (* start the xml formatted results file *)
-     List.iter l_librariesThreats_Cyber ~f:(fun mID -> 
-        let (missionReqIdStr, l_libmdl) = mID in
-        (* iterate through the list of Cyber requirements under each mission ID *)
-        List.iter l_libmdl ~f:(fun x -> 
-           (let ((reqIDStr, defenseTypeStr), (lib, mdl)) = x in
-              let t = model_to_adtree lib mdl 
-              (* -- extract some text info -- *)
-              and (modelVersion, cyberReqText, risk) = get_CyberReqText_Risk mission reqIDStr in  
-              (* -- save .ml file of the lib and mdl, for debugging purposes -- *)    
-              if save_dot_ml then saveLibraryAndModelToFile (fpath ^ modelVersion ^ "-" ^ reqIDStr ^ "-" ^ defenseTypeStr ^ ".ml") lib mdl ;
-              (* -- cutset metric file, in printbox format -- *)    
-              saveADCutSetsToFile ~cyberReqID:(reqIDStr) ~risk:(risk) ~header:("header.txt") (fpath ^ modelVersion ^ "-" ^ reqIDStr ^ "-" ^ defenseTypeStr ^ ".txt") t ;
-              (* -- save .svg tree visualizations -- *)    
-              dot_gen_show_adtree_file (fpath ^ modelVersion ^ "-" ^ reqIDStr ^ "-" ^ defenseTypeStr) t ;
-           )
-        );
-     );
-     (* fill xml datastruct, print datastruct to an xml file, and close the xml file  *)
-     let ds_MissionList = xmlBuilder_MissionList "cyber" l_librariesThreats_Cyber mission defense2nist in
-     let ds = Xml.Element("Results",[("xmlns:xsi","http://www.w3.org/2001/XMLSchema-instance")], ds_MissionList) in
-     let xml_str = Xml.to_string_fmt ds in
-     let xml_oc = Out_channel.create (fpath^deftype^".xml") in
-     fprintf xml_oc "<?xml version=\"1.0\"?>\n";
-     fprintf xml_oc "%s" xml_str;
-     Out_channel.close xml_oc; 
-        
+    if List.is_empty missionList
+        then Format.printf "Info: mission.csv is empty. No requirements to analyze@." ;
 
-     (* [SAFETY] iterate through the list of Safety reqs *)
-     List.iter l_librariesThreats_Safety ~f:(fun mID -> 
-        let (missionReqIdStr, l_libmdl) = mID in
-        (* iterate through the list of Safety requirements under each mission ID *)
-        List.iter l_libmdl ~f:(fun x -> 
-           (let ((reqIDStr, defenseTypeStr), (lib, mdl)) = x in
-              let t = model_to_ftree lib mdl
-              (* -- extract some text info -- *)
-              and (modelVersion, safetyReqText, risk) = get_CyberReqText_Risk mission reqIDStr in  
-              (* -- save .ml file of the lib and mdl, for debugging purposes -- *)    
-              if save_dot_ml then saveLibraryAndModelToFile (fpath ^ modelVersion ^ "-" ^ reqIDStr ^ "-" ^ defenseTypeStr ^ ".ml") lib mdl ;
-              (* -- cutset metric file, in printbox format -- *)    
-              saveCutSetsToFile ~reqID:(reqIDStr) ~risk:(risk) ~header:("header.txt") (fpath ^ modelVersion ^ "-" ^ reqIDStr ^ "-" ^ defenseTypeStr ^ "-safety.txt") t ;
-              (* -- save .svg tree visualizations -- *)    
-              dot_gen_show_tree_file (fpath ^ modelVersion ^ "-" ^ reqIDStr ^ "-" ^ defenseTypeStr) t ;
-           )
-        )
-     );
-     (* fill xml datastruct, print datastruct to an xml file, and close the xml file  *)
-     let ds_MissionList = xmlBuilder_MissionList "safety" l_librariesThreats_Safety mission defense2nist in
-     let ds = Xml.Element("Results",[("xmlns:xsi","http://www.w3.org/2001/XMLSchema-instance")], ds_MissionList) in
-     let xml_str = Xml.to_string_fmt ds in
-     let xml_safety_oc = Out_channel.create (fpath^deftype^"-safety.xml") in
-     fprintf xml_safety_oc "<?xml version=\"1.0\"?>\n";
-     fprintf xml_safety_oc "%s" xml_str;
-     Out_channel.close xml_safety_oc; 
+    (* generates the attack defense trees for applicable defenses *)
+    let lApplicableThreats = libraries_threatConditions
+        applProps_D compDepen compSafe attack events arch missionList defense defense2nist infeCyber infeSafe
 
-  )
+    (* generates the attack defense trees for implemented defenses *)
+    and lImplementedThreats = libraries_threatConditions
+        implProps_D compDepen compSafe attack events arch missionList defense defense2nist infeCyber infeSafe in
+
+    (* extracts a list of non-empty mission threat tuples based on an cyber/safety extractor function *)
+    let get_mission_threats lThreatLibrary fThreatExtraction = removeMissionsWithNoReq (
+        List.map lThreatLibrary ~f:(fun mID -> let (missionReqIdStr, l_libmdl) = mID in
+        (missionReqIdStr, fThreatExtraction l_libmdl missionList))) in
+
+    (* complete set of all applicable mission threats *)
+    let applicableCyberThreats = get_mission_threats lApplicableThreats extractCyberReq
+    and applicableSafetyThreats = get_mission_threats lApplicableThreats extractSafetyReq
+
+    (* mission threats using implemented defenses only ( include DAL > 0) *)
+    and implementedCyberThreats = get_mission_threats lImplementedThreats extractCyberReq
+    and implementedSafetyThreats = get_mission_threats lImplementedThreats extractSafetyReq
+
+    and save_cyber_mission missions ?(wDalSuffix = false) defType = List.iter missions 
+        ~f:(fun (mission) -> save_ad_mission_cutsets mission missionList fpath save_dot_ml ~wDalSuffix:wDalSuffix defType)
+
+    and save_safety_mission missions defType = List.iter missions
+        ~f:(fun (mission) -> save_f_mission_cutsets mission missionList fpath save_dot_ml defType) in
+
+    (* save the applicable cyber & safety mission cutset visualizations *)
+    List.iter applicableCyberThreats ~f:(fun (_,x) -> save_cyber_mission x applProps_D);
+    List.iter applicableSafetyThreats ~f:(fun (_,x) -> save_safety_mission x applProps_D);
+
+    (* save the implemented cyber & safety mission cutset visualizations *)
+    (* refer to appl. for impl. to include defense DAL < 1 in likelihood calculations *)
+    List.iter applicableCyberThreats ~f:(fun (_,x) -> save_cyber_mission x ~wDalSuffix:true implProps_D);
+    List.iter implementedSafetyThreats ~f:(fun (_,x) -> save_safety_mission x implProps_D);
+
+    (* re-generates an adtree/ftree for all missions to be saved in single xml file *)
+    let as_base_mission_xml missionThreats reqType =
+        let ds_MissionList = xmlBuilder_MissionList reqType missionThreats missionList defense2nist in
+        Xml.Element("Results",[("xmlns:xsi","http://www.w3.org/2001/XMLSchema-instance")], ds_MissionList);
+    in
+    
+    let save_base_mission_xml defType ?(suffix = "") mission_xml =
+        let xml_str = Xml.to_string_fmt mission_xml
+        and xml_oc = Out_channel.create (fpath^defType^suffix^".xml") in
+        fprintf xml_oc "<?xml version=\"1.0\"?>\n";
+        fprintf xml_oc "%s" xml_str;
+        Out_channel.close xml_oc;
+    in
+
+    (* save the base applicable mission list as .xml *)
+    let applCyberXml = as_base_mission_xml applicableCyberThreats "cyber" in
+    save_base_mission_xml applProps_D (post_process_applicable_mission applCyberXml);
+    let applSafetyXml = as_base_mission_xml applicableSafetyThreats "safety" in
+    save_base_mission_xml applProps_D ~suffix:"-safety" applSafetyXml;
+
+    (* merge probabilities from applicable which includes unimplemented defense likelihoods *)
+    let implCyberXml = as_base_mission_xml implementedCyberThreats "cyber" in
+    let flattened = flatten_probability_xml_node applCyberXml in
+    let merged = merge_cutset_probabilities implCyberXml flattened in
+    save_base_mission_xml implProps_D merged;
+
+    let implSafetyXml = as_base_mission_xml implementedSafetyThreats "safety" in
+    save_base_mission_xml implProps_D ~suffix:"-safety" implSafetyXml;
 ;;

--- a/tools/verdict-back-ends/soteria_pp/treeSynthesis-test.ml
+++ b/tools/verdict-back-ends/soteria_pp/treeSynthesis-test.ml
@@ -124,7 +124,7 @@ let cycle_cutset = cutsets_ad cycle_adtree        (* <-- AVar ("a", "a_atck") *)
 in
 
 assert( cycle_adtree = ASUM [ALeaf (("a", "a_atck"), 1.); ASUM [ALeaf (("a", "a_atck"), 1.)]] );
-assert( cycle_cutset = AVar ("a", "a_atck") );
+assert( cycle_cutset = AVar ("a", "a_atck", "") );
 
 true
 ;;
@@ -186,7 +186,7 @@ let cycle_cutset = cutsets_ad cycle_adtree       (* <-- AVar ("b", "b_atck") *)
 in
 
 assert( cycle_adtree = ASUM [ALeaf (("b", "b_atck"), 1.)]);
-assert( cycle_cutset = AVar ("b", "b_atck"););
+assert( cycle_cutset = AVar ("b", "b_atck", ""););
 
 true
 ;;
@@ -268,7 +268,7 @@ let cycle_cutset = cutsets_ad cycle_adtree (* <-- AVar ("b2", "b_atck") *)
 in
 
 assert( cycle_adtree = ASUM [ASUM [ALeaf (("b2", "b_atck"), 1.)]] );
-assert( cycle_cutset = AVar ("b2", "b_atck")  );
+assert( cycle_cutset = AVar ("b2", "b_atck", "")  );
 
 true
 
@@ -357,7 +357,7 @@ assert( cycle_adtree =
    [ALeaf (("c", "c_atck"), 1.);
     ASUM [ALeaf (("c", "c_atck"), 1.); ASUM [ALeaf (("c", "c_atck"), 1.)]];
     ASUM [ALeaf (("c", "c_atck"), 1.); ASUM [ALeaf (("c", "c_atck"), 1.)]]] );
-assert( cycle_cutset = AVar ("c", "c_atck") );
+assert( cycle_cutset = AVar ("c", "c_atck", "") );
 
 true 
 ;;
@@ -443,7 +443,7 @@ let cycle_cutset = cutsets_ad cycle_adtree       (* <-- AVar ("c", "c_atck") *)
 in
 
 assert( cycle_adtree = ASUM [ALeaf (("c", "c_atck"), 1.)] );
-assert( cycle_cutset = AVar ("c", "c_atck") );
+assert( cycle_cutset = AVar ("c", "c_atck", "") );
 
 true
 ;;

--- a/tools/verdict-back-ends/soteria_pp/validation-tests.ml
+++ b/tools/verdict-back-ends/soteria_pp/validation-tests.ml
@@ -354,7 +354,7 @@ let test_checkLibrary_listsAreConsistentLengths () =
   assert( checkLibrary_listsAreConsistentLengths library_bad2 = Error "Faults and fault formulas lists are of inconsistent lengths in component Sensor");
   assert( checkLibrary_listsAreConsistentLengths library_bad3 = Error "Attack events and attack info are of inconsistent lengths in component Sensor");
   assert( checkLibrary_listsAreConsistentLengths library_bad4 = Error "Attacks and attack formulas lists are of inconsistent lengths in component Sensor");
-  assert( checkLibrary_listsAreConsistentLengths library_bad5 = Error "Defense events and defense info are of inconsistent lengths in component Sensor");
+  assert( checkLibrary_listsAreConsistentLengths library_bad5 = Error "Defense events and defense rigors are of inconsistent lengths in component Sensor");
   true;;
 
 test_checkLibrary_listsAreConsistentLengths ();;


### PR DESCRIPTION
**GSN assurance case graph nodes are improperly colored (green) for success when a mission is failed**. The underlying issue is that assurance case fragments have incorrect likelihoods for CAPEC cutsets are only partially implemented. AD Tree Synthesis (used in calculating risk) drops DAL 0 rules of the cutset (from the tree). Risk is later calculated from the remaining nodes. In cases where only the parent (risk 1 ALeaf) node is left risk is calculated correctly but incorrectly in cases where there are remaining (DLeaf) leaves because removed rule risk is ignored. Steps to reproduce are captured in https://github.com/ge-high-assurance/VERDICT/issues/228 

1. Set secureBoot=1. Run Verdict > Create GSN Assurance Case Fragments. GSN is correctly colored red.
2. Set secureBoot=0. Run Verdict > Create GSN Assurance Case Fragments. GSN is incorrectly colored green.
3. Right click on the circle "SOLUTION_1". This will bring up the file Additive_Machine_V3-CyberReq01-ImplProperties.txt. Observe that the Calculated likelihood of successful attack (line 2) is 1e-09.

To solve the issue without editing STEM data generation (including Defenses.csv) the soteria++ logic can reference the ApplicableDefenseProperties (instead of ImplProperties in Defenses.csv) to infer DAL-0 cutset and include them in likelihood calculation. The assumptions of Defenses.csv for this fix to work are:
- ApplicableDefenseProperties, ImplProperties and DAL will always be listed in the same order
- ImplProperties defense profiles will always be formatted as the uncapitalized ApplicableDefenseProperties elements

**soteria++ installation and debug instructions enhancements**. Merged the soteria++ installation instructions between the tools README and the soteria++ README. Enhanced the debuging instructions to include ocamldebug setup

Solves: https://github.com/ge-high-assurance/VERDICT/issues/228, https://github.com/ge-high-assurance/VERDICT/issues/194