### PR TITLE
VERDICT-270: Likelihood and probability formats switch between scientific and decimal notation

### DIFF
--- a/tools/verdict-back-ends/soteria_pp/translator.ml
+++ b/tools/verdict-back-ends/soteria_pp/translator.ml
@@ -1016,7 +1016,7 @@ let cutSets cutSet =
       | AVar avar -> List.append (takeAvar (AVar avar)) ["defense", ""]
       | _ -> List.append (takeAvar AFALSE) ["defense",""] in
     let (cut,pro1,_) = cutSet in
-    List.append [("prob",(string_of_float pro1))] (cutSetToView cut);;
+    List.append [("prob",(exp_string_of_float pro1))] (cutSetToView cut);;
 
 let concat_And_Or op l =List.fold (List.tl_exn l) ~init:(List.hd_exn l) ~f:(fun x y -> x^" "^ op^" " ^y) ;;
 
@@ -1087,7 +1087,7 @@ let rec defenseToView2 cOpe l_defense2nist =
       
 let make_cutSetTuples cs l_defense2nist =     
    let (cut,pro1,_) = cs in
-   ( ("prob",(string_of_float pro1) ), 
+   ( ("prob",(exp_string_of_float pro1) ), 
       ("attacks", attacksToView cut),
       ("defense", defenseToView2 cut l_defense2nist )
    );;
@@ -1102,7 +1102,7 @@ let rec cutSetsSafetyToView cOpe =
 
 let cutSetsSafety cutSet =     
     let (cut,pro1,_) = cutSet in
-    (("prob",(string_of_float pro1)), (cutSetsSafetyToView cut));;
+    (("prob",(exp_string_of_float pro1)), (cutSetsSafetyToView cut));;
 
 let cutSetsSafetyList cutSetList = List.map cutSetList ~f:(fun x-> cutSetsSafety x);;
 
@@ -1136,7 +1136,7 @@ let xmlBuilder_Requirement reqIDStr defenseTypeStr tc_adtree l_mission l_defense
    in
    Xml.Element ("Requirement",[("label",reqIDStr);
                                ("defenseType",defenseTypeStr);
-                               ("computed_p",(string_of_float likely));
+                               ("computed_p", (exp_string_of_float likely));
                                ("acceptable_p", (severity2risk(getSeverity_Of_cybReq reqIDStr l_mission)))], ds_Cutset) ;;
 
 let xmlBuilder_Event event = 
@@ -1165,7 +1165,7 @@ let xmlBuilder_Requirement_safety reqIDStr defenseTypeStr tc_ftree l_mission =
    in
    Xml.Element ("Requirement",[("label",reqIDStr);
                                ("defenseType",defenseTypeStr);
-                               ("computed_p",(string_of_float pr));
+                               ("computed_p", (exp_string_of_float pr));
                                ("acceptable_p", (getSafety_Of_cybReq reqIDStr l_mission))], ds_Cutset) ;;
 
 let xmlBuilder_RequirementList cyberORsafety l_libmdl mission l_defense2nist =
@@ -1197,7 +1197,7 @@ let xml_gen filename_ch reqIDStr defenseTypeStr tc_adtree l_mission l_defense2ni
    let getSeverity_Of_cybReq req l_mission = getval (cybReq_Severity l_mission) req 
    in
    fprintf filename_ch "defenseType=\"%s\" computed_p=\"%s\" acceptable_p =\"%s\" >\n" 
-                        (defenseTypeStr) (string_of_float likely) (severity2risk(getSeverity_Of_cybReq reqIDStr l_mission));
+                        (defenseTypeStr) (exp_string_of_float likely) (severity2risk(getSeverity_Of_cybReq reqIDStr l_mission));
    List.iter infoList ~f:(fun ((_,p),(_,aL),(_,dL)) -> fprintf_cutSet filename_ch p aL dL);
 ;;
 
@@ -1211,7 +1211,7 @@ let xml_gen_safety filename_ch reqIDStr defenseTypeStr tc_ftree l_mission =
    let getSafety_Of_cybReq req l_mission = getval (cybReq_Safety l_mission) req 
    in
    fprintf filename_ch "defenseType=\"%s\" computed_p=\"%s\" acceptable_p =\"%s\" >\n" 
-                       (defenseTypeStr) (string_of_float pr) (getSafety_Of_cybReq reqIDStr l_mission);
+                       (defenseTypeStr) (exp_string_of_float pr) (getSafety_Of_cybReq reqIDStr l_mission);
    List.iter infoList ~f:(fun ((_,p),l) -> fprintf_cutSetSafety filename_ch p l );
 ;;
    

--- a/tools/verdict-back-ends/soteria_pp/visualization.ml
+++ b/tools/verdict-back-ends/soteria_pp/visualization.ml
@@ -979,7 +979,7 @@ let rec sprint_defenseProfile adexp wDALSuffix =
    let andStr = " ^ \n" 
    and orStr = " v " in
    match adexp with
-   | AVar(comp, event, dal) -> comp ^ ":" ^ event ^ (if wDALSuffix then ":" ^ dal else "")
+   | AVar(comp, event, dal) -> comp ^ ":" ^ event ^ (if wDALSuffix && dal <> "" then ":" ^ dal else "")
    | DPro l -> 
      (match l with 
      | hd::tl -> 
@@ -1008,7 +1008,7 @@ let rec sprint_AProAVar2 adexp str wDALSuffix =
         | hd::tl -> 
            (match hd with
               | AVar(comp, event, dal) -> 
-                    let suffix = if wDALSuffix then ":" ^ dal else "" in
+                    let suffix = if wDALSuffix && dal <> "" then ":" ^ dal else "" in
                     let aStr = (if attackStr = "" then (comp ^ ":" ^ event ^ suffix) else (attackStr ^ andStr ^ comp ^ ":" ^ event ^ suffix)) in
                     sprint_AProAVar2 (APro tl) (aStr, defenseStr ) wDALSuffix
               | DSum l -> 
@@ -1026,11 +1026,12 @@ let rec sprint_AProAVar2 adexp str wDALSuffix =
 
 (* Given the list of cutset from likelihoodCutImp, generates an output to use with PrintBox *)
 let rec sprint_each_csImp l_csImp csArray wDALSuffix =
+   let mantissa_string_of_float f = match f with 1. -> "1." | _ -> Printf.sprintf "%.0e" f in
    match l_csImp with
    | hd::tl -> 
       (let (adexp_APro, likelihood, _) = hd in 
       let (attackStr, defenseStr) = sprint_AProAVar2 adexp_APro ("","") wDALSuffix in
-      sprint_each_csImp tl (Array.append csArray [| [| (string_of_float likelihood); attackStr; defenseStr |] |] ) wDALSuffix)
+      sprint_each_csImp tl (Array.append csArray [| [| (mantissa_string_of_float likelihood); attackStr; defenseStr |] |] ) wDALSuffix)
    | [] -> csArray ;; 
 
 (* This function generates a string of failure events *)

--- a/tools/verdict-back-ends/soteria_pp/visualization.ml
+++ b/tools/verdict-back-ends/soteria_pp/visualization.ml
@@ -98,7 +98,6 @@ open TreeSynthesis;;
    unflatten_exe and dot_exe are strings that should be set to the 
    fullpaths of the "unflatten" and "dot" utilities from graphviz. 
 *)
-
 let whereIs_dot = 
    let stringOption = In_channel.input_line( Unix.open_process_in "which dot" ) in
    match stringOption with
@@ -113,6 +112,8 @@ let whereIs_unflatten =
 
 let unflatten_exe = whereIs_unflatten ;;
 let dot_exe = whereIs_dot ;;
+
+let exp_string_of_float (likelihood:float) = Printf.sprintf "%.0e" likelihood;;
 
 (* Below is code for generating a fault tree diagram using graphviz. Actually it
    generates diagrams for formulas, so you have to convert a fault tree to a
@@ -967,7 +968,7 @@ let rec print_each_csImp l ch =
    match l with
    | hd::tl -> 
       (let (adexp, likelihood, _) = hd in 
-       Out_channel.output_string ch ((string_of_float likelihood) ^ "\t\t");
+       Out_channel.output_string ch ((exp_string_of_float likelihood) ^ "\t\t");
        print_each_cs adexp ch ; 
        Out_channel.output_char ch '\n';
        print_each_csImp tl ch );
@@ -1026,12 +1027,11 @@ let rec sprint_AProAVar2 adexp str wDALSuffix =
 
 (* Given the list of cutset from likelihoodCutImp, generates an output to use with PrintBox *)
 let rec sprint_each_csImp l_csImp csArray wDALSuffix =
-   let mantissa_string_of_float f = match f with 1. -> "1." | _ -> Printf.sprintf "%.0e" f in
    match l_csImp with
    | hd::tl -> 
       (let (adexp_APro, likelihood, _) = hd in 
       let (attackStr, defenseStr) = sprint_AProAVar2 adexp_APro ("","") wDALSuffix in
-      sprint_each_csImp tl (Array.append csArray [| [| (mantissa_string_of_float likelihood); attackStr; defenseStr |] |] ) wDALSuffix)
+      sprint_each_csImp tl (Array.append csArray [| [| (exp_string_of_float likelihood); attackStr; defenseStr |] |] ) wDALSuffix)
    | [] -> csArray ;; 
 
 (* This function generates a string of failure events *)
@@ -1062,7 +1062,7 @@ let rec sprint_each_safety_csImp l_csImp csArray =
    match l_csImp with
    | hd::tl -> 
       (let (pexp, probability, _) = hd in 
-      sprint_each_safety_csImp tl (Array.append csArray [| [| (string_of_float probability); (sprint_Events pexp)|] |] ) )
+      sprint_each_safety_csImp tl (Array.append csArray [| [| (exp_string_of_float probability); (sprint_Events pexp)|] |] ) )
    | [] -> csArray ;; 
      
 (**/**)
@@ -1082,7 +1082,7 @@ let saveADCutSetsToFile ?cyberReqID:(cid="") ?risk:(r="") ?header:(h="") file ad
    let box = PrintBox.(hlist [ text ("Cyber\nReqID: \n" ^ cid); grid_text myArray ]) |> PrintBox.frame
    in
    (Out_channel.output_string ch ("\n");
-    Out_channel.output_string ch ("Calculated likelihood of successful attack = " ^ (string_of_float likelihood) ^ "\n");
+    Out_channel.output_string ch ("Calculated likelihood of successful attack = " ^ (exp_string_of_float likelihood) ^ "\n");
     Out_channel.output_string ch (targetString);
     Out_channel.output_string ch ("\n");
     PrintBox_text.output ch box;
@@ -1105,7 +1105,7 @@ let saveCutSetsToFile ?reqID:(cid="") ?risk:(r="") ?header:(h="") file ftree =
    let box = PrintBox.(hlist [ text ("Safety\nReqID: \n" ^ cid); grid_text myArray ]) |> PrintBox.frame
    in
    (Out_channel.output_string ch ("\n");
-    Out_channel.output_string ch ("Calculated probability of failure = " ^ (string_of_float probability) ^ "\n");
+    Out_channel.output_string ch ("Calculated probability of failure = " ^ (exp_string_of_float probability) ^ "\n");
     Out_channel.output_string ch (targetString);
     Out_channel.output_string ch ("\n");
     PrintBox_text.output ch box;


### PR DESCRIPTION
Cutset likelihood is represented in scientific notation for likelihoods < 1e-5 but as decimals otherwise. The notation effects MBAS output which maps likelihood levels to severity levels where doubles are not expected and default to passing "E" severity.

The likelihood print function was updated to display values in e+-dd decimal notation

Bugfix: Removes trailing ":" in attack strings of the AD fragments

Solves:
[VERDICT-270](https://github.com/ge-high-assurance/VERDICT/issues/270)

**Background**: The soteria_pp visualization:sprint_each_csImp prints all likelihoods with string_of_float from stdlib which uses the format pattern "%.12g" - g being: 
> g or G: convert a floating-point argument to decimal notation, in style f or e, E (whichever is more compact). Moreover, any trailing zeros are removed from the fractional part of the result and the decimal-point character is removed if there is no fractional part remaining. 

**Implementation Details**: 
Soteria ++ output should always format cutset likelihood in e+-dd decimal notation

References: 
https://github.com/ge-high-assurance/VERDICT/blob/21c4184852e39d6b02e374b30e377db4bff28eae/tools/verdict/com.ge.research.osate.verdict/src/com/ge/research/osate/verdict/gui/MBASResultsView.java#L67
https://github.com/ocaml/ocaml/blob/trunk/stdlib/stdlib.ml#L287
https://v2.ocaml.org/api/Printf.html
