### PR TITLE
VERDICT-277: VDM Translator XML Marshalling Error - JAXB major v. rollback

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-bom</artifactId>
-        <version>4.0.0</version>
+        <version>3.0.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Rollback of jaxb-bom major version (dependabot auto update)

Solves: VERDICT-277