### PR TITLE
VERDICT-289: Support Absolute DAL Cost Values 

### DIFF
--- a/tools/verdict-back-ends/verdict-bundle/verdict-bundle-app/src/main/java/com/ge/verdict/bundle/App.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-bundle-app/src/main/java/com/ge/verdict/bundle/App.java
@@ -8,11 +8,12 @@ import com.ge.verdict.gsn.GSNInterface;
 import com.ge.verdict.gsn.SecurityGSNInterface;
 import com.ge.verdict.lustre.VerdictLustreTranslator;
 import com.ge.verdict.stem.VerdictStem;
-import com.ge.verdict.synthesis.CostModel;
 import com.ge.verdict.synthesis.DTreeConstructor;
+import com.ge.verdict.synthesis.ICostModel;
 import com.ge.verdict.synthesis.VerdictSynthesis;
 import com.ge.verdict.synthesis.dtree.DLeaf;
 import com.ge.verdict.synthesis.dtree.DTree;
+import com.ge.verdict.synthesis.impl.MonotonicCostModelTree;
 import com.ge.verdict.test.instrumentor.VerdictTestInstrumentor;
 import com.ge.verdict.vdm.VdmTranslator;
 import com.ge.verdict.vdm.synthesis.ResultsInstance;
@@ -762,7 +763,7 @@ public class App {
         try {
             Timer.Sample sample = Timer.start(Metrics.globalRegistry);
 
-            CostModel costModel = new CostModel(new File(costModelPath));
+            final ICostModel costModel = MonotonicCostModelTree.load(new File(costModelPath));
 
             AttackDefenseCollector collector =
                     new AttackDefenseCollector(

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/App.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/App.java
@@ -5,6 +5,7 @@ import com.ge.verdict.attackdefensecollector.AttackDefenseCollector.Result;
 import com.ge.verdict.attackdefensecollector.CSVFile.MalformedInputException;
 import com.ge.verdict.synthesis.dtree.DLeaf;
 import com.ge.verdict.synthesis.dtree.DTree;
+import com.ge.verdict.synthesis.impl.MonotonicCostModelTree;
 import com.ge.verdict.vdm.synthesis.ResultsInstance;
 import java.io.File;
 import java.io.IOException;
@@ -40,8 +41,8 @@ public class App {
             System.out.println("Parent directory: " + System.getProperty("user.dir"));
         }
 
-        final CostModel costModel =
-                timed("Load cost model", () -> new CostModel(new File(costModelXml)));
+        final ICostModel costModel =
+                timed("Load cost model", () -> MonotonicCostModelTree.load(new File(costModelXml)));
 
         AttackDefenseCollector collector =
                 timed(

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/DTreeConstructor.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/DTreeConstructor.java
@@ -39,7 +39,7 @@ public class DTreeConstructor {
      */
     public static DTree construct(
             List<AttackDefenseCollector.Result> results,
-            CostModel costModel,
+            ICostModel costModel,
             boolean usePartialSolution,
             boolean meritAssignment,
             DLeaf.Factory factory) {
@@ -75,7 +75,7 @@ public class DTreeConstructor {
      */
     public static DTree construct(
             ADTree adtree,
-            CostModel costModel,
+            ICostModel costModel,
             int targetDal,
             boolean usePartialSolution,
             boolean meritAssignment,
@@ -86,7 +86,7 @@ public class DTreeConstructor {
     }
 
     /** the cost model */
-    private final CostModel costModel;
+    private final ICostModel costModel;
     /**
      * the dleaf factory, used to make sure there is only ever one instance of a given
      * component-defense pair
@@ -107,7 +107,7 @@ public class DTreeConstructor {
     private final List<DCondition> dconditions;
 
     private DTreeConstructor(
-            CostModel costModel,
+            ICostModel costModel,
             int dal,
             boolean usePartialSolution,
             boolean meritAssignment,

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/ICostModel.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/ICostModel.java
@@ -1,0 +1,103 @@
+package com.ge.verdict.synthesis;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.math3.fraction.Fraction;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public interface ICostModel {
+
+    String COMPONENT = "component";
+
+    String DEFENSE = "defense";
+
+    String DAL = "dal";
+
+    String COST = "cost";
+
+    String INFINITE = "INF";
+
+    String COMPONENT_NAME_SEPARATOR = ":::";
+
+    String UNSUPPORTED_DAL = "Unsupported DAL Value: %s";
+
+    String UNSUPPORTED_INF = "Infinite cost not supported";
+
+    String UNSUPPORTED_NEG = "Negative cost not supported: %s";
+
+    String QUALIFIED_NAME_ERROR =
+            "Invalid number of parts in qualified component name (should be 2): %s";
+
+    String COST_MODEL_TAG = "Unrecognized cost model tag: %s";
+
+    class CostModelException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public CostModelException(final String message) {
+            super(message);
+        }
+    }
+
+    /* FIXME: remove once fully qualified names are supported */
+    static Optional<String> getComponentName(final String qualifiedComponentName) {
+        final Optional<String> name = Optional.ofNullable(qualifiedComponentName);
+        return name.filter(n -> n.contains(COMPONENT_NAME_SEPARATOR))
+                .map(
+                        n -> {
+                            final String[] parts =
+                                    qualifiedComponentName.split(COMPONENT_NAME_SEPARATOR);
+                            if (parts.length != 2) {
+                                throw new CostModelException(
+                                        String.format(
+                                                QUALIFIED_NAME_ERROR, qualifiedComponentName));
+                            }
+                            return Optional.of(parts[1]);
+                        })
+                .orElse(name)
+                .filter(s -> !s.isEmpty());
+    }
+
+    /** Parse a DAL string into an integer. */
+    static int parseDal(final String dalStr) {
+        final int dal = Integer.parseInt(dalStr);
+        if (dal < 0 || dal > 9) {
+            throw new CostModelException(String.format(UNSUPPORTED_DAL, dalStr));
+        }
+        return dal;
+    }
+
+    /** Parse a decimal cost string into a fraction. */
+    static Fraction parseCost(final String costStr) {
+        if (INFINITE.equals(costStr)) {
+            throw new CostModelException(UNSUPPORTED_INF);
+        }
+        final double costDouble = Double.parseDouble(costStr);
+        if (costDouble < 0) {
+            throw new CostModelException(String.format(UNSUPPORTED_NEG, costStr));
+        }
+        return new Fraction(costDouble, 0.000001, 20); // mitigate floating point error
+    }
+
+    static List<Element> extractCostElements(final Element xml) {
+        final NodeList nodeList = xml.getElementsByTagName(COST);
+        return IntStream.range(0, nodeList.getLength())
+                .mapToObj(nodeList::item)
+                .map(n -> n instanceof Element ? (Element) n : null)
+                .collect(Collectors.toList());
+    }
+
+    static void validateRuleAttrs(final Element rule) {
+        final int attrLength = rule.getAttributes().getLength();
+        for (int i = 0; i < attrLength; i++) {
+            final String name = rule.getAttributes().item(i).getNodeName();
+            if (!COMPONENT.equals(name) && !DEFENSE.equals(name) && !DAL.equals(name)) {
+                throw new CostModelException(String.format(COST_MODEL_TAG, name));
+            }
+        }
+    }
+
+    Fraction getCost(final String defense, final String component, final int dal);
+}

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/VerdictSynthesis.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/VerdictSynthesis.java
@@ -50,7 +50,7 @@ public class VerdictSynthesis {
     public static Optional<ResultsInstance> performSynthesisMultiple(
             DTree tree,
             DLeaf.Factory factory,
-            CostModel costModel,
+            ICostModel costModel,
             boolean partialSolution,
             boolean inputSat,
             boolean meritAssignment,
@@ -150,9 +150,9 @@ public class VerdictSynthesis {
                 // instead, we re-calculate using the cost model because it is less prone to failure
                 // The cost of implemented DAL
                 Fraction inputCost =
-                        costModel.cost(pair.defenseProperty, pair.component, pair.implDal);
+                        costModel.getCost(pair.defenseProperty, pair.component, pair.implDal);
                 // The cost of output DAL from SMT
-                Fraction outputCost = costModel.cost(pair.defenseProperty, pair.component, dal);
+                Fraction outputCost = costModel.getCost(pair.defenseProperty, pair.component, dal);
 
                 // keep track of total cost
                 totalInputCost = totalInputCost.add(inputCost);
@@ -394,7 +394,7 @@ public class VerdictSynthesis {
             ResultsInstance results,
             Map<com.ge.verdict.attackdefensecollector.Pair<String, String>, Integer>
                     implCompDefPairs,
-            CostModel costModel) {
+            ICostModel costModel) {
 
         List<ResultsInstance.Item> items = new ArrayList<>(results.items);
         Fraction inputCost = results.inputCost;
@@ -418,8 +418,8 @@ public class VerdictSynthesis {
                 int implDal = entry.getValue();
 
                 // compute cost of the implemented pair
-                Fraction pairInputCost = costModel.cost(defProp, comp, implDal);
-                Fraction pairOutputCost = costModel.cost(defProp, comp, 0);
+                Fraction pairInputCost = costModel.getCost(defProp, comp, implDal);
+                Fraction pairOutputCost = costModel.getCost(defProp, comp, 0);
 
                 // the item will be a removal, so from implDal -> 0 DAL
                 items.add(

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/dtree/DLeaf.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/dtree/DLeaf.java
@@ -1,6 +1,6 @@
 package com.ge.verdict.synthesis.dtree;
 
-import com.ge.verdict.synthesis.CostModel;
+import com.ge.verdict.synthesis.ICostModel;
 import com.ge.verdict.synthesis.util.Pair;
 import com.microsoft.z3.ArithExpr;
 import com.microsoft.z3.BoolExpr;
@@ -323,17 +323,17 @@ public class DLeaf implements DTree {
             String attack,
             int implDal,
             int targetDal,
-            CostModel costModel,
+            ICostModel costModel,
             Factory factory,
             boolean usePartialSolution,
             boolean meritAssignment) {
 
-        Fraction implCost = costModel.cost(defenseProperty, component, implDal);
+        Fraction implCost = costModel.getCost(defenseProperty, component, implDal);
 
         // construct each cost
         Fraction[] costs = new Fraction[10];
         for (int dal = 0; dal < costs.length; dal++) {
-            Fraction currentDALCost = costModel.cost(defenseProperty, component, dal);
+            Fraction currentDALCost = costModel.getCost(defenseProperty, component, dal);
             if (usePartialSolution && !meritAssignment) {
                 // in the partial solutions (but no merit assignment) case, we treat
                 // implemented defenses as a sunk cost

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/impl/CostModel.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/impl/CostModel.java
@@ -1,5 +1,6 @@
-package com.ge.verdict.synthesis;
+package com.ge.verdict.synthesis.impl;
 
+import com.ge.verdict.synthesis.ICostModel;
 import com.ge.verdict.synthesis.util.Pair;
 import com.ge.verdict.synthesis.util.Triple;
 import java.io.File;
@@ -20,10 +21,11 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 /**
- * Reprents a cost model loaded from XML. Allows for efficiently looking up the cost of any
+ * Represents a cost model loaded from XML. Allows for efficiently looking up the cost of any
  * component-defense-DAL triple.
  */
-public class CostModel {
+@Deprecated
+public class CostModel implements ICostModel {
     /** Thrown if parsing fails due to an invalid cost model XML. */
     public static class ParseException extends RuntimeException {
         private static final long serialVersionUID = 1L;
@@ -64,15 +66,13 @@ public class CostModel {
         dalModel = new LinkedHashMap<>();
         defaultModel = new Fraction(1);
 
-        load(costModelXml);
+        loadModel(costModelXml);
     }
 
     /**
      * Used for testing.
      *
-     * @param component
-     * @param defense
-     * @param costs
+     * @param costs (component, defense, costs) triples
      */
     @SafeVarargs
     public CostModel(Triple<String, String, Fraction[]>... costs) {
@@ -104,7 +104,7 @@ public class CostModel {
      * @param dal
      * @return
      */
-    public Fraction cost(String defense, String component, int dal) {
+    private Fraction cost(String defense, String component, int dal) {
         // If DAL is not specified, we default to using DAL to linearly scale cost
 
         // System.out.println("Loading cost: " + defense + ", " + component + ", " + dal);
@@ -202,7 +202,7 @@ public class CostModel {
      *
      * @param costModelXml
      */
-    private void load(File costModelXml) {
+    private void loadModel(File costModelXml) {
         try {
             DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             Document xml = parser.parse(costModelXml);
@@ -300,5 +300,20 @@ public class CostModel {
         }
         // this precision should mitigate any floating point error
         return new Fraction(costDouble, 0.000001, 20);
+    }
+
+    public static ICostModel load(final File costModelXml) {
+        return new CostModel(costModelXml);
+    }
+
+    /**
+     * Calculate the cost for a specified defense at a specified design assurance level
+     *
+     * @deprecated This class is no longer acceptable to compute DAL costs
+     *     <p>Use {@link MonotonicCostModelTree#getCost(String, String, int)} instead.
+     */
+    @Override
+    public Fraction getCost(final String defense, final String component, int dal) {
+        return this.cost(defense, component, dal);
     }
 }

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/impl/MonotonicCostModelTree.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/impl/MonotonicCostModelTree.java
@@ -1,0 +1,361 @@
+package com.ge.verdict.synthesis.impl;
+
+import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
+
+import com.ge.verdict.synthesis.ICostModel;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.apache.commons.math3.fraction.Fraction;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+/**
+ * A cost model composite tree for cost lookup based on component, defense, dal Supports discrete
+ * costs for DALs, enforces monotonic properties
+ *
+ * <p>Trees will always be in Component, Defense, DAL order but not necessarily perfect e.g.
+ * component and defense may be on the same tree level if component is not provided e.g.
+ *
+ * <p>  default (cost:1) 
+ * <p>      ├── Component A (cost:2) 
+ * <p>      │        ├── Defense B (cost:4) 
+ * <p>      │        │       └── DAL 2 (cost:8) 
+ * <p>      │        └── DAL 2 (cost:6) 
+ * <p>      ├── Defense G (cost:2) 
+ * <p>      │        └── DAL 3 (cost:6) 
+ * <p>      └── DAL 5 (cost:6)
+ */
+public class MonotonicCostModelTree implements ICostModel {
+
+    private static class MonotonicCostTreeException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public MonotonicCostTreeException(final String message) {
+            super(message);
+        }
+
+        public MonotonicCostTreeException(final Exception parent) {
+            super(parent);
+        }
+
+        public MonotonicCostTreeException(final String message, final Exception parent) {
+            super(message, parent);
+        }
+    }
+
+    private static final String EMPTY = "";
+
+    private static final String YES = "YES";
+
+    private static final Fraction DEFAULT_COST = Fraction.ONE;
+
+    private static final String DEFAULT_COST_SOURCE = "Default Cost:" + DEFAULT_COST;
+
+    private static final String MISSING_XML = "Missing Cost Model XML";
+
+    private static final String NON_MONOTONIC = "Non-monotonic costs found: %s > %s";
+    
+    private static final String DAL_RANGE_ERROR = "DAL must be an odd integer between 1 and 10 but found %s";
+
+    private static final String COST_ERROR =
+            "Could not calculate cost for component, defense, dal: %s %s %s";
+
+    private static final String DUPLICATE_MODEL = "Duplicate cost model definitions found: %s %s";
+
+    private static final String WRITER_CONFIGURATION_ERROR =
+            "Unable to configure xml node to string writer";
+
+    final Map<Integer, MonotonicCostModelTree> dals;
+    final Map<String, MonotonicCostModelTree> components;
+    final Map<String, MonotonicCostModelTree> defenses;
+
+    // Nodes may have associated costs
+    String source;
+    Fraction cost;
+
+    MonotonicCostModelTree() {
+        dals = new HashMap<>();
+        components = new HashMap<>();
+        defenses = new HashMap<>();
+    }
+
+    public static MonotonicCostModelTreeBuilder.Builder builder() {
+        return new MonotonicCostModelTreeBuilder.Builder();
+    }
+
+    private Optional<Fraction> getCost() {
+        return Optional.ofNullable(this.cost);
+    }
+
+    private Optional<String> getSource() {
+        return Optional.ofNullable(this.source);
+    }
+
+    /**
+     * Validate a tree is monotonic: A tree is considered monotonic if all more generalized costs
+     * are less or equal to this cost
+     *
+     * @throws MonotonicCostTreeException on first monotonic violation between cost model
+     *     definitions
+     */
+    private static void validate(
+            final MonotonicCostModelTree tree,
+            final Map<Integer, MonotonicCostModelTree>
+                    predecessorDalCosts // DesignAssuranceLevel:Cost of preceding nodes
+            ) {
+
+        if (null == tree) return;
+
+        final Map<Integer, MonotonicCostModelTree> mutCostAcc = new HashMap<>(predecessorDalCosts);
+        final Map<Integer, MonotonicCostModelTree> mutTreeDals = new HashMap<>(tree.dals);
+
+        // Consider the base scaling factor if present
+        tree.getCost().ifPresent(c -> mutTreeDals.put(0, tree));
+
+        // General DAL costs should not be greater than more specific
+        mutTreeDals.forEach(
+                (key, value) -> {
+                    
+                    if(key > 0 && key % 2 == 0){
+                        throw new MonotonicCostTreeException(
+                                String.format(DAL_RANGE_ERROR, value.getSource().orElse(DEFAULT_COST_SOURCE)));
+                    }
+                    
+                    mutCostAcc.merge(
+                            key,
+                            value,
+                            (v1, v2) -> {
+
+                                if (v1.getCost().orElse(Fraction.ZERO)
+                                        .compareTo( value.getCost().orElse(Fraction.ZERO)) > 0) {
+
+                                    throw new MonotonicCostTreeException(
+                                            String.format(NON_MONOTONIC, v1.source, value.source));
+                                }
+                                return v2;
+                            });
+                });
+
+        /* Sequential DALs should have sequential costs
+        var assignment necessary to prevent compiler remove optimizations */
+        final boolean prevent_jc_optimization =
+                mutCostAcc.entrySet().stream()
+                        .sorted(Map.Entry.comparingByKey()) // sort by DAL before comparing costs
+                        .reduce(
+                                (a, b) -> {
+                                    final Fraction aVal =
+                                            a.getValue().getCost().orElse(Fraction.ZERO);
+                                    final Fraction bVal =
+                                            b.getValue().getCost().orElse(Fraction.ZERO);
+
+                                    /* Base scaling factor * (first DAL-2 (next odd)) should not be greater than the first DAL cost */
+                                    if (a.getKey() == 0
+                                            && aVal.multiply(b.getKey() - 2).compareTo(bVal) > 0) {
+                                        throw new MonotonicCostTreeException(
+                                                String.format(
+                                                        NON_MONOTONIC,
+                                                        a.getValue().source,
+                                                        b.getValue().source));
+
+                                    } else if (aVal.compareTo(bVal) > 0) {
+                                        throw new MonotonicCostTreeException(
+                                                String.format(
+                                                        NON_MONOTONIC,
+                                                        a.getValue().source,
+                                                        b.getValue().source));
+                                    }
+
+                                    return b;
+                                })
+                        .isPresent();
+
+        tree.components.forEach((key, value) -> MonotonicCostModelTree.validate(value, mutCostAcc));
+        tree.defenses.forEach((key, value) -> MonotonicCostModelTree.validate(value, mutCostAcc));
+    }
+
+    /**
+     * Merge cost model tree values into this <remarks>not thread safe</remarks>
+     *
+     * @throws MonotonicCostTreeException if duplicate cost model definitions are found
+     */
+    private void merge(final MonotonicCostModelTree tree) {
+        if (null == tree) return;
+
+        tree.getSource()
+                .ifPresent(
+                        s -> {
+                            // default costs can be overwritten
+                            if (getSource().filter(src -> !src.equals(DEFAULT_COST_SOURCE)).isPresent()) {
+                                throw new MonotonicCostTreeException(
+                                        String.format(DUPLICATE_MODEL, s, this.source));
+                            }
+                            this.source = s;
+                            // source check covers costs since build order is enforced
+                            tree.getCost().ifPresent(c -> this.cost = c);
+                        });
+
+        tree.dals.forEach(
+                (key, value) -> {
+                    final MonotonicCostModelTree old = this.dals.put(key, value);
+                    if (null != old) {
+                        throw new MonotonicCostTreeException(
+                                String.format(DUPLICATE_MODEL, value.source, old.source));
+                    }
+                });
+
+        tree.components.forEach(
+                (k, v) -> {
+                    if (this.components.containsKey(k)) {
+                        this.components.get(k).merge(v);
+                    } else {
+                        this.components.put(k, v);
+                    }
+                });
+        tree.defenses.forEach(
+                (k, v) -> {
+                    if (this.defenses.containsKey(k)) {
+                        this.defenses.get(k).merge(v);
+                    } else {
+                        this.defenses.put(k, v);
+                    }
+                });
+    }
+
+    /**
+     * Evaluate the cost for a defense definition at a provided design assurance level (DAL) using this
+     * cost model tree
+     *
+     * <p>Cost evaluation order and cost value:
+     *
+     * <ul>
+     *   <li>1. component, defense, dal : cost
+     *   <li>2. component, defense : scaling factor (cost) * dal
+     *   <li>3. component, dal : cost
+     *   <li>4. defense, dal : cost
+     *   <li>5. component : scaling factor (cost) * dal
+     *   <li>6. defense : scaling factor (cost) * dal
+     *   <li>7. dal : cost
+     *   <li>8. none : cost * (default) dal
+     * </ul>
+     * 
+     * @param component the component identifier for a defense definition (can be empty)
+     * @param defense the defense identifier for a defense definition (can be empty)
+     * @param dal design assurance level to compute cost for (required)
+     * @throws MonotonicCostTreeException if the cost cannot be computed
+     */
+    public Fraction getCost(final String defense, final String component, final int dal) {
+        /* Synthesis takes the greatest DAL with the least cost to meet a def. req.
+            Ceiling to the next odd DAL forces DLeaf synthesis to return a valid (odd) DAL */
+        final int oddDal = dal % 2 == 1 || dal == 0 ? dal : dal + 1;
+        return evaluateCost(component, defense, oddDal, new HashMap<>())
+                .orElseThrow(() ->
+                            new MonotonicCostTreeException(
+                                    String.format(COST_ERROR, component, defense, dal)));
+    }
+
+    private Optional<Fraction> evaluateCost(
+            final String component, final String defense, final int dal, 
+            final Map<Integer,MonotonicCostModelTree> predecessorDALCostsAcc) {
+        
+        predecessorDALCostsAcc.putAll(this.dals);
+        
+        if (null != component && !component.isEmpty() && components.containsKey(component)) {
+            return components
+                    .get(component)
+                    .evaluateCost(EMPTY, defense, dal, predecessorDALCostsAcc)
+                    .map(Optional::of)
+                    .orElse(this.getCost().map(c -> c.multiply(dal)));
+        }
+
+        if (null != defense && !defense.isEmpty() && defenses.containsKey(defense)) {
+            return defenses.get(defense)
+                    .evaluateCost(EMPTY, EMPTY, dal, predecessorDALCostsAcc)
+                    .map(Optional::of)
+                    .orElse(this.getCost().map(c -> c.multiply(dal)));
+        }
+
+        final Optional<MonotonicCostModelTree> foundDal =
+                predecessorDALCostsAcc.entrySet().stream()
+                        .sorted((a, b) -> b.getKey().compareTo(a.getKey()))
+                        .filter(e -> e.getKey() <= dal)
+                        .map(Map.Entry::getValue)
+                        .filter(v -> v.getCost().isPresent())
+                        .findFirst();
+
+        return foundDal.isPresent()
+                ? foundDal.get().getCost()
+                : this.getCost().map(c -> c.multiply(dal));
+    }
+
+    /** Stringifies an XML element */
+    private static String asString(final Element toStringify, final Transformer transformer)
+            throws TransformerException {
+        final StringWriter sw = new StringWriter();
+        transformer.transform(new DOMSource(toStringify), new StreamResult(sw));
+        return sw.toString();
+    }
+
+    /**
+     * Deserializes an XML file to a {@link MonotonicCostModelTree} cost tree
+     *
+     * @param costModelXml xml file to deserialize
+     * @return an {@link MonotonicCostModelTree} representing the xml configured costs
+     * @throws MonotonicCostTreeException if the xml configuration could not be deserialized to a
+     *     monotonic tree
+     */
+    public static MonotonicCostModelTree load(final File costModelXml) {
+        assert null != costModelXml && costModelXml.exists() : MISSING_XML;
+        try {
+            final DocumentBuilder parser =
+                    DocumentBuilderFactory.newInstance().newDocumentBuilder();
+
+            final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OMIT_XML_DECLARATION, YES);
+
+            final Document xml = parser.parse(costModelXml);
+            final List<Element> elements = ICostModel.extractCostElements(xml.getDocumentElement());
+            final MonotonicCostModelTree tree =
+                    MonotonicCostModelTree.builder()
+                            .withCost(DEFAULT_COST)
+                            .withSource(DEFAULT_COST_SOURCE)
+                            .build();
+
+            for (final Element rule : elements) {
+
+                ICostModel.validateRuleAttrs(rule);
+
+                final MonotonicCostModelTree node =
+                        MonotonicCostModelTree.builder()
+                                .withComponent(rule.getAttribute(COMPONENT))
+                                .withDefense(rule.getAttribute(DEFENSE))
+                                .withDal(rule.getAttribute(DAL))
+                                .withCost(rule.getTextContent())
+                                .withSource(asString(rule, transformer))
+                                .build();
+                
+                tree.merge(node);
+            }
+            validate(tree, new HashMap<>());
+            return tree;
+
+        } catch (final TransformerException e) {
+            throw new MonotonicCostTreeException(WRITER_CONFIGURATION_ERROR, e);
+        } catch (final IOException | SAXException | ParserConfigurationException e) {
+            throw new MonotonicCostTreeException(e);
+        }
+    }
+}

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/impl/MonotonicCostModelTreeBuilder.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/main/java/com/ge/verdict/synthesis/impl/MonotonicCostModelTreeBuilder.java
@@ -1,0 +1,100 @@
+package com.ge.verdict.synthesis.impl;
+
+import static com.ge.verdict.synthesis.ICostModel.parseCost;
+
+import com.ge.verdict.synthesis.ICostModel;
+import java.util.Optional;
+import org.apache.commons.math3.fraction.Fraction;
+
+/** Builder pattern ensuring node order for a {@link MonotonicCostModelTree} */
+class MonotonicCostModelTreeBuilder {
+
+    private static final String UNSET_COST = "Cost must be set before source";
+    private static final String EMPTY_SOURCE = "Empty cost model element found";
+
+    interface AddDef {
+        AddDal withDefense(final String d);
+    }
+
+    interface AddDal {
+        AddCost withDal(final String cost);
+    }
+
+    interface AddCost {
+        AddSource withCost(final String cost);
+    }
+
+    interface AddSource {
+        BuildTree withSource(final String source);
+    }
+
+    interface BuildTree {
+        MonotonicCostModelTree build();
+    }
+
+    /** Enforce build order (Comp, Def, Dal layering) for tree creation */
+    static class Builder implements AddDef, AddDal, AddCost, AddSource, BuildTree {
+
+        private final MonotonicCostModelTree treeNode;
+        private MonotonicCostModelTree currentNode;
+
+        Builder() {
+            this.treeNode = new MonotonicCostModelTree();
+            this.currentNode = this.treeNode;
+        }
+
+        public AddDef withComponent(final String componentNameStr) {
+            ICostModel.getComponentName(componentNameStr)
+                    .filter(s -> !s.isEmpty())
+                    .ifPresent(
+                            c -> {
+                                this.currentNode.components.put(c, new MonotonicCostModelTree());
+                                this.currentNode = currentNode.components.get(c);
+                            });
+            return this;
+        }
+
+        public AddDal withDefense(final String defenseNameStr) {
+            Optional.ofNullable(defenseNameStr)
+                    .filter(s -> !s.isEmpty())
+                    .ifPresent(
+                            d -> {
+                                this.currentNode.defenses.put(d, new MonotonicCostModelTree());
+                                this.currentNode = currentNode.defenses.get(d);
+                            });
+            return this;
+        }
+
+        public AddCost withDal(final String dalStr) {
+            Optional.ofNullable(dalStr)
+                    .filter(s -> !s.isEmpty())
+                    .map(ICostModel::parseDal)
+                    .ifPresent(
+                            d -> {
+                                this.currentNode.dals.put(d, new MonotonicCostModelTree());
+                                this.currentNode = currentNode.dals.get(d);
+                            });
+            return this;
+        }
+
+        public AddSource withCost(final String cost) {
+            return this.withCost(parseCost(cost));
+        }
+
+        public AddSource withCost(final Fraction cost) {
+            this.currentNode.cost = cost;
+            return this;
+        }
+
+        public BuildTree withSource(final String componentNodeSource) {
+            assert null != this.currentNode.cost : UNSET_COST;
+            assert null != componentNodeSource && !componentNodeSource.isEmpty() : EMPTY_SOURCE;
+            this.currentNode.source = componentNodeSource;
+            return this;
+        }
+        
+        public MonotonicCostModelTree build() {
+            return this.treeNode;
+        }
+    }
+}

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/java/com/ge/verdict/synthesis/CostModelTest.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/java/com/ge/verdict/synthesis/CostModelTest.java
@@ -1,31 +1,35 @@
 package com.ge.verdict.synthesis;
 
+import com.ge.verdict.synthesis.impl.CostModel;
 import java.io.File;
 import org.apache.commons.math3.fraction.Fraction;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class CostModelTest {
+
     @Test
     public void testLoad() {
-        CostModel costs =
-                new CostModel(new File(getClass().getResource("sampleCosts.xml").getPath()));
-        Assertions.assertThat(costs.cost("D1", "C1", 1)).isEqualTo(new Fraction(1));
-        Assertions.assertThat(costs.cost("D1", "C1", 2)).isEqualTo(new Fraction(2));
-        Assertions.assertThat(costs.cost("D2", "C2", 3)).isEqualTo(new Fraction(3));
+        final ICostModel costs =
+                CostModel.load(new File(getClass().getResource("sampleCosts.xml").getPath()));
+
+        Assertions.assertThat(costs.getCost("D1", "C1", 1)).isEqualTo(new Fraction(1));
+        Assertions.assertThat(costs.getCost("D1", "C1", 2)).isEqualTo(new Fraction(2));
+        Assertions.assertThat(costs.getCost("D2", "C2", 3)).isEqualTo(new Fraction(3));
     }
 
     @Test
     public void testDefaults() {
-        CostModel costs =
-                new CostModel(new File(getClass().getResource("defaultCosts.xml").getPath()));
-        Assertions.assertThat(costs.cost("A", "A", 1)).isEqualTo(new Fraction(16));
-        Assertions.assertThat(costs.cost("A", "B", 1)).isEqualTo(new Fraction(15));
-        Assertions.assertThat(costs.cost("B", "A", 1)).isEqualTo(new Fraction(14));
-        Assertions.assertThat(costs.cost("A", "A", 2)).isEqualTo(new Fraction(26));
-        Assertions.assertThat(costs.cost("B", "B", 1)).isEqualTo(new Fraction(12));
-        Assertions.assertThat(costs.cost("A", "B", 2)).isEqualTo(new Fraction(22));
-        Assertions.assertThat(costs.cost("B", "A", 2)).isEqualTo(new Fraction(20));
-        Assertions.assertThat(costs.cost("B", "B", 2)).isEqualTo(new Fraction(18));
+        final ICostModel costs =
+                CostModel.load(new File(getClass().getResource("defaultCosts.xml").getPath()));
+
+        Assertions.assertThat(costs.getCost("A", "A", 1)).isEqualTo(new Fraction(16));
+        Assertions.assertThat(costs.getCost("A", "B", 1)).isEqualTo(new Fraction(15));
+        Assertions.assertThat(costs.getCost("B", "A", 1)).isEqualTo(new Fraction(14));
+        Assertions.assertThat(costs.getCost("A", "A", 2)).isEqualTo(new Fraction(26));
+        Assertions.assertThat(costs.getCost("B", "B", 1)).isEqualTo(new Fraction(12));
+        Assertions.assertThat(costs.getCost("A", "B", 2)).isEqualTo(new Fraction(22));
+        Assertions.assertThat(costs.getCost("B", "A", 2)).isEqualTo(new Fraction(20));
+        Assertions.assertThat(costs.getCost("B", "B", 2)).isEqualTo(new Fraction(18));
     }
 }

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/java/com/ge/verdict/synthesis/DTreeConstructorTest.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/java/com/ge/verdict/synthesis/DTreeConstructorTest.java
@@ -18,6 +18,7 @@ import com.ge.verdict.synthesis.dtree.DLeaf;
 import com.ge.verdict.synthesis.dtree.DNot;
 import com.ge.verdict.synthesis.dtree.DOr;
 import com.ge.verdict.synthesis.dtree.DTree;
+import com.ge.verdict.synthesis.impl.MonotonicCostModelTree;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,8 +53,10 @@ public class DTreeConstructorTest {
     public void testConstruct() {
         DLeaf.Factory factory = new DLeaf.Factory();
 
-        CostModel dummyCosts =
-                new CostModel(new File(getClass().getResource("dummyCosts.xml").getPath()));
+        final ICostModel dummyCosts =
+                MonotonicCostModelTree.load(
+                        new File(getClass().getResource("dummyCosts.xml").getPath()));
+
         int dal = 5;
 
         SystemModel system = new SystemModel("S1");
@@ -93,8 +96,10 @@ public class DTreeConstructorTest {
     public void testUnmitigated() {
         DLeaf.Factory factory = new DLeaf.Factory();
 
-        CostModel dummyCosts =
-                new CostModel(new File(getClass().getResource("dummyCosts.xml").getPath()));
+        final ICostModel dummyCosts =
+                MonotonicCostModelTree.load(
+                        new File(getClass().getResource("dummyCosts.xml").getPath()));
+
         int dal = 5;
 
         SystemModel system = new SystemModel("S1");
@@ -114,8 +119,10 @@ public class DTreeConstructorTest {
     public void testUnmitigatedMixed() {
         DLeaf.Factory factory = new DLeaf.Factory();
 
-        CostModel dummyCosts =
-                new CostModel(new File(getClass().getResource("dummyCosts.xml").getPath()));
+        final ICostModel dummyCosts =
+                MonotonicCostModelTree.load(
+                        new File(getClass().getResource("dummyCosts.xml").getPath()));
+
         int dal = 5;
 
         SystemModel system = new SystemModel("S1");
@@ -154,8 +161,10 @@ public class DTreeConstructorTest {
     public void partialSolutionTest() {
         DLeaf.Factory factory = new DLeaf.Factory();
 
-        CostModel dummyCosts =
-                new CostModel(new File(getClass().getResource("dummyCosts.xml").getPath()));
+        final ICostModel dummyCosts =
+                MonotonicCostModelTree.load(
+                        new File(getClass().getResource("dummyCosts.xml").getPath()));
+
         int dal = 5;
 
         SystemModel system = new SystemModel("S1");
@@ -193,8 +202,9 @@ public class DTreeConstructorTest {
     public void multipleRequirementsTest() {
         DLeaf.Factory factory = new DLeaf.Factory();
 
-        CostModel dummyCosts =
-                new CostModel(new File(getClass().getResource("dummyCosts.xml").getPath()));
+        final ICostModel dummyCosts =
+                MonotonicCostModelTree.load(
+                        new File(getClass().getResource("dummyCosts.xml").getPath()));
 
         SystemModel system = new SystemModel("S1");
 

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/java/com/ge/verdict/synthesis/MonotonicCostModelTreeTest.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/java/com/ge/verdict/synthesis/MonotonicCostModelTreeTest.java
@@ -1,0 +1,236 @@
+package com.ge.verdict.synthesis;
+
+import static org.apache.commons.math3.fraction.Fraction.ZERO;
+
+import com.ge.verdict.synthesis.impl.MonotonicCostModelTree;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class MonotonicCostModelTreeTest {
+
+    private static final String NON_MONOTONIC_PREF = "Non-monotonic";
+    private static final String[] xmlAttrs =
+            new String[] {" component=\"%s\"", " defense=\"%s\"", " dal=\"%s\"", ">%s</cost>"};
+
+    private static File getTempFile(final String body) throws IOException {
+        final File tmpFile = File.createTempFile("MonotonicTree", "Tests");
+        tmpFile.deleteOnExit();
+        FileOutputStream fos = new FileOutputStream(tmpFile);
+        fos.write(body.getBytes(StandardCharsets.UTF_8));
+        return tmpFile;
+    }
+
+    /* attrs = {comp,def,dal,cost}; null to exclude */
+    private static String toXmlStr(final String[] attrs) {
+        return "<cost"
+                + IntStream.range(0, attrs.length)
+                .filter(i -> null != attrs[i])
+                .mapToObj(i -> String.format(xmlAttrs[i], attrs[i]))
+                .collect(Collectors.joining());
+    }
+
+    private static File toXmlFile(final String[][] elements) {
+        try {
+            return getTempFile(
+                    "<cost-model>"
+                            + Arrays.stream(elements)
+                            .map(MonotonicCostModelTreeTest::toXmlStr)
+                            .collect(Collectors.joining())
+                            + "</cost-model>");
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testDefaultCosts() {
+        IntStream.range(1, 12).forEach(i -> {
+            final File payload = toXmlFile(new String[][] {{null, null, null, String.valueOf(i)}});
+            final ICostModel tree = MonotonicCostModelTree.load(payload);
+            Assertions.assertThat(tree.getCost("", "", 1).intValue()).isEqualTo(i);
+            Assertions.assertThat(tree.getCost("", "", 5).intValue()).isEqualTo(i * 5);
+            Assertions.assertThat(tree.getCost("", "", 9).intValue()).isEqualTo(i * 9);
+        });
+    }
+
+    @Test
+    public void testComponentCosts() {
+        IntStream.range(1, 10).filter(i -> i % 2 == 1).forEach(i -> {
+            final String v = String.valueOf(i);
+            final File payload = toXmlFile( new String[][] { {v, null, null, v} });
+            final ICostModel tree = MonotonicCostModelTree.load(payload);
+            Assertions.assertThat(tree.getCost( "", v,1).intValue()).isEqualTo(i);
+            Assertions.assertThat(tree.getCost("", "", i).intValue()).isEqualTo(i);
+            Assertions.assertThat(tree.getCost("", "", 9).intValue()).isEqualTo(9);
+        });
+    }
+
+    @Test
+    public void testDefenseCosts() {
+        IntStream.range(1, 10).filter(i -> i % 2 == 1).forEach(i -> {
+            final String v = String.valueOf(i);
+            final File payload = toXmlFile( new String[][] { { v, v, null, v } });
+            final ICostModel tree = MonotonicCostModelTree.load(payload);
+            Assertions.assertThat(tree.getCost(v, v, 1).intValue()).isEqualTo(i);
+            Assertions.assertThat(tree.getCost(v, "", i).intValue()).isEqualTo(i);
+            Assertions.assertThat(tree.getCost("", "", 9).intValue()).isEqualTo(9);
+        });
+    }
+
+    @Test
+    public void testDalCosts() {
+        IntStream.range(1, 10).filter(i -> i % 2 == 1).forEach(i -> {
+            final String v = String.valueOf(i);
+            final File payload = toXmlFile(new String[][] {{ v, v, v, v }});
+            final ICostModel tree = MonotonicCostModelTree.load(payload);
+            Assertions.assertThat(tree.getCost(v, v, 1).intValue()).isEqualTo(1);
+            Assertions.assertThat(tree.getCost(v, v, i).intValue()).isEqualTo(i);
+            Assertions.assertThat(tree.getCost(v, "", 5).intValue()).isEqualTo(5);
+            Assertions.assertThat(tree.getCost("", "", 9).intValue()).isEqualTo(9);
+        });
+    }
+
+    @Test
+    public void testGetCostDal0() { // DAL zero is a scaling multiplier, not a default value
+        final File payload = toXmlFile(new String[][] {{"COMP", "DEF", "", "40"}});
+        final ICostModel tree = MonotonicCostModelTree.load(payload);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 0)).isEqualTo(ZERO);
+    }
+
+    @Test
+    public void testFallbackCosts() {
+        final File payload =
+                toXmlFile(
+                        new String[][] {
+                                {"COMP", "DEF", "9", "900"},
+                                {"COMP", "DEF", "3", "200"},
+                                {"COMP", "DEF", "", "100"},
+                                {"COMP", "", "7", "600"},
+                                {"COMP", "", "", "50"},
+                                {"", "DEF", "7", "300"},
+                                {"", "DEF", "3", "180"},
+                                {"", "DEF", "", "40"},
+                                {"", "", "7", "300"},
+                                {"", "", "", "20"}
+                        });
+
+        final ICostModel tree = MonotonicCostModelTree.load(payload);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 9).intValue()).isEqualTo(900);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 5).intValue()).isEqualTo(200);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 3).intValue()).isEqualTo(200);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 1).intValue()).isEqualTo(100);
+
+        Assertions.assertThat(tree.getCost("", "COMP", 9).intValue()).isEqualTo(600);
+        Assertions.assertThat(tree.getCost("", "COMP", 5).intValue()).isEqualTo(250);
+        Assertions.assertThat(tree.getCost("", "COMP", 3).intValue()).isEqualTo(50 * 3);
+        Assertions.assertThat(tree.getCost("", "COMP", 1).intValue()).isEqualTo(50);
+
+        Assertions.assertThat(tree.getCost("DEF", "", 9).intValue()).isEqualTo(300);
+        Assertions.assertThat(tree.getCost("DEF", "", 7).intValue()).isEqualTo(300);
+        Assertions.assertThat(tree.getCost("DEF", "", 3).intValue()).isEqualTo(180);
+        Assertions.assertThat(tree.getCost("DEF", "", 1).intValue()).isEqualTo(40);
+        Assertions.assertThat(tree.getCost("DEF", "", 0).intValue()).isEqualTo(0);
+
+        Assertions.assertThat(tree.getCost("", "", 9).intValue()).isEqualTo(300);
+        Assertions.assertThat(tree.getCost("", "", 7).intValue()).isEqualTo(300);
+        Assertions.assertThat(tree.getCost("", "", 3).intValue()).isEqualTo(20 * 3);
+        Assertions.assertThat(tree.getCost("", "", 1).intValue()).isEqualTo(20);
+    }
+
+
+    @Test
+    public void testEvenDALFailures() {
+        final String EXP_STR_ERROR = "DAL must be an odd integer between 1 and 10 but found";
+        IntStream.range(1, 10)
+                .filter(i -> i % 2 == 0)
+                .mapToObj(i -> {
+                    final String v = String.valueOf(i);
+                    return toXmlFile(new String[][] {{null, null, v, v}});
+                })
+                .forEach(payload -> Assertions.assertThatThrownBy(() ->
+                        MonotonicCostModelTree.load(payload)).hasMessageContaining(EXP_STR_ERROR));
+    }
+
+    @Test
+    public void testMonotonicFailures() {
+        final String[][] payload =
+                new String[][] {
+                        {"", "", "7", "4"},
+                        {"", "DEF", "7", "3"},
+                        {"", "DEF", "3", "4"},
+                        {"", "", "", "5"},
+                        {"COMP", "", "", "4"},
+                        {"COMP", "", "7", "3"},
+                        {"COMP", "DEF", "", "4"},
+                        {"COMP", "DEF", "9", "3"}
+                };
+
+        final String ERR_STR = "Expected monotonic error between %s & %s but none thrown";
+        // Any sequential pair of the above should throw an error
+        IntStream.range(1, payload.length).forEach(i -> {
+            final String[] hd = payload[i - 1];
+            final String[] tl = payload[i];
+            Assertions.assertThatThrownBy(() ->
+                                    MonotonicCostModelTree.load(toXmlFile(new String[][] { tl, hd })),
+                            String.format(ERR_STR,Arrays.toString(tl),Arrays.toString(hd)))
+                    .hasMessageContaining(NON_MONOTONIC_PREF);
+        });
+    }
+
+    @Test
+    public void testMonotonicNonLinearScaleFactors() {
+        final File payload =
+                toXmlFile(
+                        new String[][] {
+                                {"COMP", "DEF", "", "300"},
+                                {"COMP", "DEF", "3", "300"},
+                                {"COMP", "DEF", "5", "300"},
+                                {"COMP", "DEF", "7", "300"},
+                                {"COMP", "DEF", "9", "300"},
+                        });
+
+        final ICostModel tree = MonotonicCostModelTree.load(payload);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 1).intValue()).isEqualTo(300);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 3).intValue()).isEqualTo(300);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 5).intValue()).isEqualTo(300);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 7).intValue()).isEqualTo(300);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 9).intValue()).isEqualTo(300);
+    }
+
+    /* If the base scale factor is changed, subsequent factors should validate against it (enabling costs < 1) */
+    @Test
+    public void testScaleFactorsLessBase() {
+        final File payload =
+                toXmlFile(
+                        new String[][] {
+                                {"", "", "", ".01"},
+                                {"COMP", "", "1", ".2"}
+                        });
+
+        final ICostModel tree = MonotonicCostModelTree.load(payload);
+        Assertions.assertThat(tree.getCost("", "COMP", 1).doubleValue()).isEqualTo(.2);
+    }
+
+    /* If a scaling factor for a DAL in a more general def. definition is set it becomes the base scaling factor  */
+    @Test
+    public void testScaleFactorsFromGeneralDef() {
+        final File payload =
+                toXmlFile(
+                        new String[][] {
+                                {"", "", "", ".5"},
+                                {"COMP", "", "3", ".5"},
+                                {"COMP", "DEF", "7", "1"}
+                        });
+
+        final ICostModel tree = MonotonicCostModelTree.load(payload);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 3).doubleValue()).isEqualTo(.5);
+        Assertions.assertThat(tree.getCost("DEF", "COMP", 7).doubleValue()).isEqualTo(1);
+    }
+}

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/java/com/ge/verdict/synthesis/Util.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/java/com/ge/verdict/synthesis/Util.java
@@ -3,11 +3,11 @@ package com.ge.verdict.synthesis;
 import org.apache.commons.math3.fraction.Fraction;
 
 public class Util {
+
     public static Fraction[] fractionCosts(double[] costs) {
         Fraction[] fractions = new Fraction[costs.length];
         for (int i = 0; i < costs.length; i++) {
-            // this is kind of dumb but whatever
-            fractions[i] = CostModel.parseCost(Double.toString(costs[i]));
+            fractions[i] = ICostModel.parseCost(Double.toString(costs[i]));
         }
         return fractions;
     }
@@ -15,7 +15,6 @@ public class Util {
     public static Fraction[] fractionCosts(int[] costs) {
         Fraction[] fractions = new Fraction[costs.length];
         for (int i = 0; i < costs.length; i++) {
-            // this is kind of dumb but whatever
             fractions[i] = new Fraction(costs[i]);
         }
         return fractions;

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/java/com/ge/verdict/synthesis/VerdictSynthesisTest.java
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/java/com/ge/verdict/synthesis/VerdictSynthesisTest.java
@@ -2,33 +2,21 @@ package com.ge.verdict.synthesis;
 
 import com.ge.verdict.attackdefensecollector.AttackDefenseCollector;
 import com.ge.verdict.attackdefensecollector.Prob;
-import com.ge.verdict.attackdefensecollector.adtree.ADAnd;
-import com.ge.verdict.attackdefensecollector.adtree.ADNot;
-import com.ge.verdict.attackdefensecollector.adtree.ADOr;
-import com.ge.verdict.attackdefensecollector.adtree.ADTree;
-import com.ge.verdict.attackdefensecollector.adtree.Attack;
-import com.ge.verdict.attackdefensecollector.adtree.Defense;
+import com.ge.verdict.attackdefensecollector.adtree.*;
 import com.ge.verdict.attackdefensecollector.model.CIA;
 import com.ge.verdict.attackdefensecollector.model.CyberReq;
 import com.ge.verdict.attackdefensecollector.model.SystemModel;
 import com.ge.verdict.synthesis.VerdictSynthesis.Approach;
-import com.ge.verdict.synthesis.dtree.ALeaf;
-import com.ge.verdict.synthesis.dtree.DAnd;
-import com.ge.verdict.synthesis.dtree.DLeaf;
+import com.ge.verdict.synthesis.dtree.*;
 import com.ge.verdict.synthesis.dtree.DLeaf.ComponentDefense;
-import com.ge.verdict.synthesis.dtree.DOr;
-import com.ge.verdict.synthesis.dtree.DTree;
+import com.ge.verdict.synthesis.impl.CostModel;
+import com.ge.verdict.synthesis.impl.MonotonicCostModelTree;
 import com.ge.verdict.synthesis.util.Pair;
 import com.ge.verdict.synthesis.util.Triple;
 import com.ge.verdict.vdm.synthesis.ResultsInstance;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.math3.fraction.Fraction;
 import org.assertj.core.api.Assertions;
@@ -112,8 +100,9 @@ public class VerdictSynthesisTest {
 
     @Test
     public void decimalCostsTest() {
-        CostModel costs =
-                new CostModel(new File(getClass().getResource("decimalCosts.xml").getPath()));
+        ICostModel costs =
+                MonotonicCostModelTree.load(
+                        new File(getClass().getResource("decimalCosts.xml").getPath()));
 
         DLeaf.Factory factory = new DLeaf.Factory();
 
@@ -189,9 +178,10 @@ public class VerdictSynthesisTest {
 
     @Test
     public void partialSolutionTest() {
-        CostModel costModel =
-                new CostModel(new File(getClass().getResource("partialCosts.xml").getPath()));
-        int dal = 2;
+        ICostModel costModel =
+                MonotonicCostModelTree.load(
+                        new File(getClass().getResource("partialCosts.xml").getPath()));
+        int dal = 3;
 
         SystemModel system = new SystemModel("C1");
 
@@ -293,8 +283,9 @@ public class VerdictSynthesisTest {
 
     @Test
     public void biggerMeritAssignmentTest() {
-        CostModel costModel =
-                new CostModel(new File(getClass().getResource("meritCosts.xml").getPath()));
+        ICostModel costModel =
+                MonotonicCostModelTree.load(
+                        new File(getClass().getResource("meritCosts.xml").getPath()));
 
         SystemModel system = new SystemModel("C1");
 

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/resources/com/ge/verdict/synthesis/decimalCosts.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/resources/com/ge/verdict/synthesis/decimalCosts.xml
@@ -1,4 +1,5 @@
 <cost-model>
+    <cost>0</cost>
     <cost component="A" defense="A" dal="1">4.2</cost>
     <cost component="B" defense="B" dal="1">0.035</cost>
     <cost component="C" defense="C" dal="1">10.77</cost>

--- a/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/resources/com/ge/verdict/synthesis/partialCosts.xml
+++ b/tools/verdict-back-ends/verdict-bundle/verdict-synthesis/src/test/resources/com/ge/verdict/synthesis/partialCosts.xml
@@ -1,4 +1,4 @@
 <cost-model>
     <cost component="C1" defense="D1" dal="1">1</cost>
-    <cost component="C1" defense="D1" dal="2">2</cost>
+    <cost component="C1" defense="D1" dal="3">2</cost>
 </cost-model>


### PR DESCRIPTION
VERDICT-289: Support Absolute DAL Cost Values

Adding support for non-scalar cost modeling for defense definitions. Costs can now be declared as absolute values based on DAL. MonotonicCostModelTree validation ensures cost configurations are monotonic meaning all defense definitions (component, defense, dal couples) have greater or equal costs than predecessors (being lesser DALs or more general definitions). 

Solves: VERDICT-289