### PR TITLE
Update VERDICT to Java 17 and SADL 3.6.0-SNAPSHOT

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         distribution: [ temurin ]
-        java-version: [ 11 ]
+        java-version: [ 17 ]
         os: [ ubuntu-22.04 ]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         distribution: [ temurin ]
-        java-version: [ 11 ]
+        java-version: [ 17 ]
         ocaml-compiler: [ 4.09.1 ]
         os: [ macos-12, ubuntu-22.04 ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         distribution: [ temurin ]
-        java-version: [ 11 ]
+        java-version: [ 17 ]
         os: [ ubuntu-22.04 ]
 
     steps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,14 +14,14 @@ in a temporary container.
 
 Front-end **prerequisites**
 
-- [Java 11](https://adoptium.net/)
+- [Java 17](https://adoptium.net/)
 - [OSATE 2.10.2](https://osate-build.sei.cmu.edu/download/osate/stable/2.10.2-vfinal/products/)
 
-You will need [Java 11](https://adoptium.net/) to run OSATE and our
-plugin.  OSATE runs fine on Java 11 even though its documentation says
-it officially supports only Java 8.  You cannot build our plugin
-source code with Java 8; Java 8 is too old and no longer supported by
-Maven's Eclipse Tycho build system.
+Maven's Eclipse Tycho build system no longer supports Java 11 so you
+will need [Java 17](https://adoptium.net/) to build our VERDICT plugin
+source code.  However, you will not need Java 17 to use OSATE with our
+VERDICT plugin because VERDICT is compatible with Java 11 and OSATE
+uses its own Java 11 bundled inside OSATE to run OSATE anyway.
 
 You will need [OSATE](https://osate.org/about-osate.html) (Open Source
 AADL Tool Environment) in order to use our VERDICT plugin:

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -3,13 +3,13 @@
      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <!-- Define ourselves -->
+  <!-- Define our GAV coordinates -->
   <groupId>com.ge.verdict</groupId>
   <artifactId>tools</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <!-- Build all modules in one place -->
+  <!-- Build our modules -->
   <modules>
     <module>verdict</module>
     <module>verdict-back-ends</module>
@@ -26,15 +26,18 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <!-- Versions of dependencies -->
+    <!-- Versions of plugins/dependencies -->
+    <!-- Need version.antlr to match logicng -->
     <version.antlr>4.9.3</version.antlr>
     <version.asm>9.5</version.asm>
     <version.micrometer>1.11.0</version.micrometer>
-    <version.sadl>3.5.0-SNAPSHOT</version.sadl>
-    <version.slf4j>2.0.7</version.slf4j>
+    <version.sadl>3.6.0-SNAPSHOT</version.sadl>
+    <!-- Need version.slf4j to match Eclipse and SADL -->
+    <version.slf4j>1.7.36</version.slf4j>
     <version.surefire>3.1.2</version.surefire>
-    <version.tycho>2.7.5</version.tycho>
+    <version.tycho>3.0.4</version.tycho>
     <version.verdict>${project.version}</version.verdict>
+    <!-- No need for version.xtext to match VERDICT target platform -->
     <version.xtext>2.31.0</version.xtext>
   </properties>
 
@@ -169,13 +172,6 @@
         <groupId>edu.uiowa.cs.clc</groupId>
         <artifactId>kind2-java-api</artifactId>
         <version>0.3.4</version>
-        <!-- Exclude to avoid vulnerabilities -->
-        <exclusions>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>guru.nidi</groupId>

--- a/tools/verdict-back-ends/Dockerfile
+++ b/tools/verdict-back-ends/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     graphviz \
     libzmq5 \
-    openjdk-11-jre-headless \
+    openjdk-17-jre-headless \
     z3 \
  && rm -rf /var/lib/apt/lists/* \
  && adduser --disabled-password --gecos VERDICT verdict
@@ -28,6 +28,6 @@ COPY verdict-bundle/verdict-bundle-app/target/verdict-bundle-app-*-capsule.jar /
 
 USER verdict
 WORKDIR /data
-# Java 11 LTS has better memory heuristics, but needs --add-open arguments
+# Java 17 LTS needs --add-open arguments
 ENTRYPOINT ["java", "-Xmx1536m", "--add-opens", "java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "-jar", "/app/verdict.jar"]
 ENV GraphVizPath=/usr/bin

--- a/tools/verdict-back-ends/README.md
+++ b/tools/verdict-back-ends/README.md
@@ -39,10 +39,10 @@ VERDICT plugin to run the back-end programs using the Docker image.
 
 ## Set up your build environment
 
-You will need both [Java 11](https://adoptium.net/) and [Apache
+You will need both [Java 17](https://adoptium.net/) and [Apache
 Maven](https://maven.apache.org) to build our Java program sources.
-You cannot build our plugin source code with Java 8; Java 8 is too old
-and no longer supported by Maven's Eclipse Tycho build system.
+You cannot build our plugin source code with Java 11; Maven's Eclipse
+Tycho build system no longer supports Java 11.
 
 The traditional way to install Maven is to download the latest Maven
 distribution from Apache's website, unpack the Maven distribution

--- a/tools/verdict-back-ends/verdict-bundle/z3-native-libs/pom.xml
+++ b/tools/verdict-back-ends/verdict-bundle/z3-native-libs/pom.xml
@@ -65,7 +65,7 @@
             </goals>
             <phase>generate-resources</phase>
             <configuration>
-              <checkSignature>true</checkSignature>
+              <alwaysVerifyChecksum>true</alwaysVerifyChecksum>
               <sha256>${z3-osx.sha256}</sha256>
               <unpack>true</unpack>
               <uri>${z3-download.uri}/z3-${z3.version}/z3-${z3.version}-x64-osx-${z3-osx.version}.zip</uri>
@@ -78,7 +78,7 @@
             </goals>
             <phase>generate-resources</phase>
             <configuration>
-              <checkSignature>true</checkSignature>
+              <alwaysVerifyChecksum>true</alwaysVerifyChecksum>
               <sha256>${z3-ubuntu.sha256}</sha256>
               <unpack>true</unpack>
               <uri>${z3-download.uri}/z3-${z3.version}/z3-${z3.version}-x64-ubuntu-${z3-ubuntu.version}.zip</uri>
@@ -91,7 +91,7 @@
             </goals>
             <phase>generate-resources</phase>
             <configuration>
-              <checkSignature>true</checkSignature>
+              <alwaysVerifyChecksum>true</alwaysVerifyChecksum>
               <sha256>${z3-win.sha256}</sha256>
               <unpack>true</unpack>
               <uri>${z3-download.uri}/z3-${z3.version}/z3-${z3.version}-x64-win.zip</uri>

--- a/tools/verdict/README.md
+++ b/tools/verdict/README.md
@@ -26,9 +26,9 @@ plugin version via an update site URL.
 
 ## Set up your build environment
 
-You will need [Java 11](https://adoptium.net/) to build all of our
-Java program sources.  Java 8 is too old and no longer supported by
-Maven's Eclipse Tycho build system.
+You will need [Java 17](https://adoptium.net/) to build all of our
+Java program sources.  Maven's Eclipse Tycho build system no longer
+supports Java 11 so Java 17 is required to build VERDICT.
 
 You also will need [Apache Maven](https://maven.apache.org) to build
 all of our Java program sources.  Your operating system may have

--- a/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
+++ b/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
@@ -16,7 +16,7 @@
       includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.elk.feature.feature.group" version="0.0.0" />
       <repository
-        location="https://download.eclipse.org/elk/updates/releases/0.7.1" />
+        location="https://download.eclipse.org/elk/updates/releases/0.8.1" />
     </location>
     <location includeAllPlatforms="false"
       includeConfigurePhase="true" includeMode="planner"
@@ -74,7 +74,7 @@
       includeSource="true" type="InstallableUnit">
       <unit id="org.yakindu.base.xtext.utils.jface" version="0.0.0" />
       <repository
-        location="https://updates.yakindu.com/statecharts/releases/3.5.9" />
+        location="https://updates.yakindu.com/statecharts/releases/3.5.13" />
     </location>
   </locations>
 </target>


### PR DESCRIPTION
Update pom and manifests to make VERDICT work with Java 17 and SADL 3.6.0-SNAPSHOT.  Loads successfully in Emacs 2022-12, need to test functionality next.

integration.yml, main.ymp, release.yml: Change JDK from Java 11 to Java 17.

pom.xml: Change compiler from Java 11 to Java 17.  Bump SADL from 3.5.0-SNAPSHOT to 3.6.0-SNAPSHOT and use same SLF4J version as SADL uses.  Bump Tycho from 2.7.5 to 3.0.4 (it's the reason why we have to switch both SADL and VERDICT to Java 17).

Dockerfile: Run VERDICT bundle jar with Java 17 like everything else.

README.md: Update Java version in build instructions.

**/*.java: Automatic formatter changes.

z3-native-libs/pom.xml: Replace deprecated checkSignature with newly recommended alwaysVerifyChecksum.

**/{.classpath,MANIFEST.MF}: Update JavaSE version.