### PR TITLE
Fix CI failures due to AGREE-Updates move

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ safer, you can install AGREE in OSATE first before installing VERDICT
 by applying the following URL in OSATE's "Install New Software..."
 dialog:
 
-<https://raw.githubusercontent.com/loonwerks/AGREE-Updates/master>
+<https://loonwerks.github.io/AGREE-Updates>
 
 The above URL will install an AGREE plugin matching your OSATE version
 automatically, allowing you to use all of AGREE's functionality or

--- a/tools/verdict/README.md
+++ b/tools/verdict/README.md
@@ -257,10 +257,10 @@ OSATE sources, you can import our VERDICT plugin sources into it as
 well.  You will not need to use our VERDICT plugin's target platform
 to make some build errors go away; OSATE's target platform will be a
 superset of our target platform except for the following features
-(AGREE 2.5.2 and Xtext Antlr SDK) which you will have to install into
-your OSATE development IDE from their own update sites:
+(AGREE and Xtext Antlr SDK) which you will have to install into your
+OSATE development IDE from their own update sites:
 
-- [com.rockwellcollins.atc.agree.feature](https://raw.githubusercontent.com/loonwerks/AGREE-Updates/master/agree_2.5.2)
+- [com.rockwellcollins.atc.agree.feature](https://loonwerks.github.io/AGREE-Updates/releases/2.9.1)
 - [de.itemis.xtext.antlr.sdk](http://download.itemis.com/updates/releases/2.1.1)
 
 # Additional notes

--- a/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
+++ b/tools/verdict/com.ge.research.osate.verdict.targetplatform/com.ge.research.osate.verdict.targetplatform.target
@@ -67,7 +67,7 @@
       <unit id="edu.uah.rsesc.aadlsimulator.feature.feature.group"
         version="0.0.0" />
       <repository
-        location="https://raw.githubusercontent.com/loonwerks/AGREE-Updates/master/agree_2.9.1" />
+        location="https://loonwerks.github.io/AGREE-Updates/releases/2.9.1" />
     </location>
     <location includeAllPlatforms="false"
       includeConfigurePhase="true" includeMode="planner"


### PR DESCRIPTION
The AGREE folks have reorganized and renamed the locations of the AGREE releases in the AGREE-Updates repo, which has broken our last two CI jobs.  Update our links to point to the correct location within the AGREE update site, which also now is hosted on loonwerks.github.io (we no longer need to use raw.githubusercontent.com).